### PR TITLE
test: explore if we can create a particular DAG structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ sqlx-prepare:
 	cd cala-ledger && cargo sqlx prepare -- --all-features
 	cd cala-server && cargo sqlx prepare -- --all-features
 
+reset-tf-state:
+	rm -rf bats/tf/terraform.tfstate
+
+run-tf:
+	cd bats/tf && tofu init && tofu apply -auto-approve
+
 test-in-ci: start-deps setup-db
 	cargo nextest run --verbose --locked
 	cargo test --doc

--- a/bats/add-interest-account.bats
+++ b/bats/add-interest-account.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load "helpers"
+
+setup_file() {
+  make reset-tf-state run-tf || true
+}
+
+@test "add-interest-account: can add account" {
+  interest_account_id=$(random_uuid)
+  variables=$(
+    jq -n \
+    --arg interest_account_id "$interest_account_id" \
+    '{
+      "interestAccountId": $interest_account_id,
+      "interestAccountName": ("Interest Income #" + $interest_account_id),
+      "interestAccountCode": ("INTEREST_INCOME." + $interest_account_id),
+      "interestRevenueControlAccountSetId": "00000000-0000-0000-0000-140000000001"
+    }'
+  )
+  exec_graphql 'add-interest-account' "$variables"
+  graphql_output
+  id=$(graphql_output '.data.interest.account.accountId')
+  [[ "$id" == "$interest_account_id" ]] || exit 1
+}

--- a/bats/gql/add-interest-account.gql
+++ b/bats/gql/add-interest-account.gql
@@ -1,0 +1,19 @@
+mutation CreateInterestAccount(
+  $interestAccountId: UUID!
+  $interestAccountCode: String!
+  $interestAccountName: String!
+  $interestRevenueControlAccountSetId: UUID!
+) {
+  interest: accountCreate(
+    input: {
+      accountId: $interestAccountId
+      code: $interestAccountCode
+      name: $interestAccountName
+      accountSetIds: [$interestRevenueControlAccountSetId]
+    }
+  ) {
+    account {
+      accountId
+    }
+  }
+}

--- a/bats/tf/.gitignore
+++ b/bats/tf/.gitignore
@@ -1,0 +1,4 @@
+.terraform.*
+.terraform/*
+terraform.tfstate
+terraform.tfstate.*

--- a/bats/tf/accounts.tf
+++ b/bats/tf/accounts.tf
@@ -1,0 +1,62 @@
+# "Chart of Accounts" Account Set
+resource "cala_account_set" "chart_of_accounts" {
+  id         = "00000000-0000-0000-0000-100000000001"
+  journal_id = cala_journal.journal.id
+  name       = "Chart of Accounts"
+}
+
+# EQUITY
+resource "random_uuid" "equity" {}
+resource "cala_account_set" "equity" {
+  id                  = random_uuid.equity.result
+  journal_id          = cala_journal.journal.id
+  name                = "Equity"
+  normal_balance_type = "CREDIT"
+}
+resource "cala_account_set_member_account_set" "equity" {
+  account_set_id        = cala_account_set.chart_of_accounts.id
+  member_account_set_id = cala_account_set.equity.id
+}
+
+resource "random_uuid" "retained_earnings" {}
+resource "cala_account_set" "retained_earnings" {
+  id                  = random_uuid.retained_earnings.result
+  journal_id          = cala_journal.journal.id
+  name                = "Retained Earnings"
+  normal_balance_type = "CREDIT"
+}
+resource "cala_account_set_member_account_set" "retained_earnings_in_equity" {
+  account_set_id        = cala_account_set.equity.id # this should be 'equity'
+  member_account_set_id = cala_account_set.retained_earnings.id
+}
+
+
+# REVENUE
+resource "random_uuid" "revenue" {}
+resource "cala_account_set" "revenue" {
+  id                  = random_uuid.revenue.result
+  journal_id          = cala_journal.journal.id
+  name                = "Revenue"
+  normal_balance_type = "CREDIT"
+}
+resource "cala_account_set_member_account_set" "revenue" {
+  account_set_id        = cala_account_set.chart_of_accounts.id
+  member_account_set_id = cala_account_set.revenue.id
+}
+resource "cala_account_set_member_account_set" "revenue_in_retained_earnings" {
+  account_set_id        = cala_account_set.retained_earnings.id
+  member_account_set_id = cala_account_set.revenue.id
+}
+
+# REVENUE: Members
+resource "cala_account_set" "interest_revenue_control" {
+  id                  = "00000000-0000-0000-0000-140000000001"
+  journal_id          = cala_journal.journal.id
+  name                = "Interest Revenue Control Account"
+  normal_balance_type = "CREDIT"
+}
+resource "cala_account_set_member_account_set" "interest_revenue_control_in_revenue" {
+  account_set_id        = cala_account_set.revenue.id
+  member_account_set_id = cala_account_set.interest_revenue_control.id
+}
+

--- a/bats/tf/journal.tf
+++ b/bats/tf/journal.tf
@@ -1,0 +1,5 @@
+resource "cala_journal" "journal" {
+  id          = "00000000-0000-0000-0000-000000000001"
+  name        = "My Journal"
+  description = "Journal for my accounts"
+}

--- a/bats/tf/main.tf
+++ b/bats/tf/main.tf
@@ -1,0 +1,12 @@
+provider "cala" {
+  endpoint = "http://localhost:2252/graphql"
+}
+
+terraform {
+  required_providers {
+    cala = {
+      source  = "registry.terraform.io/galoymoney/cala"
+      version = "0.0.18"
+    }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,7 @@
       nativeBuildInputs = with pkgs;
         [
           rustToolchain
+          opentofu
           alejandra
           sqlx-cli
           cargo-nextest


### PR DESCRIPTION
## Description

**_DO NOT MERGE, this is to explore the problem and see if it's an actual bug._** _So far, it's just a misuse of account sets._

I've been able to isolate the issue to [this DAG](https://mermaid.live/edit#pako:eNp9kU1Pg0AQhv_KZs60oXyXgwmhHHoyovageFhhW4hlty67xtr0vzuwVvsRO6eZZ959yTvsoBQVgxhWkm5q8jArOMHq9KsBaU2lImJJkrIUmqvO7PtKb5PnAi4F8GI0jFcFP7PL3nWjtn8e2d0jevzQw8O-8gx5zhRtOKtIRiVv-Oq6d84-GNfs2GMxmBh87D7PU9zMuWKSderwkqSCKynWhyhXv3Z5j3ly7PmPhxnwdGQ0uunjG4DNAPLsVIARDMiz83kxAExiADZkNO5JUnCwoGWypU2Ff3bXCwpQNWvxCjG2FZVvBRR8jzqqlbjf8hJiJTWzQAq9qiFe0nWHk95UVLFZQzF0-0s3lD8JcTJDvINPiF3fGYfO1LWnduTY7sTxLdhC7NnjaeSGQeQF7sT1wiDYW_A1WODGCXw7jHxv4gWh7QX7bzm3wt4)

![mermaid-diagram-2024-07-26-173134](https://github.com/user-attachments/assets/d22103a8-24bc-4f43-8d07-5623d41719a5)

The problem shows up when we create an interest account under this setup of account sets. Can be done via:
- In one terminal `make reset-deps run-server`
- In another terminal after server is running `bats -t bats/add-interest-account.bats`

**The problem goes away if any of the solid lines in the DAG is broken** since it breaks double-adding interest account to chart of accounts account-set.

_Should this problem show up before we get to the `Interest Account` creation though?_
