### PR TITLE
perf: use uuid v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ clap = { version = "4.5", features = ["derive", "env", "cargo"] }
 derive_builder = "0.20.1"
 sqlx = { version = "0.8.3", features = [ "runtime-tokio-rustls", "postgres", "rust_decimal", "uuid", "chrono", "json" ] }
 thiserror = "2.0.12"
-uuid = { version = "1.16", features = ["serde", "v4"] }
+uuid = { version = "1.17", features = ["serde", "v7"] }
 regex = "1.11.1"
 tracing = "0.1.40"
 tracing-opentelemetry = "0.25.0"

--- a/cala-ledger/src/account/entity.rs
+++ b/cala-ledger/src/account/entity.rs
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn it_builds() {
         let new_account = NewAccount::builder()
-            .id(uuid::Uuid::new_v4())
+            .id(uuid::Uuid::now_v7())
             .code("code")
             .name("name")
             .build()
@@ -355,7 +355,7 @@ mod tests {
     fn accepts_metadata() {
         use serde_json::json;
         let new_account = NewAccount::builder()
-            .id(uuid::Uuid::new_v4())
+            .id(uuid::Uuid::now_v7())
             .code("code")
             .name("name")
             .metadata(json!({"foo": "bar"}))

--- a/cala-ledger/src/lib.rs
+++ b/cala-ledger/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //!     let tx_code = "GENERAL_INCOME";
 //!     let new_template = NewTxTemplate::builder()
-//!         .id(uuid::Uuid::new_v4())
+//!         .id(uuid::Uuid::now_v7())
 //!         .code(tx_code)
 //!         .params(params)
 //!         .transaction(

--- a/cala-ledger/src/transaction/entity.rs
+++ b/cala-ledger/src/transaction/entity.rs
@@ -251,12 +251,12 @@ mod tests {
 
     #[test]
     fn it_builds() {
-        let id = uuid::Uuid::new_v4();
+        let id = uuid::Uuid::now_v7();
         let new_transaction = NewTransaction::builder()
             .id(id)
             .created_at(chrono::Utc::now())
-            .journal_id(uuid::Uuid::new_v4())
-            .tx_template_id(uuid::Uuid::new_v4())
+            .journal_id(uuid::Uuid::now_v7())
+            .tx_template_id(uuid::Uuid::now_v7())
             .entry_ids(vec![EntryId::new()])
             .effective(chrono::NaiveDate::default())
             .build()
@@ -275,10 +275,10 @@ mod tests {
     fn accepts_metadata() {
         use serde_json::json;
         let new_transaction = NewTransaction::builder()
-            .id(uuid::Uuid::new_v4())
+            .id(uuid::Uuid::now_v7())
             .created_at(chrono::Utc::now())
-            .journal_id(uuid::Uuid::new_v4())
-            .tx_template_id(uuid::Uuid::new_v4())
+            .journal_id(uuid::Uuid::now_v7())
+            .tx_template_id(uuid::Uuid::now_v7())
             .effective(chrono::NaiveDate::default())
             .metadata(json!({"foo": "bar"}))
             .entry_ids(vec![EntryId::new()])

--- a/cala-ledger/src/tx_template/entity.rs
+++ b/cala-ledger/src/tx_template/entity.rs
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn it_builds() {
-        let journal_id = Uuid::new_v4();
+        let journal_id = Uuid::now_v7();
         let entries = vec![NewTxTemplateEntry::builder()
             .entry_type("'TEST_DR'")
             .account_id("param.recipient")

--- a/cala-ledger/tests/helpers.rs
+++ b/cala-ledger/tests/helpers.rs
@@ -32,14 +32,14 @@ pub fn test_journal_with_effective_balances() -> NewJournal {
 pub fn test_accounts() -> (NewAccount, NewAccount) {
     let code = Alphanumeric.sample_string(&mut rand::rng(), 32);
     let sender_account = NewAccount::builder()
-        .id(uuid::Uuid::new_v4())
+        .id(uuid::Uuid::now_v7())
         .name(format!("Test Sender Account {code}"))
         .code(code)
         .build()
         .unwrap();
     let code = Alphanumeric.sample_string(&mut rand::rng(), 32);
     let recipient_account = NewAccount::builder()
-        .id(uuid::Uuid::new_v4())
+        .id(uuid::Uuid::now_v7())
         .name(format!("Test Recipient Account {code}"))
         .code(code)
         .build()
@@ -129,7 +129,7 @@ pub fn currency_conversion_template(code: &str) -> NewTxTemplate {
             .unwrap(),
     ];
     NewTxTemplate::builder()
-        .id(uuid::Uuid::new_v4())
+        .id(uuid::Uuid::now_v7())
         .code(code)
         .params(params)
         .transaction(
@@ -213,7 +213,7 @@ pub fn velocity_template(code: &str) -> NewTxTemplate {
             .unwrap(),
     ];
     NewTxTemplate::builder()
-        .id(uuid::Uuid::new_v4())
+        .id(uuid::Uuid::now_v7())
         .code(code)
         .params(params)
         .transaction(


### PR DESCRIPTION
https://docs.rs/uuid/1.17.0/uuid/#which-uuid-version-should-i-use

```
If you want to use UUIDs as database keys or need to sort them then consider version 7 (v7) UUIDs.
```

note: cargo.lock was not updated because it is already using 1.17 https://github.com/GaloyMoney/cala/blob/main/Cargo.lock#L4223

## Security 
apply the same security concerns of mongodb ids but:
- Performance and storage efficiency are more important for a financial ledger
- if there are security concerns, they should be handled by the main service (ex: Lana) at the end this is an internal service/lib that is not exposed directly to final users