### PR TITLE
refactor: remove Input suffix from domain types

### DIFF
--- a/bats/gql/tx-template-create.gql
+++ b/bats/gql/tx-template-create.gql
@@ -17,7 +17,7 @@ mutation CreateDepositAndWithdrawalTxTemplates($depositTemplateId: UUID!, $depos
           description: "Effective date for transaction."
         }
       ]
-      txInput: {
+      transaction: {
         journalId: $journalId
         effective: "params.effective"
       }
@@ -64,7 +64,7 @@ mutation CreateDepositAndWithdrawalTxTemplates($depositTemplateId: UUID!, $depos
           description: "Effective date for transaction."
         }
       ]
-      txInput: {
+      transaction: {
         journalId: $journalId
         effective: "params.effective"
       }

--- a/cala-ledger-core-types/src/tx_template.rs
+++ b/cala-ledger-core-types/src/tx_template.rs
@@ -10,14 +10,14 @@ pub struct TxTemplateValues {
     pub version: u32,
     pub code: String,
     pub params: Option<Vec<ParamDefinition>>,
-    pub tx_input: TxInput,
-    pub entries: Vec<EntryInput>,
+    pub transaction: TxTemplateTransaction,
+    pub entries: Vec<TxTemplateEntry>,
     pub description: Option<String>,
     pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EntryInput {
+pub struct TxTemplateEntry {
     pub entry_type: CelExpression,
     pub account_id: CelExpression,
     pub layer: CelExpression,
@@ -28,7 +28,7 @@ pub struct EntryInput {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct TxInput {
+pub struct TxTemplateTransaction {
     pub effective: CelExpression,
     pub journal_id: CelExpression,
     pub correlation_id: Option<CelExpression>,

--- a/cala-ledger/src/lib.rs
+++ b/cala-ledger/src/lib.rs
@@ -54,7 +54,7 @@
 //!     ];
 //!
 //!     let entries = vec![
-//!         NewEntryInput::builder()
+//!         NewTxTemplateEntry::builder()
 //!             .entry_type("'INCOME_DR'")
 //!             .account_id("params.sender_account_id")
 //!             .layer("SETTLED")
@@ -62,7 +62,7 @@
 //!             .units("params.units")
 //!             .currency("'BTC'")
 //!             .build()?,
-//!         NewEntryInput::builder()
+//!         NewTxTemplateEntry::builder()
 //!             .entry_type("'INCOME_CR'")
 //!             .account_id(format!("uuid('{}')", main_account_id))
 //!             .layer("SETTLED")
@@ -77,8 +77,8 @@
 //!         .id(uuid::Uuid::new_v4())
 //!         .code(tx_code)
 //!         .params(params)
-//!         .tx_input(
-//!             NewTxInput::builder()
+//!         .transaction(
+//!             NewTxTemplateTransaction::builder()
 //!                 .effective("date()")
 //!                 .journal_id(format!("uuid('{}')", journal_id))
 //!                 .build()?,

--- a/cala-ledger/src/lib.rs
+++ b/cala-ledger/src/lib.rs
@@ -107,7 +107,7 @@
 //!     params.insert("sender_account_id", sender_account_id);
 //!     params.insert("units", Decimal::ONE);
 //!     // Create the transaction via the template
-//!     cala.transaction_post(TransactionId::new(), "GENERAL_INCOME", params)
+//!     cala.post_transaction(TransactionId::new(), "GENERAL_INCOME", params)
 //!         .await?;
 //!
 //!     let account_balance = cala

--- a/cala-ledger/src/outbox/server/convert.rs
+++ b/cala-ledger/src/outbox/server/convert.rs
@@ -279,7 +279,7 @@ impl From<TxTemplateValues> for proto::TxTemplate {
             version,
             code,
             params,
-            tx_input,
+            transaction,
             entries,
             description,
             metadata,
@@ -295,7 +295,7 @@ impl From<TxTemplateValues> for proto::TxTemplate {
             version,
             code,
             params,
-            tx_input: Some(tx_input.into()),
+            transaction: Some(transaction.into()),
             entries: entries.into_iter().map(|entry| entry.into()).collect(),
             description,
             metadata: metadata.map(|json| {
@@ -305,9 +305,9 @@ impl From<TxTemplateValues> for proto::TxTemplate {
     }
 }
 
-impl From<EntryInput> for proto::EntryInput {
+impl From<TxTemplateEntry> for proto::TxTemplateEntry {
     fn from(
-        EntryInput {
+        TxTemplateEntry {
             entry_type,
             account_id,
             layer,
@@ -315,9 +315,9 @@ impl From<EntryInput> for proto::EntryInput {
             currency,
             units,
             description,
-        }: EntryInput,
+        }: TxTemplateEntry,
     ) -> Self {
-        proto::EntryInput {
+        proto::TxTemplateEntry {
             entry_type: String::from(entry_type),
             account_id: String::from(account_id),
             layer: String::from(layer),
@@ -363,18 +363,18 @@ impl From<ParamDataType> for proto::ParamDataType {
     }
 }
 
-impl From<TxInput> for proto::TxInput {
+impl From<TxTemplateTransaction> for proto::TxTemplateTransaction {
     fn from(
-        TxInput {
+        TxTemplateTransaction {
             effective,
             journal_id,
             correlation_id,
             external_id,
             description,
             metadata,
-        }: TxInput,
+        }: TxTemplateTransaction,
     ) -> Self {
-        proto::TxInput {
+        proto::TxTemplateTransaction {
             effective: String::from(effective),
             journal_id: String::from(journal_id),
             correlation_id: correlation_id.map(String::from),

--- a/cala-ledger/src/tx_template/mod.rs
+++ b/cala-ledger/src/tx_template/mod.rs
@@ -94,7 +94,7 @@ impl TxTemplates {
 
         let ctx = params.into_context(tmpl.params.as_ref())?;
 
-        let journal_id: Uuid = tmpl.tx_input.journal_id.try_evaluate(&ctx)?;
+        let journal_id: Uuid = tmpl.transaction.journal_id.try_evaluate(&ctx)?;
 
         let entries = self.prep_entries(&tmpl, tx_id, JournalId::from(journal_id), &ctx)?;
 
@@ -106,25 +106,25 @@ impl TxTemplates {
 
         tx_builder.journal_id(journal_id);
 
-        let effective: NaiveDate = tmpl.tx_input.effective.try_evaluate(&ctx)?;
+        let effective: NaiveDate = tmpl.transaction.effective.try_evaluate(&ctx)?;
         tx_builder.effective(effective);
 
-        if let Some(correlation_id) = tmpl.tx_input.correlation_id.as_ref() {
+        if let Some(correlation_id) = tmpl.transaction.correlation_id.as_ref() {
             let correlation_id: String = correlation_id.try_evaluate(&ctx)?;
             tx_builder.correlation_id(correlation_id);
         }
 
-        if let Some(external_id) = tmpl.tx_input.external_id.as_ref() {
+        if let Some(external_id) = tmpl.transaction.external_id.as_ref() {
             let external_id: String = external_id.try_evaluate(&ctx)?;
             tx_builder.external_id(external_id);
         }
 
-        if let Some(description) = tmpl.tx_input.description.as_ref() {
+        if let Some(description) = tmpl.transaction.description.as_ref() {
             let description: String = description.try_evaluate(&ctx)?;
             tx_builder.description(description);
         }
 
-        if let Some(metadata) = tmpl.tx_input.metadata.as_ref() {
+        if let Some(metadata) = tmpl.transaction.metadata.as_ref() {
             let metadata: serde_json::Value = metadata.try_evaluate(&ctx)?;
             tx_builder.metadata(metadata);
         }

--- a/cala-ledger/tests/helpers.rs
+++ b/cala-ledger/tests/helpers.rs
@@ -62,7 +62,7 @@ pub fn test_template(code: &str) -> NewTxTemplate {
             .unwrap(),
     ];
     let entries = vec![
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_BTC_DR'")
             .account_id("params.sender")
             .layer("SETTLED")
@@ -71,7 +71,7 @@ pub fn test_template(code: &str) -> NewTxTemplate {
             .currency("'BTC'")
             .build()
             .unwrap(),
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_BTC_CR'")
             .account_id("params.recipient")
             .layer("SETTLED")
@@ -80,7 +80,7 @@ pub fn test_template(code: &str) -> NewTxTemplate {
             .currency("'BTC'")
             .build()
             .unwrap(),
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_USD_DR'")
             .account_id("params.sender")
             .layer("SETTLED")
@@ -89,7 +89,7 @@ pub fn test_template(code: &str) -> NewTxTemplate {
             .currency("'USD'")
             .build()
             .unwrap(),
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_USD_CR'")
             .account_id("params.recipient")
             .layer("SETTLED")
@@ -98,7 +98,7 @@ pub fn test_template(code: &str) -> NewTxTemplate {
             .currency("'USD'")
             .build()
             .unwrap(),
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_USD_PENDING_DR'")
             .account_id("params.sender")
             .layer("PENDING")
@@ -107,7 +107,7 @@ pub fn test_template(code: &str) -> NewTxTemplate {
             .currency("'USD'")
             .build()
             .unwrap(),
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_USD_PENDING_CR'")
             .account_id("params.recipient")
             .layer("PENDING")
@@ -121,8 +121,8 @@ pub fn test_template(code: &str) -> NewTxTemplate {
         .id(uuid::Uuid::new_v4())
         .code(code)
         .params(params)
-        .tx_input(
-            NewTxInput::builder()
+        .transaction(
+            NewTxTemplateTransaction::builder()
                 .effective("params.effective")
                 .journal_id("params.journal_id")
                 .metadata(r#"{"foo": "bar"}"#)

--- a/cala-server/schema.graphql
+++ b/cala-server/schema.graphql
@@ -231,16 +231,6 @@ enum DebitOrCredit {
 
 scalar Decimal
 
-type EntryInput {
-	entryType: Expression!
-	accountId: Expression!
-	layer: Expression!
-	direction: Expression!
-	units: Expression!
-	currency: Expression!
-	description: Expression
-}
-
 scalar Expression
 
 
@@ -441,23 +431,14 @@ type TransactionPostPayload {
 	transaction: Transaction!
 }
 
-type TxInput {
-	effective: Expression!
-	journalId: Expression!
-	correlationId: Expression
-	externalId: Expression
-	description: Expression
-	metadata: Expression
-}
-
 type TxTemplate {
 	id: ID!
 	txTemplateId: UUID!
 	version: Int!
 	code: String!
 	params: [ParamDefinition!]
-	txInput: TxInput!
-	entries: [EntryInput!]!
+	transaction: TxTemplateTransaction!
+	entries: [TxTemplateEntry!]!
 	description: String
 	metadata: JSON
 	createdAt: Timestamp!
@@ -468,7 +449,7 @@ input TxTemplateCreateInput {
 	txTemplateId: UUID!
 	code: String!
 	params: [ParamDefinitionInput!]
-	txInput: TxTemplateTxInput!
+	transaction: TxTemplateTransactionInput!
 	entries: [TxTemplateEntryInput!]!
 	description: String
 	metadata: JSON
@@ -476,6 +457,16 @@ input TxTemplateCreateInput {
 
 type TxTemplateCreatePayload {
 	txTemplate: TxTemplate!
+}
+
+type TxTemplateEntry {
+	entryType: Expression!
+	accountId: Expression!
+	layer: Expression!
+	direction: Expression!
+	units: Expression!
+	currency: Expression!
+	description: Expression
 }
 
 input TxTemplateEntryInput {
@@ -488,7 +479,16 @@ input TxTemplateEntryInput {
 	description: Expression
 }
 
-input TxTemplateTxInput {
+type TxTemplateTransaction {
+	effective: Expression!
+	journalId: Expression!
+	correlationId: Expression
+	externalId: Expression
+	description: Expression
+	metadata: Expression
+}
+
+input TxTemplateTransactionInput {
 	effective: Expression!
 	journalId: Expression!
 	correlationId: Expression

--- a/cala-server/src/graphql/schema.rs
+++ b/cala-server/src/graphql/schema.rs
@@ -497,31 +497,32 @@ impl<E: MutationExtensionMarker> CoreMutation<E> {
             .data_unchecked::<DbOp>()
             .try_lock()
             .expect("Lock held concurrently");
-        let mut new_tx_input_builder = cala_ledger::tx_template::NewTxInput::builder();
-        let TxTemplateTxInput {
+        let mut new_tx_template_transaction_builder =
+            cala_ledger::tx_template::NewTxTemplateTransaction::builder();
+        let TxTemplateTransactionInput {
             effective,
             journal_id,
             correlation_id,
             external_id,
             description,
             metadata,
-        } = input.tx_input;
-        new_tx_input_builder
+        } = input.transaction;
+        new_tx_template_transaction_builder
             .effective(effective)
             .journal_id(journal_id);
         if let Some(correlation_id) = correlation_id {
-            new_tx_input_builder.correlation_id(correlation_id);
+            new_tx_template_transaction_builder.correlation_id(correlation_id);
         };
         if let Some(external_id) = external_id {
-            new_tx_input_builder.external_id(external_id);
+            new_tx_template_transaction_builder.external_id(external_id);
         };
         if let Some(description) = description {
-            new_tx_input_builder.description(description);
+            new_tx_template_transaction_builder.description(description);
         };
         if let Some(metadata) = metadata {
-            new_tx_input_builder.metadata(metadata);
+            new_tx_template_transaction_builder.metadata(metadata);
         }
-        let new_tx_input = new_tx_input_builder.build()?;
+        let new_transaction = new_tx_template_transaction_builder.build()?;
 
         let mut new_params = Vec::new();
         if let Some(params) = input.params {
@@ -550,7 +551,8 @@ impl<E: MutationExtensionMarker> CoreMutation<E> {
                 currency,
                 description,
             } = entry;
-            let mut new_entry_input_builder = cala_ledger::tx_template::NewEntryInput::builder();
+            let mut new_entry_input_builder =
+                cala_ledger::tx_template::NewTxTemplateEntry::builder();
             new_entry_input_builder
                 .entry_type(entry_type)
                 .account_id(account_id)
@@ -569,7 +571,7 @@ impl<E: MutationExtensionMarker> CoreMutation<E> {
         new_tx_template_builder
             .id(input.tx_template_id)
             .code(input.code)
-            .tx_input(new_tx_input)
+            .transaction(new_transaction)
             .params(new_params)
             .entries(new_entries);
         if let Some(desc) = input.description {

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -82,12 +82,12 @@ async fn main() -> anyhow::Result<()> {
     journal.update(builder);
     cala.journals().persist(&mut journal).await?;
 
-    let tx_input = NewTxInput::builder()
+    let transaction = NewTxTemplateTransaction::builder()
         .journal_id(format!("uuid('{}')", journal_id))
         .effective("date('2022-11-01')")
         .build()?;
     let entries = vec![
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_DR'")
             .account_id("param.recipient")
             .layer("'SETTLED'")
@@ -96,7 +96,7 @@ async fn main() -> anyhow::Result<()> {
             .currency("'BTC'")
             .build()
             .unwrap(),
-        NewEntryInput::builder()
+        NewTxTemplateEntry::builder()
             .entry_type("'TEST_CR'")
             .account_id("param.sender")
             .layer("'SETTLED'")
@@ -111,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
     let new_tx_template = NewTxTemplate::builder()
         .id(tx_template_id)
         .code(format!("CODE_{}", example_suffix))
-        .tx_input(tx_input)
+        .transaction(transaction)
         .entries(entries)
         .build()
         .unwrap();

--- a/proto/ledger/outbox_service.proto
+++ b/proto/ledger/outbox_service.proto
@@ -148,13 +148,13 @@ message TxTemplate {
   uint32 version = 2;
   string code = 3;
   repeated ParamDefinition params = 4;
-  TxInput tx_input = 5;
-  repeated EntryInput entries = 6;
+  TxTemplateTransaction transaction = 5;
+  repeated TxTemplateEntry entries = 6;
   optional string description = 7;
   optional google.protobuf.Struct metadata = 8;
 }
 
-message EntryInput {
+message TxTemplateEntry {
   string entry_type = 1;
   string account_id = 2;
   string layer = 3;
@@ -164,7 +164,7 @@ message EntryInput {
   optional string description = 7;
 }
 
-message TxInput {
+message TxTemplateTransaction {
   string effective = 1;
   string journal_id = 2;
   optional string correlation_id = 3;


### PR DESCRIPTION
`tx_input` -> `transaction`
`TxInput` -> `TxTemplateTransaction`
`EntryInput` -> `TxTemplateEntry`