### PR TITLE
ci: releasing cala-server binaries to github and gcr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM clux/muslrust:stable AS build
+  COPY . /src
+  WORKDIR /src
+  RUN SQLX_OFFLINE=true cargo build --locked
+
+FROM ubuntu
+  COPY --from=build /src/target/x86_64-unknown-linux-musl/debug/cala-server /usr/local/bin
+  RUN mkdir /cala-server
+  RUN chown -R 1000 /cala-server && chmod -R u+w /cala-server
+  USER 1000
+  WORKDIR /cala-server
+  CMD ["cala-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM clux/muslrust:stable AS build
   COPY . /src
   WORKDIR /src
-  RUN SQLX_OFFLINE=true cargo build --locked
+  RUN SQLX_OFFLINE=true cargo build --locked --bin cala-server
 
 FROM ubuntu
   COPY --from=build /src/target/x86_64-unknown-linux-musl/debug/cala-server /usr/local/bin

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,21 @@
+FROM alpine:latest as load
+
+ARG VERSION
+ENV VERSION ${VERSION}
+RUN mkdir cala-home && mkdir cala && cd cala \
+  && wget https://github.com/GaloyMoney/cala/releases/download/${VERSION}/cala-x86_64-unknown-linux-musl-${VERSION}.tar.gz -O cala.tar.gz \
+  && tar --strip-components=1 -xf cala.tar.gz \
+  && mv cala-server /usr/local/bin && cd ../ && rm -rf ./cala
+
+FROM gcr.io/distroless/static
+  COPY --from=load /usr/local/bin/cala-server /bin/cala-server
+  COPY --from=load --chown=1000:0 --chmod=755 /cala-home /cala
+  USER 1000
+  ARG VERSION
+  ARG BUILDTIME
+  ARG COMMITHASH
+  ENV VERSION ${VERSION}
+  ENV BUILDTIME ${BUILDTIME}
+  ENV COMMITHASH ${COMMITHASH}
+  ENV CALA_HOME /cala
+  CMD ["cala-server"]

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -64,6 +64,7 @@ groups:
   - bats-tests
   - build-edge-image
   - release
+  - release-docker
 
 jobs:
 - #@ rust_check_code()
@@ -198,6 +199,61 @@ jobs:
     params:
       file: version/version
 
+- name: release-docker
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      passed:
+      - release
+    - get: version
+      passed:
+      - release
+      trigger: true
+    - get: pipeline-tasks
+  - task: prepare-docker-build
+    config:
+      platform: linux
+      image_resource: #@ rust_task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: version
+      - name: repo
+      outputs:
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/prep-docker-build-env.sh
+  - task: build
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: gcr.io/kaniko-project/executor
+          tag: debug
+      inputs:
+      - name: repo
+      outputs:
+      - name: image
+      run:
+        path: /bin/sh
+        args:
+        - -exc
+        - |
+          /kaniko/executor \
+            --dockerfile=repo/Dockerfile.release \
+            --context=repo \
+            $(awk -F= '{print "--build-arg="$1"="$2}' repo/.env) \
+            --use-new-run \
+            --single-snapshot \
+            --cache=false \
+            --no-push \
+            --tar-path=image/image.tar
+  - put: latest-image
+    params:
+      image: image/image.tar
+      additional_tags: version/version
+
 resources:
 - #@ repo_resource(True)
 - #@ pipeline_tasks_resource()
@@ -205,6 +261,13 @@ resources:
 - #@ edge_image_resource()
 - #@ version_resource()
 - #@ gh_release_resource()
+- name: latest-image
+  type: registry-image
+  source:
+    tag: latest
+    username: #@ data.values.docker_registry_user
+    password: #@ data.values.docker_registry_password
+    repository: #@ public_docker_registry() + "/" + data.values.gh_repository
 - name: nix-host
   type: pool
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -65,6 +65,62 @@ groups:
   - build-edge-image
   - release
   - release-docker
+  - set-dev-version
+
+  plan:
+  - in_parallel:
+    - { get: repo, passed: [release] }
+    - { get: pipeline-tasks }
+    - get: version
+      trigger: true
+      params: { bump: patch }
+      passed: [release]
+  - task: set-dev-version
+    config:
+      image_resource: #@ release_task_image_config()
+      platform: linux
+      inputs:
+      - name: version
+      - name: repo
+      - name: pipeline-tasks
+      outputs:
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/set-dev-version.sh
+      params:
+        BRANCH: #@ data.values.git_branch
+  - put: repo
+    params:
+      repository: repo
+      rebase: true
+
+- name: set-dev-version
+  plan:
+  - in_parallel:
+    - { get: repo, passed: [release] }
+    - { get: pipeline-tasks }
+    - get: version
+      trigger: true
+      params: { bump: patch }
+      passed: [release]
+  - task: set-dev-version
+    config:
+      image_resource: #@ release_task_image_config()
+      platform: linux
+      inputs:
+      - name: version
+      - name: repo
+      - name: pipeline-tasks
+      outputs:
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/set-dev-version.sh
+      params:
+        BRANCH: #@ data.values.git_branch
+  - put: repo
+    params:
+      repository: repo
+      rebase: true
 
 jobs:
 - #@ rust_check_code()
@@ -253,6 +309,34 @@ jobs:
     params:
       image: image/image.tar
       additional_tags: version/version
+
+- name: set-dev-version
+  plan:
+  - in_parallel:
+    - { get: repo, passed: [release] }
+    - { get: pipeline-tasks }
+    - get: version
+      trigger: true
+      params: { bump: patch }
+      passed: [release]
+  - task: set-dev-version
+    config:
+      image_resource: #@ release_task_image_config()
+      platform: linux
+      inputs:
+      - name: version
+      - name: repo
+      - name: pipeline-tasks
+      outputs:
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/set-dev-version.sh
+      params:
+        BRANCH: #@ data.values.git_branch
+  - put: repo
+    params:
+      repository: repo
+      rebase: true
 
 resources:
 - #@ repo_resource(True)

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -106,6 +106,21 @@ jobs:
       - name: repo
       run:
         path: pipeline-tasks/ci/tasks/update-repo.sh
+  - task: publish-to-crates
+    config:
+      image_resource: #@ rust_task_image_config()
+      platform: linux
+      inputs:
+      - name: version
+      - name: pipeline-tasks
+      - name: repo
+      params:
+        CRATES_API_TOKEN: #@ data.values.crates_api_token
+      caches:
+      - path: cargo-home
+      - path: cargo-target-dir
+      run:
+        path: pipeline-tasks/ci/tasks/publish-to-crates.sh
   - in_parallel:
     - task: build-osx-release
       privileged: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -62,15 +62,18 @@ groups:
   jobs:
   - check-code
   - bats-tests
+  - build-edge-image
 
 jobs:
 - #@ rust_check_code()
 - #@ on_nix_host("bats-tests", "make e2e")
+- #@ build_edge_image()
 
 resources:
 - #@ repo_resource(True)
 - #@ pipeline_tasks_resource()
 - #@ slack_resource()
+- #@ edge_image_resource()
 - name: nix-host
   type: pool
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -63,17 +63,133 @@ groups:
   - check-code
   - bats-tests
   - build-edge-image
+  - release
 
 jobs:
 - #@ rust_check_code()
 - #@ on_nix_host("bats-tests", "make e2e")
 - #@ build_edge_image()
 
+- name: release
+  serial: true
+  plan:
+  - in_parallel:
+    - get: repo
+      passed:
+      - bats-tests
+      - check-code
+    - get: pipeline-tasks
+    - get: version
+  - task: prep-release
+    config:
+      platform: linux
+      image_resource: #@ release_task_image_config()
+      inputs:
+      - name: pipeline-tasks
+      - name: repo
+      - name: version
+      outputs:
+      - name: version
+      - name: artifacts
+      run:
+        path: pipeline-tasks/ci/vendor/tasks/prep-release-src.sh
+  - task: update-repo
+    config:
+      platform: linux
+      image_resource: #@ rust_task_image_config()
+      inputs:
+      - name: artifacts
+      - name: pipeline-tasks
+      - name: repo
+      - name: version
+      outputs:
+      - name: repo
+      run:
+        path: pipeline-tasks/ci/tasks/update-repo.sh
+  - in_parallel:
+    - task: build-osx-release
+      privileged: true
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source:
+            username: #@ data.values.osxcross_docker_username
+            password: #@ data.values.osxcross_docker_password
+            repository: #@ data.values.osxcross_repository
+        inputs:
+        - name: version
+        - name: pipeline-tasks
+        - name: repo
+        outputs:
+        - name: x86_64-apple-darwin
+        caches:
+        - path: cargo-home
+        - path: cargo-target-dir
+        params:
+          TARGET: x86_64-apple-darwin
+          OUT: x86_64-apple-darwin
+        run:
+          path: pipeline-tasks/ci/tasks/build-release.sh
+    - task: build-static-release
+      privileged: true
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: { repository: clux/muslrust, tag: 1.70.0-stable }
+        inputs:
+        - name: version
+        - name: pipeline-tasks
+        - name: repo
+        outputs:
+        - name: x86_64-unknown-linux-musl
+        caches:
+        - path: cargo-home
+        - path: cargo-target-dir
+        params:
+          TARGET: x86_64-unknown-linux-musl
+          OUT: x86_64-unknown-linux-musl
+        run:
+          path: pipeline-tasks/ci/tasks/build-release.sh
+  - put: repo
+    params:
+      tag: artifacts/gh-release-tag
+      repository: repo
+      merge: true
+  - task: github-release
+    config:
+      image_resource: #@ rust_task_image_config()
+      platform: linux
+      inputs:
+      - name: x86_64-apple-darwin
+      - name: x86_64-unknown-linux-musl
+      - name: version
+      - name: pipeline-tasks
+      - name: artifacts
+      outputs:
+      - name: artifacts
+      params:
+        BRANCH: #@ data.values.git_branch
+      run:
+        path: pipeline-tasks/ci/tasks/github-release.sh
+  - put: gh-release
+    params:
+      name: artifacts/gh-release-name
+      tag: artifacts/gh-release-tag
+      body: artifacts/gh-release-notes.md
+      globs: [artifacts/binaries/*]
+  - put: version
+    params:
+      file: version/version
+
 resources:
 - #@ repo_resource(True)
 - #@ pipeline_tasks_resource()
 - #@ slack_resource()
 - #@ edge_image_resource()
+- #@ version_resource()
+- #@ gh_release_resource()
 - name: nix-host
   type: pool
   source:

--- a/ci/tasks/build-release.sh
+++ b/ci/tasks/build-release.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eu
+
+VERSION=""
+if [[ -f version/version ]];then
+  VERSION="$(cat version/version)"
+fi
+
+REPO=${REPO:-repo}
+BINARY=cala-server
+OUT=${OUT:-none}
+WORKSPACE="$(pwd)"
+
+export CARGO_HOME="$(pwd)/cargo-home"
+export CARGO_TARGET_DIR="$(pwd)/cargo-target-dir"
+
+[ -f /workspace/.cargo/config ] && cp /workspace/.cargo/config ${CARGO_HOME}/config
+
+pushd ${REPO}
+
+set -x
+
+make build-${TARGET}-release
+
+cd ${CARGO_TARGET_DIR}/${TARGET}/release
+OUT_DIR="${BINARY}-${TARGET}-${VERSION}"
+rm -rf "${OUT_DIR}" || true
+mkdir "${OUT_DIR}"
+mv ./${BINARY} ${OUT_DIR}
+tar -czvf ${OUT_DIR}.tar.gz ${OUT_DIR}
+
+mv ${OUT_DIR}.tar.gz ${WORKSPACE}/${OUT}/

--- a/ci/tasks/prepare-docker-build-env.sh
+++ b/ci/tasks/prepare-docker-build-env.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ -f version/version ]]; then
+  echo "VERSION=$(cat version/version)" >> repo/.env
+fi
+
+echo "COMMITHASH=$(cat repo/.git/ref)" >> repo/.env
+echo "BUILDTIME=$(date -u '+%F-%T')" >> repo/.env

--- a/ci/tasks/publish-to-crates.sh
+++ b/ci/tasks/publish-to-crates.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+pushd repo
+
+cat <<EOF | cargo login
+${CRATES_API_TOKEN}
+EOF
+
+cargo publish -p cala-cel-parser --all-features --no-verify
+cargo publish -p cala-cel-interpreter --all-features --no-verify
+cargo publish -p cala-core-types --all-features --no-verify
+cargo publish -p cala-ledger-outbox-client --all-features --no-verify
+cargo publish -p cala-ledger --all-features --no-verify
+cargo publish -p cala-server --all-features --no-verify

--- a/ci/tasks/publish-to-crates.sh
+++ b/ci/tasks/publish-to-crates.sh
@@ -10,7 +10,7 @@ EOF
 
 cargo publish -p cala-cel-parser --all-features --no-verify
 cargo publish -p cala-cel-interpreter --all-features --no-verify
-cargo publish -p cala-core-types --all-features --no-verify
+cargo publish -p cala-ledger-core-types --all-features --no-verify
 cargo publish -p cala-ledger-outbox-client --all-features --no-verify
 cargo publish -p cala-ledger --all-features --no-verify
 cargo publish -p cala-server --all-features --no-verify

--- a/ci/tasks/set-dev-version.sh
+++ b/ci/tasks/set-dev-version.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+VERSION="$(cat version/version)-dev"
+
+pushd repo
+
+for file in $(find . -mindepth 2 -name Cargo.toml); do
+    sed -i'' "s/^version.*/version = \"${VERSION}\"/" ${file}
+done
+
+sed -i'' "s/cala-cel-parser\", version = .*/cala-cel-parser\", version = \"${VERSION}\" }/" cala-cel-parser/Cargo.toml
+sed -i'' "s/cala-cel-interpreter\", version = .*/cala-cel-interpreter\", version = \"${VERSION}\" }/" cala-cel-interpreter/Cargo.toml
+sed -i'' "s/cala-ledger-core-types\", version = .*/cala-ledger-core-types\", version = \"${VERSION}\" }/" cala-ledger-core-types/Cargo.toml
+sed -i'' "s/cala-ledger-outbox-client\", version = .*/cala-ledger-outbox-client\", version = \"${VERSION}\" }/" cala-ledger-outbox-client/Cargo.toml
+sed -i'' "s/cala-ledger\", version = .*/cala-ledger\", version = \"${VERSION}\" }/" cala-ledger/Cargo.toml
+sed -i'' "s/cala-server\", version = .*/cala-server\", version = \"${VERSION}\" }/" cala-server/Cargo.toml
+
+if [[ -z $(git config --global user.email) ]]; then
+  git config --global user.email "bot@cepler.dev"
+fi
+if [[ -z $(git config --global user.name) ]]; then
+  git config --global user.name "CI Bot"
+fi
+
+git status
+git add -A
+
+if [[ "$(git status -s -uno)" != ""  ]]; then
+  git commit -m "ci(dev): set version to ${VERSION}"
+fi

--- a/ci/tasks/update-repo.sh
+++ b/ci/tasks/update-repo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -eu
+
+# ----------- UPDATE REPO -----------
+git config --global user.email "bot@galoy.io"
+git config --global user.name "CI Bot"
+
+pushd repo
+
+VERSION="$(cat ../version/version)"
+
+cat <<EOF >new_change_log.md
+# [cala release v${VERSION}](https://github.com/GaloyMoney/cala/releases/tag/${VERSION})
+
+$(cat ../artifacts/gh-release-notes.md)
+
+$(cat CHANGELOG.md)
+EOF
+mv new_change_log.md CHANGELOG.md
+
+sed -i'' "0,/version/{s/version.*/version = \"${VERSION}\"/}" Cargo.toml
+sed -i'' "/^name = \"cala/,/version/{s/version.*/version = \"${VERSION}\"/}" ./Cargo.lock
+
+git status
+git add .
+
+if [[ "$(git status -s -uno)" != ""  ]]; then
+  git commit -m "ci(release): release version $(cat ../version/version)"
+fi

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -27,6 +27,8 @@ git_version_branch: version
 gh_org: GaloyMoney
 gh_repository: cala
 
+crates_api_token: ((crates.token))
+
 slack_channel: cala-github
 slack_username: concourse
 slack_webhook_url: ((addons-slack.api_url))


### PR DESCRIPTION
CI can be applied to concourse, would be better to merge and test.
It's heavily inspired from the patterns at [bria](http://github.com/GaloyMoney/bria) and [stablesats](http://github.com/GaloyMoney/stablesats-rs).

- Building docker images: edge and release variants
- Publishing all the modules to Crates
