### PR TITLE
chore: add website-demo.bats to generate json variables and response files

### DIFF
--- a/.github/workflows/website-update-api-reference.yml
+++ b/.github/workflows/website-update-api-reference.yml
@@ -20,12 +20,18 @@ jobs:
           npm install spectaql
           npx spectaql spectaql-config.yml -t static -f api-reference.html
 
-      - name: Deploy the API reference
+      - name: Generate the website demo json files
+        run: nix develop -c make e2e
+
+      - name: Copy the bats/gql/ files to the website/static/gql/ folder
+        run: cp -r bats/gql/* website/static/gql/
+
+      - name: Commit the API reference and website demo changes
         run: |
           git config --local user.name 'github-actions[bot]'
           git config --local user.email 'github-actions[bot]@users.noreply.github.com'
-          git add website/static/api-reference.html
-          git commit -m "docs: api reference update: $GITHUB_SHA"
+          git add website/static
+          git commit -m "docs: api reference and website examples update: $GITHUB_SHA"
           git push origin HEAD:main
 
       - name: Install Website Dependencies

--- a/.github/workflows/website-update-api-reference.yml
+++ b/.github/workflows/website-update-api-reference.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  update-api-reference:
+  update-api-reference-and-website-demo-files:
     runs-on: ubuntu-latest
     steps:
       - uses: DeterminateSystems/nix-installer-action@v12
@@ -32,7 +32,7 @@ jobs:
           git config --local user.email 'github-actions[bot]@users.noreply.github.com'
           git add website/static
           git commit -m "docs: api reference and website examples update: $GITHUB_SHA"
-          # git push origin HEAD:main
+          git push origin HEAD:main
 
       - name: Install Website Dependencies
         run: |
@@ -44,10 +44,10 @@ jobs:
           cd website
           nix-shell -p yarn --run "yarn build"
 
-      #- name: Deploy to GitHub Pages
-      #  uses: peaceiris/actions-gh-pages@v3
-      #  with:
-      #    github_token: ${{ secrets.GITHUB_TOKEN }}
-      #    publish_dir: ./website/build
-      #    user_name: github-actions[bot]
-      #    user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/.github/workflows/website-update-api-reference.yml
+++ b/.github/workflows/website-update-api-reference.yml
@@ -20,11 +20,8 @@ jobs:
           npm install spectaql
           npx spectaql spectaql-config.yml -t static -f api-reference.html
 
-      - name: Generate the website demo json files
+      - name: Generate the website demo files
         run: nix develop -c make e2e
-
-      - name: Copy the bats/gql/ files to the website/static/gql/ folder
-        run: cp -r bats/gql/* website/static/gql/
 
       - name: Commit the API reference and website demo changes
         run: |

--- a/.github/workflows/website-update-api-reference.yml
+++ b/.github/workflows/website-update-api-reference.yml
@@ -32,7 +32,7 @@ jobs:
           git config --local user.email 'github-actions[bot]@users.noreply.github.com'
           git add website/static
           git commit -m "docs: api reference and website examples update: $GITHUB_SHA"
-          git push origin HEAD:main
+          # git push origin HEAD:main
 
       - name: Install Website Dependencies
         run: |
@@ -44,10 +44,10 @@ jobs:
           cd website
           nix-shell -p yarn --run "yarn build"
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./website/build
-          user_name: github-actions[bot]
-          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+      #- name: Deploy to GitHub Pages
+      #  uses: peaceiris/actions-gh-pages@v3
+      #  with:
+      #    github_token: ${{ secrets.GITHUB_TOKEN }}
+      #    publish_dir: ./website/build
+      #    user_name: github-actions[bot]
+      #    user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/bats/website-demo.bats
+++ b/bats/website-demo.bats
@@ -32,10 +32,12 @@ save_json() {
       "name": "General Ledger"
     }
   }')
-  exec_graphql 'journal-create' "$variables"
+  gql_request='journal-create'
+  exec_graphql "$gql_request" "$variables"
   [[ "$output" != "null" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/journalCreate.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/journalCreateResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # create liability account
   liability_account_id=$(random_uuid)
@@ -47,10 +49,12 @@ save_json() {
       "normalBalanceType": "CREDIT"
     }
   }')
-  exec_graphql 'account-create' "$variables"
+  gql_request='account-create'
+  exec_graphql "$gql_request" "$variables"
   [[ "$output" != "null" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/accountCreateChecking.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/accountCreateCheckingResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # create asset account
   asset_account_id=$(random_uuid)
@@ -62,10 +66,11 @@ save_json() {
       "normalBalanceType": "DEBIT"
     }
   }')
-  exec_graphql 'account-create' "$variables"
+  exec_graphql "$gql_request" "$variables"
   [[ "$output" != "null" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/accountCreateDebit.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/accountCreateDebitResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # create transaction templates
   deposit_template_id=$(random_uuid)
@@ -78,9 +83,11 @@ save_json() {
     "assetAccountId": ("uuid(\u0027" + $assetAccountId + "\u0027)"),
     "journalId": ("uuid(\u0027" + $journalId + "\u0027)")
   }')
-  exec_graphql 'tx-template-create' "$variables"
+  gql_request='tx-template-create'
+  exec_graphql "$gql_request" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/variables/txTemplateCreate.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/txTemplateCreateResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # post transaction
   transaction_id=$(random_uuid)
@@ -95,11 +102,13 @@ save_json() {
       }
     }
   }')
-  exec_graphql 'transaction-post' "$variables"
+  gql_request='transaction-post'
+  exec_graphql "$gql_request" "$variables"
   correlation_id=$(graphql_output '.data.transactionPost.transaction.correlationId')
   [[ $correlation_id == $transaction_id ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/transactionPost.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/transactionPostResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # check account balance
   variables=$(jq -n --arg journalId "$journal_id" --arg accountId "$liability_account_id" '{
@@ -107,11 +116,13 @@ save_json() {
     "journalId": $journalId,
     "currency": "USD"
   }')
-  exec_graphql 'account-with-balance' "$variables"
+  gql_request='account-with-balance'
+  exec_graphql "$gql_request" "$variables"
   balance=$(graphql_output '.data.account.balance.settled.normalBalance.units')
   [[ $balance == "9.53" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/accountWithBalance.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/accountWithBalanceResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # create account set
   account_set_id=$(random_uuid)
@@ -123,12 +134,13 @@ save_json() {
       "normalBalanceType": "CREDIT"
     }
   }')
-
-  exec_graphql 'account-set-create' "$variables"
+  gql_request='account-set-create'
+  exec_graphql "$gql_request" "$variables"
   res=$(graphql_output '.data.accountSetCreate.accountSet.accountSetId')
   [[ "$res" != "null" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/accountSetCreate.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/accountSetCreateResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # add account to account set
   variables=$(jq -n --arg account_set_id "$account_set_id" --arg member_id "$liability_account_id" '{
@@ -138,11 +150,13 @@ save_json() {
       "memberType": "ACCOUNT"
     }
   }')
-  exec_graphql 'add-to-account-set' "$variables"
+  gql_request='add-to-account-set'
+  exec_graphql "$gql_request" "$variables"
   balance=$(graphql_output '.data.addToAccountSet.accountSet.balance.settled.normalBalance.units')
   [[ $balance == "9.53" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/addToAccountSet.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/addToAccountSetResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 
   # balance check for account set
   variables=$(jq -n --arg journalId "$journal_id" --arg accountSetId "$account_set_id" '{
@@ -150,9 +164,11 @@ save_json() {
     "journalId": $journalId,
     "currency": "USD"
   }')
-  exec_graphql 'account-set-with-balance' "$variables"
+  gql_request='account-set-with-balance'
+  exec_graphql "$gql_request" "$variables"
   balance=$(graphql_output '.data.accountSet.balance.settled.normalBalance.units')
   [[ $balance == "9.53" ]] || exit 1
   save_json "${REPO_ROOT}/website/static/gql/variables/accountSetWithBalance.json" "$variables"
   save_json "${REPO_ROOT}/website/static/gql/responses/accountSetWithBalanceResponse.json" "$output"
+  cp "${REPO_ROOT}/bats/gql/${gql_request}.gql" "${REPO_ROOT}/website/static/gql/"
 }

--- a/bats/website-demo.bats
+++ b/bats/website-demo.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+
+load "helpers"
+
+setup_file() {
+  start_server
+}
+
+teardown_file() {
+  stop_server
+}
+
+save_json() {
+  local filename="$1"
+  local json_content="$2"
+  if [[ -z "$json_content" || "$json_content" == "null" ]]; then
+    echo "JSON content is empty or null, exiting."
+    exit 1
+  fi
+  echo "$json_content" | jq . >"$filename" || {
+    echo "Failed to write JSON to $filename"
+    exit 1
+  }
+}
+
+@test "cala: generate variables and responses for the website demo" {
+  # creating a journal
+  journal_id=$(random_uuid)
+  variables=$(jq -n --arg journal_id "$journal_id" '{
+    "input": {
+      "journalId": $journal_id,
+      "name": "General Ledger"
+    }
+  }')
+  exec_graphql 'journal-create' "$variables"
+  [[ "$output" != "null" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/journalCreate.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/journalCreateResponse.json" "$output"
+
+  # create liability account
+  liability_account_id=$(random_uuid)
+  variables=$(jq -n --arg liability_account_id "$liability_account_id" '{
+    "input": {
+      "accountId": $liability_account_id,
+      "name": "Alice - Checking",
+      "code": ("ALICE.CHECKING-" + $liability_account_id),
+      "normalBalanceType": "CREDIT"
+    }
+  }')
+  exec_graphql 'account-create' "$variables"
+  [[ "$output" != "null" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/accountCreateChecking.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/accountCreateCheckingResponse.json" "$output"
+
+  # create asset account
+  asset_account_id=$(random_uuid)
+  variables=$(jq -n --arg asset_account_id "$asset_account_id" '{
+    "input": {
+      "accountId": $asset_account_id,
+      "name": "Assets",
+      "code": ("ASSET-"+ $asset_account_id),
+      "normalBalanceType": "DEBIT"
+    }
+  }')
+  exec_graphql 'account-create' "$variables"
+  [[ "$output" != "null" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/accountCreateDebit.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/accountCreateDebitResponse.json" "$output"
+
+  # create transaction templates
+  deposit_template_id=$(random_uuid)
+  withdrawal_template_id=$(random_uuid)
+  variables=$(jq -n --arg depositTemplateId "$deposit_template_id" --arg withdrawalTemplateId "$withdrawal_template_id" --arg assetAccountId "$asset_account_id" --arg journalId "$journal_id" '{
+    "depositTemplateId": $depositTemplateId,
+    "depositTemplateCode": ("DEPOSIT-" + $depositTemplateId),
+    "withdrawalTemplateId": $withdrawalTemplateId,
+    "withdrawalTemplateCode": ("WITHDRAWAL-" + $withdrawalTemplateId),
+    "assetAccountId": ("uuid(\u0027" + $assetAccountId + "\u0027)"),
+    "journalId": ("uuid(\u0027" + $journalId + "\u0027)")
+  }')
+  exec_graphql 'tx-template-create' "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/variables/txTemplateCreate.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/txTemplateCreateResponse.json" "$output"
+
+  # post transaction
+  transaction_id=$(random_uuid)
+  variables=$(jq -n --arg transaction_id "$transaction_id" --arg account_id "$liability_account_id" --arg depositTemplateId "$deposit_template_id" '{
+    "input": {
+      "transactionId": $transaction_id,
+      "txTemplateCode": ("DEPOSIT-" + $depositTemplateId),
+      "params": {
+        "account": $account_id,
+        "amount": "9.53",
+        "effective": "2022-09-21"
+      }
+    }
+  }')
+  exec_graphql 'transaction-post' "$variables"
+  correlation_id=$(graphql_output '.data.transactionPost.transaction.correlationId')
+  [[ $correlation_id == $transaction_id ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/transactionPost.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/transactionPostResponse.json" "$output"
+
+  # check account balance
+  variables=$(jq -n --arg journalId "$journal_id" --arg accountId "$liability_account_id" '{
+    "accountId": $accountId,
+    "journalId": $journalId,
+    "currency": "USD"
+  }')
+  exec_graphql 'account-with-balance' "$variables"
+  balance=$(graphql_output '.data.account.balance.settled.normalBalance.units')
+  [[ $balance == "9.53" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/accountWithBalance.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/accountWithBalanceResponse.json" "$output"
+
+  # create account set
+  account_set_id=$(random_uuid)
+  variables=$(jq -n --arg account_set_id "$account_set_id" --arg journal_id "$journal_id" '{
+    "input": {
+      "accountSetId": $account_set_id,
+      "journalId": $journal_id,
+      "name": "Account Set",
+      "normalBalanceType": "CREDIT"
+    }
+  }')
+
+  exec_graphql 'account-set-create' "$variables"
+  res=$(graphql_output '.data.accountSetCreate.accountSet.accountSetId')
+  [[ "$res" != "null" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/accountSetCreate.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/accountSetCreateResponse.json" "$output"
+
+  # add account to account set
+  variables=$(jq -n --arg account_set_id "$account_set_id" --arg member_id "$liability_account_id" '{
+    "input": {
+      "accountSetId": $account_set_id,
+      "memberId": $member_id,
+      "memberType": "ACCOUNT"
+    }
+  }')
+  exec_graphql 'add-to-account-set' "$variables"
+  balance=$(graphql_output '.data.addToAccountSet.accountSet.balance.settled.normalBalance.units')
+  [[ $balance == "9.53" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/addToAccountSet.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/addToAccountSetResponse.json" "$output"
+
+  # balance check for account set
+  variables=$(jq -n --arg journalId "$journal_id" --arg accountSetId "$account_set_id" '{
+    "accountSetId": $accountSetId,
+    "journalId": $journalId,
+    "currency": "USD"
+  }')
+  exec_graphql 'account-set-with-balance' "$variables"
+  balance=$(graphql_output '.data.accountSet.balance.settled.normalBalance.units')
+  [[ $balance == "9.53" ]] || exit 1
+  save_json "${REPO_ROOT}/website/static/gql/variables/accountSetWithBalance.json" "$variables"
+  save_json "${REPO_ROOT}/website/static/gql/responses/accountSetWithBalanceResponse.json" "$output"
+}

--- a/website/docs/demo/account-set.mdx
+++ b/website/docs/demo/account-set.mdx
@@ -4,6 +4,12 @@ title: Use an Account Set
 slug: /docs/account-set
 ---
 
+import {
+  GraphQLBody,
+  GraphQLVariables,
+  GraphQLResponse,
+} from "../../src/components/GraphQLDisplay";
+
 Group the created accounts into an account set and check its balance.
 
 ## Create an Account Set
@@ -17,46 +23,17 @@ This initial step sets up the framework for grouping accounts under a common set
 - **Name**: The `name` parameter specifies the label or designation of the account set. This name helps users and systems identify and refer to the account set in operations and reports.
 - **Normal Balance Type**: The `normalBalanceType` indicates the expected normal balance of the account set (either 'DEBIT' or 'CREDIT'). This setting is foundational for ensuring that the account set correctly represents the nature of the majority of its transactions, aiding in proper financial analysis.
 
-```json
-{
-  "input": {
-    "accountSetId": "e0cacaef-b692-48d6-81e2-238a5a614a04",
-    "journalId": "bcc24f47-990c-457d-88cb-76332450ac77",
-    "name": "Main Account Set",
-    "normalBalanceType": "CREDIT"
-  }
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/accountSetCreate.json" />
 
 ### GraphQL Request Body
 
-```graphql
-mutation accountSetCreate($input: AccountSetCreateInput!) {
-  accountSetCreate(input: $input) {
-    accountSet {
-      accountSetId
-      name
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/account-set-create.gql" />
 
 ### Response
 
-```json
-{
-  "data": {
-    "accountSetCreate": {
-      "accountSet": {
-        "accountSetId": "e0cacaef-b692-48d6-81e2-238a5a614a04",
-        "name": "Main Account Set"
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/accountSetCreateResponse.json" />
 
-## Add Accounts to the Account Set
+## Add an Account to the Account Set
 
 After creating an account set, this section explains how to add individual accounts to it.
 
@@ -66,57 +43,15 @@ After creating an account set, this section explains how to add individual accou
 - **Member ID**: The `memberId` refers to the unique identifier of the account (e.g., `Alice - Checking`) being added to the account set.
 - **Member Type**: The `memberType` indicates the type of member being added to the set, in this case, an "ACCOUNT." This helps the system understand how to treat the member within the set, whether it's an individual account or another entity type.
 
-```json
-{
-  "input": {
-    "accountSetId": "e0cacaef-b692-48d6-81e2-238a5a614a04",
-    "memberId": "3a7d421b-7f5a-43ca-ba6f-5f3e6ee67237",
-    "memberType": "ACCOUNT"
-  }
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/addToAccountSet.json" />
 
 ### GraphQL Request Body
 
-```graphql
-mutation addToAccountSet($input: AddToAccountSetInput!) {
-  addToAccountSet(input: $input) {
-    accountSet {
-      accountSetId
-      name
-      balance(currency: "USD") {
-        settled {
-          normalBalance {
-            units
-          }
-        }
-      }
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/add-to-account-set.gql" />
 
 ### Response
 
-```json
-{
-  "data": {
-    "addToAccountSet": {
-      "accountSet": {
-        "accountSetId": "e0cacaef-b692-48d6-81e2-238a5a614a04",
-        "name": "Main Account Set",
-        "balance": {
-          "settled": {
-            "normalBalance": {
-              "units": "9.53"
-            }
-          }
-        }
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/addToAccountSetResponse.json" />
 
 ## Check the Balance of the Account Set
 
@@ -128,51 +63,15 @@ This section explains how to query the balance of the entire account set. This o
 - **Journal ID**: The `journalId` helps to specify the journal context for the balance query. Since an account set could potentially be linked to multiple journals over time, this helps ensure the balance retrieved is relevant to the specified journal.
 - **Currency**: The `currency` specifies the currency unit (e.g., USD) in which the balance should be reported.
 
-```json
-{
-  "accountSetId": "e0cacaef-b692-48d6-81e2-238a5a614a04",
-  "journalId": "bcc24f47-990c-457d-88cb-76332450ac77",
-  "currency": "USD"
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/accountSetWithBalance.json" />
 
 ### GraphQL Request Body
 
-```graphql
-query accountSetWithBalance($accountSetId: UUID!, $currency: CurrencyCode!) {
-  accountSet(id: $accountSetId) {
-    name
-    journalId
-    balance(currency: $currency) {
-      settled {
-        normalBalance {
-          units
-        }
-      }
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/account-set-with-balance.gql" />
 
 ### Response
 
-```json
-{
-  "data": {
-    "accountSet": {
-      "name": "Main Account Set",
-      "journalId": "bcc24f47-990c-457d-88cb-76332450ac77",
-      "balance": {
-        "settled": {
-          "normalBalance": {
-            "units": "9.53"
-          }
-        }
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/accountSetWithBalanceResponse.json" />
 
 ## Significance
 

--- a/website/docs/demo/check-account-balance.mdx
+++ b/website/docs/demo/check-account-balance.mdx
@@ -4,6 +4,12 @@ title: Check the Balance of an Account
 slug: /docs/check-account-balance
 ---
 
+import {
+  GraphQLBody,
+  GraphQLVariables,
+  GraphQLResponse,
+} from "../../src/components/GraphQLDisplay";
+
 The functionality is essential for users (e.g., account holders, financial managers) to view the balance of a specific account in a particular journal and currency. This allows for real-time financial monitoring and decision-making based on up-to-date account information.
 
 ## Process
@@ -14,62 +20,24 @@ The functionality is essential for users (e.g., account holders, financial manag
 - **Journal ID**: The `journalId` specifies which journal to check for the account's balance. This is important because an account may have different balances in different journals due to various types of transactions.
 - **Currency**: The `currency` parameter ensures that the balance is provided in the desired currency, in this case, USD. This is crucial for accuracy and relevance, especially in multi-currency environments.
 
-```
-{
-  "accountId": "3a7d421b-7f5a-43ca-ba6f-5f3e6ee67237",
-  "journalId": "bcc24f47-990c-457d-88cb-76332450ac77",
-  "currency": "USD"
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/accountWithBalance.json" />
 
 ### GraphQL Request Body
 
 The `accountWithBalance` query is executed with the provided inputs. The query fetches the account's name and its settled balance in the specified journal and currency.
 
-```graphql
-query accountWithBalance(
-  $accountId: UUID!
-  $journalId: UUID!
-  $currency: CurrencyCode!
-) {
-  account(id: $accountId) {
-    name
-    balance(journalId: $journalId, currency: $currency) {
-      settled {
-        normalBalance {
-          units
-        }
-      }
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/account-with-balance.gql" />
 
 The system retrieves the settled balance from the specified journal for the given account.
 
-## Response
+### Response
 
 The response includes the account's name and its settled balance in the specified currency and journal. This information is returned in a structured JSON format, which includes:
 
 - **Account Name**: "Alice - Checking", confirming that the balance belongs to the correct account.
 - **Settled Balance**: The `normalBalance` `units` show the account's balance as "9.53" USD, indicating the available settled funds in the account.
 
-```json
-{
-  "data": {
-    "account": {
-      "name": "Alice - Checking",
-      "balance": {
-        "settled": {
-          "normalBalance": {
-            "units": "9.53"
-          }
-        }
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/accountWithBalanceResponse.json" />
 
 ## Significance
 

--- a/website/docs/demo/create-journal-and-accounts.mdx
+++ b/website/docs/demo/create-journal-and-accounts.mdx
@@ -4,6 +4,12 @@ title: Create a Journal and Accounts
 slug: /docs/create-journal-and-accounts
 ---
 
+import {
+  GraphQLBody,
+  GraphQLVariables,
+  GraphQLResponse,
+} from "../../src/components/GraphQLDisplay";
+
 Create different types of accounts (journal, checking, and debit accounts) through the GraphQL API.
 
 ## Create a Journal
@@ -12,46 +18,20 @@ Initiate the creation of a journal, specifically a "General Ledger," which is fu
 
 ### Variables
 
-The GraphQL mutation request input contains the unique ID and the name of the journal. The system creates a journal entity with these details.
+<GraphQLVariables variablesPath="/gql/variables/journalCreate.json" />
 
-```json
-{
-  "input": {
-    "journalId": "bcc24f47-990c-457d-88cb-76332450ac77",
-    "name": "General Ledger"
-  }
-}
-```
+The GraphQL mutation request input contains the unique ID and the name of the journal. The system creates a journal entity with these details.
 
 ### GraphQL Request Body
 
-```graphql
-mutation journalCreate($input: JournalCreateInput!) {
-  journalCreate(input: $input) {
-    journal {
-      journalId
-      name
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/journal-create.gql" />
 
 ### Response
 
-The system returns the details of the newly created journal, including its ID and name, confirming the successful creation.
+The system returns the details of the newly created journal, including
+its ID and name, confirming the successful creation.
 
-```json
-{
-  "data": {
-    "journalCreate": {
-      "journal": {
-        "journalId": "bcc24f47-990c-457d-88cb-76332450ac77",
-        "name": "General Ledger"
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/journalCreateResponse.json" />
 
 ## Create a Checking Account
 
@@ -62,46 +42,16 @@ The `normalBalanceType` indicates whether the account is a debit or credit type,
 
 ### Variables
 
-```json
-{
-  "input": {
-    "accountId": "3a7d421b-7f5a-43ca-ba6f-5f3e6ee67237",
-    "name": "Alice - Checking",
-    "code": "ALICE.CHECKING-3a7d421b-7f5a-43ca-ba6f-5f3e6ee67237",
-    "normalBalanceType": "CREDIT"
-  }
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/accountCreateChecking.json" />
 
-### GraphQL body
+### GraphQL Request Body
 
-```graphql
-mutation accountCreate($input: AccountCreateInput!) {
-  accountCreate(input: $input) {
-    account {
-      accountId
-      name
-    }
-  }
-}
-```
-
+<GraphQLBody queryPath="/gql/account-create.gql" />
 ### Response
 
 The response confirms the creation of the checking account with the specified details, ensuring the account is ready for transactional activities.
 
-```json
-{
-  "data": {
-    "accountCreate": {
-      "account": {
-        "accountId": "3a7d421b-7f5a-43ca-ba6f-5f3e6ee67237",
-        "name": "Alice - Checking"
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/accountCreateCheckingResponse.json" />
 
 ## Create a Debit Account
 
@@ -111,43 +61,15 @@ Similar to the previous account creation, the mutation includes unique identifie
 
 ### Variables
 
-```
-{
-  "input": {
-    "accountId": "2e40175d-35c2-4b6f-9c01-cc2309934d25",
-    "name": "Assets",
-    "code": "ASSET-2e40175d-35c2-4b6f-9c01-cc2309934d25",
-    "normalBalanceType": "DEBIT"
-  }
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/accountCreateDebit.json" />
 
 ### GraphQL Request Body
 
-```graphql
-mutation accountCreate($input: AccountCreateInput!) {
-  accountCreate(input: $input) {
-    account {
-      accountId
-      name
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/account-create.gql" />
 
 ### Response
 
-The response shows the successful creation of the debit account, confirming that it's set up to track asset-related transactions.
+The response shows the successful creation of the debit account, confirming that
+it's set up to track asset-related transactions.
 
-```json
-{
-  "data": {
-    "accountCreate": {
-      "account": {
-        "accountId": "2e40175d-35c2-4b6f-9c01-cc2309934d25",
-        "name": "Assets"
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/accountCreateDebitResponse.json" />

--- a/website/docs/demo/transaction-post.mdx
+++ b/website/docs/demo/transaction-post.mdx
@@ -4,6 +4,12 @@ title: Post a Transaction
 slug: /docs/transaction-post
 ---
 
+import {
+  GraphQLBody,
+  GraphQLVariables,
+  GraphQLResponse,
+} from "../../src/components/GraphQLDisplay";
+
 This functionality allows to execute financial transactions based on predefined parameters and templates. The specific transaction being posted here is based on a deposit template, which facilitates adding funds to a user's account.
 
 ## Process
@@ -14,53 +20,21 @@ This functionality allows to execute financial transactions based on predefined 
 - **Template Code**: The `txTemplateCode` specifies the template to use for the transaction, in this case, a deposit. This ensures that the transaction adheres to predefined rules and parameters for deposits.
 - **Parameters**: The `params` specify the particular details for the transaction, such as the account to which the deposit is made, the amount of the deposit, and the effective date of the transaction. These details are crucial for the accurate execution of the transaction according to the user’s needs and timing requirements.
 
-```json
-{
-  "input": {
-    "transactionId": "204d087b-5b6d-4544-9203-6674d54528d3",
-    "txTemplateCode": "DEPOSIT-ea1c7224-ca09-409f-b581-3551beead58c",
-    "params": {
-      "account": "3a7d421b-7f5a-43ca-ba6f-5f3e6ee67237",
-      "amount": "9.53",
-      "effective": "2022-09-21"
-    }
-  }
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/transactionPost.json" />
 
 ### GraphQL Request Body
 
 The `transactionPost` mutation is called with the inputs below. This mutation processes the transaction based on the provided template and parameters.
 
-```graphql
-mutation transactionPost($input: TransactionInput!) {
-  transactionPost(input: $input) {
-    transaction {
-      transactionId
-      correlationId
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/transaction-post.gql" />
 
 The system validates the input data against the specified template, calculates any necessary values or triggers other business logic as defined by the template, and logs the transaction in the appropriate accounts.
 
-## Response
+### Response
 
 Upon successful processing of the mutation, the system returns the transaction ID and a correlation ID. The correlation ID can be used to track the transaction through other systems or logs for auditing or debugging purposes. This ensures traceability and accountability of the transaction.
 
-```json
-{
-  "data": {
-    "transactionPost": {
-      "transaction": {
-        "transactionId": "204d087b-5b6d-4544-9203-6674d54528d3",
-        "correlationId": "204d087b-5b6d-4544-9203-6674d54528d3"
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/transactionPostResponse.json" />
 
 ## Significance
 

--- a/website/docs/demo/tx-template-create.mdx
+++ b/website/docs/demo/tx-template-create.mdx
@@ -4,11 +4,17 @@ title: Create Transaction Templates
 slug: /docs/tx-template-create
 ---
 
+import {
+  GraphQLBody,
+  GraphQLVariables,
+  GraphQLResponse,
+} from "../../src/components/GraphQLDisplay";
+
 This functionality allows a user (an administrator or financial manager) to define templates for recurring transaction types - specifically deposits and withdrawals. By defining these templates, the user ensures consistency, accuracy, and efficiency in transaction processing.
 
 ## Process
 
-### Creation of Deposit Transaction Template
+### Deposit Transaction Template
 
 - **Identification and Description**: The template is uniquely identified by a `txTemplateId` and a descriptive code. The description explains that this template is for an ACH credit into a customer's account.
 
@@ -17,7 +23,7 @@ This functionality allows a user (an administrator or financial manager) to defi
 - **Transaction and Entries Definition**:
   The transaction input specifies which journal to log this transaction under and when it becomes effective. Entries detail the movement of funds, specifying which account to debit and which to credit, in what amount, and under what transaction conditions, e.g., `currency` and transaction type (`entryType`).
 
-### Creation of Withdrawal Transaction Template
+### Withdrawal Transaction Template
 
 - **Identification and Description**: Similarly, this template has its unique identifier and code, and is described for use in ACH debits from a customer's account.
 
@@ -27,104 +33,7 @@ This functionality allows a user (an administrator or financial manager) to defi
 
 ### GraphQL Request Body
 
-```graphql
-mutation CreateDepositAndWithdrawalTxTemplates(
-  $depositTemplateId: UUID!
-  $depositTemplateCode: String!
-  $withdrawalTemplateId: UUID!
-  $withdrawalTemplateCode: String!
-  $journalId: Expression!
-  $assetAccountId: Expression!
-) {
-  depositTemplate: txTemplateCreate(
-    input: {
-      txTemplateId: $depositTemplateId
-      code: $depositTemplateCode
-      description: "An ACH credit into a customer account."
-      params: [
-        { name: "account", type: UUID, description: "Deposit account ID." }
-        {
-          name: "amount"
-          type: DECIMAL
-          description: "Amount with decimal, e.g. `1.23`."
-        }
-        {
-          name: "effective"
-          type: DATE
-          description: "Effective date for transaction."
-        }
-      ]
-      transaction: { journalId: $journalId, effective: "params.effective" }
-      entries: [
-        {
-          accountId: $assetAccountId
-          units: "params.amount"
-          currency: "'USD'"
-          entryType: "'ACH_DR'"
-          direction: "DEBIT"
-          layer: "SETTLED"
-        }
-        {
-          accountId: "params.account"
-          units: "params.amount"
-          currency: "'USD'"
-          entryType: "'ACH_CR'"
-          direction: "CREDIT"
-          layer: "SETTLED"
-        }
-      ]
-    }
-  ) {
-    txTemplate {
-      txTemplateId
-    }
-  }
-
-  withdrawalTemplate: txTemplateCreate(
-    input: {
-      txTemplateId: $withdrawalTemplateId
-      code: $withdrawalTemplateCode
-      description: "An ACH debit into a customer account."
-      params: [
-        { name: "account", type: UUID, description: "Withdraw account ID." }
-        {
-          name: "amount"
-          type: DECIMAL
-          description: "Amount with decimal, e.g. `1.23`."
-        }
-        {
-          name: "effective"
-          type: DATE
-          description: "Effective date for transaction."
-        }
-      ]
-      transaction: { journalId: $journalId, effective: "params.effective" }
-      entries: [
-        {
-          accountId: $assetAccountId
-          units: "params.amount"
-          currency: "'USD'"
-          entryType: "'ACH_CR'"
-          direction: "CREDIT"
-          layer: "SETTLED"
-        }
-        {
-          accountId: "params.account"
-          units: "params.amount"
-          currency: "'USD'"
-          entryType: "'ACH_DR'"
-          direction: "DEBIT"
-          layer: "SETTLED"
-        }
-      ]
-    }
-  ) {
-    txTemplate {
-      txTemplateId
-    }
-  }
-}
-```
+<GraphQLBody queryPath="/gql/tx-template-create.gql" />
 
 ### Variables
 
@@ -135,37 +44,13 @@ mutation CreateDepositAndWithdrawalTxTemplates(
 - **journalId**: The identifier for the journal where the transactions will be logged. This links the transaction to the correct financial journal.
 - **assetAccountId**: The identifier for the asset account involved in the transactions. This specifies which account will be debited or credited during the transaction.
 
-```json
-{
-  "depositTemplateId": "ea1c7224-ca09-409f-b581-3551beead58c",
-  "depositTemplateCode": "DEPOSIT-ea1c7224-ca09-409f-b581-3551beead58c",
-  "withdrawalTemplateId": "241ef9dd-8c6c-4fb8-b9fb-931083f2b728",
-  "withdrawalTemplateCode": "withdrawal-241ef9dd-8c6c-4fb8-b9fb-931083f2b728",
-  "assetAccountId": "uuid('2e40175d-35c2-4b6f-9c01-cc2309934d25')",
-  "journalId": "uuid('bcc24f47-990c-457d-88cb-76332450ac77')"
-}
-```
+<GraphQLVariables variablesPath="/gql/variables/txTemplateCreate.json" />
 
-## Response
+### Response
 
 Upon successful submission of the GraphQL mutations, the system creates these templates and returns their IDs in the response. This confirms that the templates are ready for use in future transactions.
 
-```json
-{
-  "data": {
-    "depositTemplate": {
-      "txTemplate": {
-        "txTemplateId": "ea1c7224-ca09-409f-b581-3551beead58c"
-      }
-    },
-    "withdrawalTemplate": {
-      "txTemplate": {
-        "txTemplateId": "241ef9dd-8c6c-4fb8-b9fb-931083f2b728"
-      }
-    }
-  }
-}
-```
+<GraphQLResponse responsePath="/gql/responses/txTemplateCreateResponse.json" />
 
 ## Significance
 

--- a/website/src/components/GraphQLDisplay.js
+++ b/website/src/components/GraphQLDisplay.js
@@ -1,0 +1,74 @@
+import React, { useState, useEffect } from 'react';
+import CodeBlock from '@theme/CodeBlock';
+
+export const GraphQLBody = ({ queryPath }) => {
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const loadQuery = async () => {
+      try {
+        const queryResponse = await fetch(queryPath);
+        const queryText = await queryResponse.text();
+        setQuery(queryText);
+      } catch (error) {
+        console.error('Error loading query:', error);
+      }
+    };
+
+    loadQuery();
+  }, [queryPath]);
+
+  return (
+    <CodeBlock className="language-graphql">
+      {query}
+    </CodeBlock>
+  );
+};
+
+export const GraphQLVariables = ({ variablesPath }) => {
+  const [variables, setVariables] = useState({});
+
+  useEffect(() => {
+    const loadVariables = async () => {
+      try {
+        const variablesResponse = await fetch(variablesPath);
+        const variablesJson = await variablesResponse.json();
+        setVariables(variablesJson);
+      } catch (error) {
+        console.error('Error loading variables:', error);
+      }
+    };
+
+    loadVariables();
+  }, [variablesPath]);
+
+  return (
+    <CodeBlock className="language-json">
+      {JSON.stringify(variables, null, 2)}
+    </CodeBlock>
+  );
+};
+
+export const GraphQLResponse = ({ responsePath }) => {
+  const [response, setResponse] = useState({});
+
+  useEffect(() => {
+    const loadResponse = async () => {
+      try {
+        const responseResponse = await fetch(responsePath);
+        const responseJson = await responseResponse.json();
+        setResponse(responseJson);
+      } catch (error) {
+        console.error('Error loading response:', error);
+      }
+    };
+
+    loadResponse();
+  }, [responsePath]);
+
+  return (
+    <CodeBlock className="language-json">
+      {JSON.stringify(response, null, 2)}
+    </CodeBlock>
+  );
+};

--- a/website/static/gql/account-create.gql
+++ b/website/static/gql/account-create.gql
@@ -1,0 +1,8 @@
+mutation accountCreate($input: AccountCreateInput!) {
+  accountCreate(input: $input) {
+    account {
+      accountId
+      name
+    }
+  }
+}

--- a/website/static/gql/account-set-create.gql
+++ b/website/static/gql/account-set-create.gql
@@ -1,0 +1,8 @@
+mutation accountSetCreate($input: AccountSetCreateInput!) {
+  accountSetCreate(input: $input) {
+   accountSet{
+      accountSetId
+      name
+    }
+  }
+}

--- a/website/static/gql/account-set-with-balance.gql
+++ b/website/static/gql/account-set-with-balance.gql
@@ -1,0 +1,13 @@
+query accountSetWithBalance($accountSetId: UUID!, $currency: CurrencyCode!) {
+  accountSet(id: $accountSetId) {
+    name
+    journalId
+    balance(currency: $currency) {
+      settled {
+        normalBalance {
+          units
+        }
+      }
+    }
+  }
+}

--- a/website/static/gql/account-with-balance.gql
+++ b/website/static/gql/account-with-balance.gql
@@ -1,0 +1,12 @@
+query accountWithBalance($accountId: UUID!, $journalId: UUID!, $currency: CurrencyCode!) {
+  account(id: $accountId) {
+    name
+    balance(journalId: $journalId, currency: $currency) {
+      settled {
+        normalBalance {
+          units
+        }
+      }
+    }
+  }
+}

--- a/website/static/gql/add-to-account-set.gql
+++ b/website/static/gql/add-to-account-set.gql
@@ -1,0 +1,15 @@
+mutation addToAccountSet($input: AddToAccountSetInput!) {
+  addToAccountSet(input: $input) {
+   accountSet{
+      accountSetId
+      name
+      balance(currency: "USD") {
+        settled {
+          normalBalance {
+            units
+          }
+        }
+      }
+    }
+  }
+}

--- a/website/static/gql/journal-create.gql
+++ b/website/static/gql/journal-create.gql
@@ -1,0 +1,8 @@
+mutation journalCreate($input: JournalCreateInput!) {
+  journalCreate(input: $input) {
+    journal {
+      journalId
+      name
+    }
+  }
+}

--- a/website/static/gql/responses/accountCreateCheckingResponse.json
+++ b/website/static/gql/responses/accountCreateCheckingResponse.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountCreate": {
+      "account": {
+        "accountId": "6ad8cd41-efe4-4d42-b7b6-a83df144721f",
+        "name": "Alice - Checking"
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/accountCreateDebitResponse.json
+++ b/website/static/gql/responses/accountCreateDebitResponse.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountCreate": {
+      "account": {
+        "accountId": "3ec6c31b-d032-40f7-8f09-29258edd3f8b",
+        "name": "Assets"
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/accountSetCreateResponse.json
+++ b/website/static/gql/responses/accountSetCreateResponse.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "accountSetCreate": {
+      "accountSet": {
+        "accountSetId": "b9a9c376-945f-46f4-83e4-ce3b5b974d9b",
+        "name": "Account Set"
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/accountSetWithBalanceResponse.json
+++ b/website/static/gql/responses/accountSetWithBalanceResponse.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "accountSet": {
+      "name": "Account Set",
+      "journalId": "18f8eeb5-740f-4040-89fb-2e6575da2b46",
+      "balance": {
+        "settled": {
+          "normalBalance": {
+            "units": "9.53"
+          }
+        }
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/accountWithBalanceResponse.json
+++ b/website/static/gql/responses/accountWithBalanceResponse.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "account": {
+      "name": "Alice - Checking",
+      "balance": {
+        "settled": {
+          "normalBalance": {
+            "units": "9.53"
+          }
+        }
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/addToAccountSetResponse.json
+++ b/website/static/gql/responses/addToAccountSetResponse.json
@@ -1,0 +1,17 @@
+{
+  "data": {
+    "addToAccountSet": {
+      "accountSet": {
+        "accountSetId": "b9a9c376-945f-46f4-83e4-ce3b5b974d9b",
+        "name": "Account Set",
+        "balance": {
+          "settled": {
+            "normalBalance": {
+              "units": "9.53"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/journalCreateResponse.json
+++ b/website/static/gql/responses/journalCreateResponse.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "journalCreate": {
+      "journal": {
+        "journalId": "18f8eeb5-740f-4040-89fb-2e6575da2b46",
+        "name": "General Ledger"
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/transactionPostResponse.json
+++ b/website/static/gql/responses/transactionPostResponse.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "transactionPost": {
+      "transaction": {
+        "transactionId": "e3ce1352-5c72-4d0a-be1c-873a282d7234",
+        "correlationId": "e3ce1352-5c72-4d0a-be1c-873a282d7234"
+      }
+    }
+  }
+}

--- a/website/static/gql/responses/txTemplateCreateResponse.json
+++ b/website/static/gql/responses/txTemplateCreateResponse.json
@@ -1,0 +1,14 @@
+{
+  "data": {
+    "depositTemplate": {
+      "txTemplate": {
+        "txTemplateId": "e1ae6c67-bd8f-4a8a-af7f-9d84c39ca6d7"
+      }
+    },
+    "withdrawalTemplate": {
+      "txTemplate": {
+        "txTemplateId": "fcd003c9-2372-47b8-8f06-c5cb5d78a01c"
+      }
+    }
+  }
+}

--- a/website/static/gql/transaction-post.gql
+++ b/website/static/gql/transaction-post.gql
@@ -1,0 +1,8 @@
+mutation transactionPost($input: TransactionInput!) {
+  transactionPost(input: $input) {
+    transaction {
+      transactionId
+      correlationId
+    }
+  }
+}

--- a/website/static/gql/tx-template-create.gql
+++ b/website/static/gql/tx-template-create.gql
@@ -1,0 +1,95 @@
+mutation CreateDepositAndWithdrawalTxTemplates($depositTemplateId: UUID!, $depositTemplateCode: String!, $withdrawalTemplateId: UUID!, $withdrawalTemplateCode: String!, $journalId: Expression!, $assetAccountId: Expression!) {
+  depositTemplate: txTemplateCreate(
+    input: {
+      txTemplateId: $depositTemplateId
+      code: $depositTemplateCode
+      description: "An ACH credit into a customer account."
+      params: [
+        { name: "account", type: UUID, description: "Deposit account ID." }
+        {
+          name: "amount"
+          type: DECIMAL
+          description: "Amount with decimal, e.g. `1.23`."
+        }
+        {
+          name: "effective"
+          type: DATE
+          description: "Effective date for transaction."
+        }
+      ]
+      transaction: {
+        journalId: $journalId
+        effective: "params.effective"
+      }
+      entries: [
+        {
+          accountId: $assetAccountId
+          units: "params.amount"
+          currency: "'USD'"
+          entryType: "'ACH_DR'"
+          direction: "DEBIT"
+          layer: "SETTLED"
+        }
+        {
+          accountId: "params.account"
+          units: "params.amount"
+          currency: "'USD'"
+          entryType: "'ACH_CR'"
+          direction: "CREDIT"
+          layer: "SETTLED"
+        }
+      ]
+    }
+  ) {
+    txTemplate{
+      txTemplateId
+    }
+  }
+
+  withdrawalTemplate: txTemplateCreate(
+    input: {
+      txTemplateId: $withdrawalTemplateId
+      code: $withdrawalTemplateCode
+      description: "An ACH debit into a customer account."
+      params: [
+        { name: "account", type: UUID, description: "Withdraw account ID." }
+        {
+          name: "amount"
+          type: DECIMAL
+          description: "Amount with decimal, e.g. `1.23`."
+        }
+        {
+          name: "effective"
+          type: DATE
+          description: "Effective date for transaction."
+        }
+      ]
+      transaction: {
+        journalId: $journalId
+        effective: "params.effective"
+      }
+      entries: [
+        {
+          accountId: $assetAccountId
+          units: "params.amount"
+          currency: "'USD'"
+          entryType: "'ACH_CR'"
+          direction: "CREDIT"
+          layer: "SETTLED"
+        }
+        {
+          accountId: "params.account"
+          units: "params.amount"
+          currency: "'USD'"
+          entryType: "'ACH_DR'"
+          direction: "DEBIT"
+          layer: "SETTLED"
+        }
+      ]
+    }
+  ) {
+    txTemplate{
+      txTemplateId
+    }
+  }
+}

--- a/website/static/gql/variables/accountCreateChecking.json
+++ b/website/static/gql/variables/accountCreateChecking.json
@@ -1,0 +1,8 @@
+{
+  "input": {
+    "accountId": "6ad8cd41-efe4-4d42-b7b6-a83df144721f",
+    "name": "Alice - Checking",
+    "code": "ALICE.CHECKING-6ad8cd41-efe4-4d42-b7b6-a83df144721f",
+    "normalBalanceType": "CREDIT"
+  }
+}

--- a/website/static/gql/variables/accountCreateDebit.json
+++ b/website/static/gql/variables/accountCreateDebit.json
@@ -1,0 +1,8 @@
+{
+  "input": {
+    "accountId": "3ec6c31b-d032-40f7-8f09-29258edd3f8b",
+    "name": "Assets",
+    "code": "ASSET-3ec6c31b-d032-40f7-8f09-29258edd3f8b",
+    "normalBalanceType": "DEBIT"
+  }
+}

--- a/website/static/gql/variables/accountSetCreate.json
+++ b/website/static/gql/variables/accountSetCreate.json
@@ -1,0 +1,8 @@
+{
+  "input": {
+    "accountSetId": "b9a9c376-945f-46f4-83e4-ce3b5b974d9b",
+    "journalId": "18f8eeb5-740f-4040-89fb-2e6575da2b46",
+    "name": "Account Set",
+    "normalBalanceType": "CREDIT"
+  }
+}

--- a/website/static/gql/variables/accountSetWithBalance.json
+++ b/website/static/gql/variables/accountSetWithBalance.json
@@ -1,0 +1,5 @@
+{
+  "accountSetId": "b9a9c376-945f-46f4-83e4-ce3b5b974d9b",
+  "journalId": "18f8eeb5-740f-4040-89fb-2e6575da2b46",
+  "currency": "USD"
+}

--- a/website/static/gql/variables/accountWithBalance.json
+++ b/website/static/gql/variables/accountWithBalance.json
@@ -1,0 +1,5 @@
+{
+  "accountId": "6ad8cd41-efe4-4d42-b7b6-a83df144721f",
+  "journalId": "18f8eeb5-740f-4040-89fb-2e6575da2b46",
+  "currency": "USD"
+}

--- a/website/static/gql/variables/addToAccountSet.json
+++ b/website/static/gql/variables/addToAccountSet.json
@@ -1,0 +1,7 @@
+{
+  "input": {
+    "accountSetId": "b9a9c376-945f-46f4-83e4-ce3b5b974d9b",
+    "memberId": "6ad8cd41-efe4-4d42-b7b6-a83df144721f",
+    "memberType": "ACCOUNT"
+  }
+}

--- a/website/static/gql/variables/journalCreate.json
+++ b/website/static/gql/variables/journalCreate.json
@@ -1,0 +1,6 @@
+{
+  "input": {
+    "journalId": "18f8eeb5-740f-4040-89fb-2e6575da2b46",
+    "name": "General Ledger"
+  }
+}

--- a/website/static/gql/variables/transactionPost.json
+++ b/website/static/gql/variables/transactionPost.json
@@ -1,0 +1,11 @@
+{
+  "input": {
+    "transactionId": "e3ce1352-5c72-4d0a-be1c-873a282d7234",
+    "txTemplateCode": "DEPOSIT-e1ae6c67-bd8f-4a8a-af7f-9d84c39ca6d7",
+    "params": {
+      "account": "6ad8cd41-efe4-4d42-b7b6-a83df144721f",
+      "amount": "9.53",
+      "effective": "2022-09-21"
+    }
+  }
+}

--- a/website/static/gql/variables/txTemplateCreate.json
+++ b/website/static/gql/variables/txTemplateCreate.json
@@ -1,0 +1,8 @@
+{
+  "depositTemplateId": "e1ae6c67-bd8f-4a8a-af7f-9d84c39ca6d7",
+  "depositTemplateCode": "DEPOSIT-e1ae6c67-bd8f-4a8a-af7f-9d84c39ca6d7",
+  "withdrawalTemplateId": "fcd003c9-2372-47b8-8f06-c5cb5d78a01c",
+  "withdrawalTemplateCode": "WITHDRAWAL-fcd003c9-2372-47b8-8f06-c5cb5d78a01c",
+  "assetAccountId": "uuid('3ec6c31b-d032-40f7-8f09-29258edd3f8b')",
+  "journalId": "uuid('18f8eeb5-740f-4040-89fb-2e6575da2b46')"
+}


### PR DESCRIPTION
PR to regenerate the examples on the cala.sh website on a new release published as part of a bats test.

gh action tested successfully in: https://github.com/GaloyMoney/cala/actions/runs/9991827283