### PR TITLE
chore: replace cel category slug

### DIFF
--- a/cala-cel-interpreter/Cargo.toml
+++ b/cala-cel-interpreter/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/GaloyMoney/cala"
 version = "0.2.22-dev"
 edition = "2021"
 license = "Apache-2.0"
-categories = ["parsing", "cel"]
+categories = ["parsing", "compilers"]
 
 [features]
 

--- a/cala-cel-parser/Cargo.toml
+++ b/cala-cel-parser/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.2.22-dev"
 authors = ["Justin Carter <justin@galoy.io>"]
 edition = "2021"
 license = "Apache-2.0"
-categories = ["parsing", "cel"]
+categories = ["parsing", "compilers"]
 
 [features]
 


### PR DESCRIPTION
`cel` category is no longer a part: https://crates.io/category_slugs