### PR TITLE
refactor: clean up velocity `new_snapshot` logic

### DIFF
--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -207,14 +207,8 @@ impl Balances {
                     } else {
                         None
                     };
-
                 let current = current_balances.remove(&(account_id, entry.currency));
-
-                let balance = if let Some(latest) = latest {
-                    Some(latest)
-                } else if let Some(current) = current {
-                    current
-                } else {
+                let Some(balance) = latest.map(Some).or(current) else {
                     continue;
                 };
 

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -471,5 +471,33 @@ mod tests {
 
             assert!(result.is_empty());
         }
+
+        #[test]
+        fn new_snapshots_creates_snapshots_for_mapped_account_sets() {
+            let account_id = AccountId::new();
+            let account_set_id = AccountSetId::new();
+            let currency: Currency = "USD".parse().unwrap();
+
+            let entry = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), None);
+            current_balances.insert((AccountId::from(&account_set_id), currency), None);
+
+            let mut mappings = HashMap::new();
+            mappings.insert(account_id, vec![account_set_id]);
+
+            let entries = vec![entry];
+
+            let result = Balances::new_snapshots(Utc::now(), current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 2);
+        }
     }
 }

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -200,32 +200,30 @@ impl Balances {
                 .map(AccountId::from)
                 .chain(std::iter::once(entry.account_id))
             {
-                let balance = if let Some(latest) =
-                    latest_balances.remove(&(account_id, &entry.currency))
-                {
-                    new_balances.push(latest.clone());
+                let latest =
+                    if let Some(latest) = latest_balances.remove(&(account_id, &entry.currency)) {
+                        new_balances.push(latest.clone());
+                        Some(latest)
+                    } else {
+                        None
+                    };
+
+                let current = current_balances.remove(&(account_id, entry.currency));
+
+                let balance = if let Some(latest) = latest {
                     Some(latest)
-                } else if let Some(current) = current_balances.remove(&(account_id, entry.currency))
-                {
+                } else if let Some(current) = current {
                     current
                 } else {
                     continue;
                 };
 
-                match balance {
-                    Some(balance) => {
-                        latest_balances.insert(
-                            (account_id, &entry.currency),
-                            Snapshots::update_snapshot(time, balance, entry),
-                        );
-                    }
-                    None => {
-                        latest_balances.insert(
-                            (account_id, &entry.currency),
-                            Snapshots::new_snapshot(time, account_id, entry),
-                        );
-                    }
-                }
+                let new_snapshot = match balance {
+                    Some(balance) => Snapshots::update_snapshot(time, balance, entry),
+                    None => Snapshots::new_snapshot(time, account_id, entry),
+                };
+
+                latest_balances.insert((account_id, &entry.currency), new_snapshot);
             }
         }
         new_balances.extend(latest_balances.into_values());

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -274,3 +274,523 @@ impl Balances {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    mod new_snapshots {
+        use super::*;
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        use std::collections::HashMap;
+        
+        use cala_types::{
+            balance::BalanceAmount,
+            entry::EntryValues,
+            primitives::{DebitOrCredit, Layer},
+        };
+        
+        use crate::primitives::{
+            Currency, EntryId, JournalId, TransactionId,
+        };
+
+        fn create_test_entry(
+            units: Decimal,
+            direction: DebitOrCredit,
+            layer: Layer,
+            currency: &str,
+            account_id: AccountId,
+        ) -> EntryValues {
+            EntryValues {
+                id: EntryId::new(),
+                version: 1,
+                transaction_id: TransactionId::new(),
+                journal_id: JournalId::new(),
+                account_id,
+                entry_type: "TEST_ENTRY".to_string(),
+                sequence: 1,
+                layer,
+                currency: currency.parse().unwrap(),
+                direction,
+                units,
+                description: None,
+                metadata: None,
+            }
+        }
+
+        fn create_test_balance_snapshot(
+            account_id: AccountId,
+            journal_id: JournalId,
+            currency: Currency,
+            version: u32,
+        ) -> BalanceSnapshot {
+            let time = Utc::now();
+            let entry_id = EntryId::new();
+            BalanceSnapshot {
+                journal_id,
+                account_id,
+                entry_id,
+                currency,
+                settled: BalanceAmount {
+                    dr_balance: Decimal::ZERO,
+                    cr_balance: Decimal::ZERO,
+                    entry_id,
+                    modified_at: time,
+                },
+                pending: BalanceAmount {
+                    dr_balance: Decimal::ZERO,
+                    cr_balance: Decimal::ZERO,
+                    entry_id,
+                    modified_at: time,
+                },
+                encumbrance: BalanceAmount {
+                    dr_balance: Decimal::ZERO,
+                    cr_balance: Decimal::ZERO,
+                    entry_id,
+                    modified_at: time,
+                },
+                version,
+                modified_at: time,
+                created_at: time,
+            }
+        }
+
+        #[test]
+        fn new_snapshots_empty_entries_returns_empty() {
+            let time = Utc::now();
+            let current_balances = HashMap::new();
+            let entries = vec![];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn new_snapshots_single_entry_no_existing_balance() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let currency: Currency = "USD".parse().unwrap();
+            let entry = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), None);
+
+            let entries = vec![entry];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 1);
+            let snapshot = &result[0];
+            assert_eq!(snapshot.account_id, account_id);
+            assert_eq!(snapshot.currency, currency);
+            assert_eq!(snapshot.version, 1);
+            assert_eq!(snapshot.settled.dr_balance, Decimal::from(100));
+            assert_eq!(snapshot.settled.cr_balance, Decimal::ZERO);
+        }
+
+        #[test]
+        fn new_snapshots_single_entry_with_existing_balance() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let journal_id = JournalId::new();
+            let currency: Currency = "USD".parse().unwrap();
+            
+            let mut existing_balance = create_test_balance_snapshot(account_id, journal_id, currency, 5);
+            existing_balance.settled.dr_balance = Decimal::from(200);
+            existing_balance.settled.cr_balance = Decimal::from(50);
+
+            let entry = create_test_entry(
+                Decimal::from(75),
+                DebitOrCredit::Credit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), Some(existing_balance));
+
+            let entries = vec![entry];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 1);
+            let snapshot = &result[0];
+            assert_eq!(snapshot.version, 6); // Previous was 5
+            assert_eq!(snapshot.settled.dr_balance, Decimal::from(200)); // Unchanged
+            assert_eq!(snapshot.settled.cr_balance, Decimal::from(125)); // 50 + 75
+        }
+
+        #[test]
+        fn new_snapshots_multiple_entries_same_account() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let currency: Currency = "USD".parse().unwrap();
+
+            let entry1 = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+            let entry2 = create_test_entry(
+                Decimal::from(50),
+                DebitOrCredit::Credit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), None);
+
+            let entries = vec![entry1, entry2];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 2);
+            
+            // First balance after first entry
+            assert_eq!(result[0].version, 1);
+            assert_eq!(result[0].settled.dr_balance, Decimal::from(100));
+            assert_eq!(result[0].settled.cr_balance, Decimal::ZERO);
+            
+            // Second balance after second entry
+            assert_eq!(result[1].version, 2);
+            assert_eq!(result[1].settled.dr_balance, Decimal::from(100));
+            assert_eq!(result[1].settled.cr_balance, Decimal::from(50));
+        }
+
+        #[test]
+        fn new_snapshots_multiple_accounts() {
+            let time = Utc::now();
+            let account1 = AccountId::new();
+            let account2 = AccountId::new();
+            let currency: Currency = "USD".parse().unwrap();
+
+            let entry1 = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account1,
+            );
+            let entry2 = create_test_entry(
+                Decimal::from(200),
+                DebitOrCredit::Credit,
+                Layer::Pending,
+                "USD",
+                account2,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account1, currency), None);
+            current_balances.insert((account2, currency), None);
+
+            let entries = vec![entry1, entry2];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 2);
+            
+            // Find snapshots for each account
+            let account1_snapshot = result.iter().find(|s| s.account_id == account1).unwrap();
+            assert_eq!(account1_snapshot.settled.dr_balance, Decimal::from(100));
+            assert_eq!(account1_snapshot.settled.cr_balance, Decimal::ZERO);
+            assert_eq!(account1_snapshot.pending.dr_balance, Decimal::ZERO);
+            assert_eq!(account1_snapshot.pending.cr_balance, Decimal::ZERO);
+
+            let account2_snapshot = result.iter().find(|s| s.account_id == account2).unwrap();
+            assert_eq!(account2_snapshot.settled.dr_balance, Decimal::ZERO);
+            assert_eq!(account2_snapshot.settled.cr_balance, Decimal::ZERO);
+            assert_eq!(account2_snapshot.pending.dr_balance, Decimal::ZERO);
+            assert_eq!(account2_snapshot.pending.cr_balance, Decimal::from(200));
+        }
+
+        #[test]
+        fn new_snapshots_different_currencies() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let usd: Currency = "USD".parse().unwrap();
+            let eur: Currency = "EUR".parse().unwrap();
+
+            let entry1 = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+            let entry2 = create_test_entry(
+                Decimal::from(200),
+                DebitOrCredit::Credit,
+                Layer::Settled,
+                "EUR",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, usd), None);
+            current_balances.insert((account_id, eur), None);
+
+            let entries = vec![entry1, entry2];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 2);
+            
+            let usd_snapshot = result.iter().find(|s| s.currency == usd).unwrap();
+            assert_eq!(usd_snapshot.settled.dr_balance, Decimal::from(100));
+            assert_eq!(usd_snapshot.settled.cr_balance, Decimal::ZERO);
+
+            let eur_snapshot = result.iter().find(|s| s.currency == eur).unwrap();
+            assert_eq!(eur_snapshot.settled.dr_balance, Decimal::ZERO);
+            assert_eq!(eur_snapshot.settled.cr_balance, Decimal::from(200));
+        }
+
+        #[test]
+        fn new_snapshots_with_account_set_mappings() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let account_set_id1 = AccountSetId::new();
+            let account_set_id2 = AccountSetId::new();
+            let currency: Currency = "USD".parse().unwrap();
+
+            let entry = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), None);
+            current_balances.insert((AccountId::from(&account_set_id1), currency), None);
+            current_balances.insert((AccountId::from(&account_set_id2), currency), None);
+
+            let entries = vec![entry];
+            let mut mappings = HashMap::new();
+            mappings.insert(account_id, vec![account_set_id1, account_set_id2]);
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 3);
+            
+            // All balances should have the same debit amount
+            for snapshot in &result {
+                assert_eq!(snapshot.settled.dr_balance, Decimal::from(100));
+                assert_eq!(snapshot.settled.cr_balance, Decimal::ZERO);
+                assert_eq!(snapshot.version, 1);
+            }
+        }
+
+        #[test]
+        fn new_snapshots_different_layers() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let currency: Currency = "USD".parse().unwrap();
+
+            let entry1 = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+            let entry2 = create_test_entry(
+                Decimal::from(50),
+                DebitOrCredit::Credit,
+                Layer::Pending,
+                "USD",
+                account_id,
+            );
+            let entry3 = create_test_entry(
+                Decimal::from(25),
+                DebitOrCredit::Debit,
+                Layer::Encumbrance,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), None);
+
+            let entries = vec![entry1, entry2, entry3];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 3);
+            
+            // Final snapshot should have all layers updated
+            let final_snapshot = &result[2];
+            assert_eq!(final_snapshot.version, 3);
+            assert_eq!(final_snapshot.settled.dr_balance, Decimal::from(100));
+            assert_eq!(final_snapshot.settled.cr_balance, Decimal::ZERO);
+            assert_eq!(final_snapshot.pending.dr_balance, Decimal::ZERO);
+            assert_eq!(final_snapshot.pending.cr_balance, Decimal::from(50));
+            assert_eq!(final_snapshot.encumbrance.dr_balance, Decimal::from(25));
+            assert_eq!(final_snapshot.encumbrance.cr_balance, Decimal::ZERO);
+        }
+
+        #[test]
+        fn new_snapshots_preserves_other_layer_balances() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+            let journal_id = JournalId::new();
+            let currency: Currency = "USD".parse().unwrap();
+            
+            let mut existing_balance = create_test_balance_snapshot(account_id, journal_id, currency, 2);
+            existing_balance.settled.dr_balance = Decimal::from(100);
+            existing_balance.pending.cr_balance = Decimal::from(50);
+            existing_balance.encumbrance.dr_balance = Decimal::from(25);
+
+            let entry = create_test_entry(
+                Decimal::from(30),
+                DebitOrCredit::Credit,
+                Layer::Pending,
+                "USD",
+                account_id,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), Some(existing_balance));
+
+            let entries = vec![entry];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 1);
+            let snapshot = &result[0];
+            assert_eq!(snapshot.version, 3);
+            // Settled layer unchanged
+            assert_eq!(snapshot.settled.dr_balance, Decimal::from(100));
+            assert_eq!(snapshot.settled.cr_balance, Decimal::ZERO);
+            // Pending layer updated
+            assert_eq!(snapshot.pending.dr_balance, Decimal::ZERO);
+            assert_eq!(snapshot.pending.cr_balance, Decimal::from(80)); // 50 + 30
+            // Encumbrance layer unchanged
+            assert_eq!(snapshot.encumbrance.dr_balance, Decimal::from(25));
+            assert_eq!(snapshot.encumbrance.cr_balance, Decimal::ZERO);
+        }
+
+        #[test]
+        fn new_snapshots_missing_balance_in_current_balances_skipped() {
+            let time = Utc::now();
+            let account_id = AccountId::new();
+
+            let entry = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+
+            let current_balances = HashMap::new();
+            // Note: NOT adding the balance to current_balances
+
+            let entries = vec![entry];
+            let mappings = HashMap::new();
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            assert!(result.is_empty());
+        }
+
+        #[test]
+        fn new_snapshots_complex_scenario_multiple_accounts_and_mappings() {
+            let time = Utc::now();
+            let account1 = AccountId::new();
+            let account2 = AccountId::new();
+            let account_set1 = AccountSetId::new();
+            let account_set2 = AccountSetId::new();
+            let usd: Currency = "USD".parse().unwrap();
+            let eur: Currency = "EUR".parse().unwrap();
+
+            let entry1 = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account1,
+            );
+            let entry2 = create_test_entry(
+                Decimal::from(200),
+                DebitOrCredit::Credit,
+                Layer::Pending,
+                "EUR",
+                account2,
+            );
+            let entry3 = create_test_entry(
+                Decimal::from(50),
+                DebitOrCredit::Debit,
+                Layer::Encumbrance,
+                "USD",
+                account1,
+            );
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account1, usd), None);
+            current_balances.insert((account2, eur), None);
+            current_balances.insert((AccountId::from(&account_set1), usd), None);
+            current_balances.insert((AccountId::from(&account_set2), usd), None);
+
+            let entries = vec![entry1, entry2, entry3];
+            let mut mappings = HashMap::new();
+            mappings.insert(account1, vec![account_set1, account_set2]);
+
+            let result = Balances::new_snapshots(time, current_balances, &entries, &mappings);
+
+            // Should have:
+            // - 2 snapshots for account1 (settled + encumbrance entries)
+            // - 1 snapshot for account2 (pending entry)
+            // - 2 snapshots for account_set1 (mapped from account1, both entries)
+            // - 2 snapshots for account_set2 (mapped from account1, both entries)
+            assert_eq!(result.len(), 7);
+
+            // Check account1 final state
+            let account1_snapshots: Vec<_> = result.iter()
+                .filter(|s| s.account_id == account1 && s.currency == usd)
+                .collect();
+            assert_eq!(account1_snapshots.len(), 2);
+            let final_account1 = account1_snapshots.last().unwrap();
+            assert_eq!(final_account1.settled.dr_balance, Decimal::from(100));
+            assert_eq!(final_account1.encumbrance.dr_balance, Decimal::from(50));
+
+            // Check account2 state
+            let account2_snapshot = result.iter()
+                .find(|s| s.account_id == account2)
+                .unwrap();
+            assert_eq!(account2_snapshot.pending.cr_balance, Decimal::from(200));
+
+            // Check account sets have same balances as account1
+            for account_set_id in [account_set1, account_set2] {
+                let set_snapshots: Vec<_> = result.iter()
+                    .filter(|s| s.account_id == AccountId::from(&account_set_id))
+                    .collect();
+                assert_eq!(set_snapshots.len(), 2);
+                let final_set = set_snapshots.last().unwrap();
+                assert_eq!(final_set.settled.dr_balance, Decimal::from(100));
+                assert_eq!(final_set.encumbrance.dr_balance, Decimal::from(50));
+            }
+        }
+    }
+}

--- a/cala-ledger/src/velocity/balance/mod.rs
+++ b/cala-ledger/src/velocity/balance/mod.rs
@@ -339,12 +339,14 @@ mod tests {
         fn new_snapshots_single_entry_no_previous_balance() {
             let time = Utc::now();
             let key = create_test_key();
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(100),
                 DebitOrCredit::Debit,
                 Layer::Settled,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(1000),
@@ -353,7 +355,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -380,12 +382,14 @@ mod tests {
         fn new_snapshots_single_entry_with_existing_balance() {
             let time = Utc::now();
             let key = create_test_key();
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(50),
                 DebitOrCredit::Credit,
                 Layer::Pending,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(1000),
@@ -394,7 +398,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let existing_balance =
@@ -424,7 +428,6 @@ mod tests {
         fn new_snapshots_multiple_entries_same_key() {
             let time = Utc::now();
             let key = create_test_key();
-            let account_id = AccountId::new();
             let mut entry1 = create_test_entry(
                 Decimal::from(100),
                 DebitOrCredit::Debit,
@@ -437,9 +440,9 @@ mod tests {
                 Layer::Settled,
                 "USD",
             );
-            // Ensure both entries use the same account ID
-            entry1.account_id = account_id;
-            entry2.account_id = account_id;
+            // Ensure both entries use the same account ID as the key
+            entry1.account_id = key.account_id;
+            entry2.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(1000),
@@ -448,7 +451,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -490,18 +493,21 @@ mod tests {
                 limit_id: VelocityLimitId::new(),
             };
 
-            let entry1 = create_test_entry(
+            let mut entry1 = create_test_entry(
                 Decimal::from(100),
                 DebitOrCredit::Debit,
                 Layer::Settled,
                 "USD",
             );
-            let entry2 = create_test_entry(
+            let mut entry2 = create_test_entry(
                 Decimal::from(200),
                 DebitOrCredit::Credit,
                 Layer::Pending,
                 "EUR",
             );
+            // Ensure entries use the same account_id as their respective keys
+            entry1.account_id = key1.account_id;
+            entry2.account_id = key2.account_id;
             let limit1 = create_test_limit(
                 key1.limit_id,
                 Decimal::from(1000),
@@ -516,8 +522,8 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account1 = create_test_account(entry1.account_id);
-            let account2 = create_test_account(entry2.account_id);
+            let account1 = create_test_account(key1.account_id);
+            let account2 = create_test_account(key2.account_id);
             let context = EvalContext::new(&transaction, [&account1, &account2].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -542,12 +548,14 @@ mod tests {
             let time = Utc::now();
             let key = create_test_key();
             // Entry tries to debit 500, but limit only allows 100
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(500),
                 DebitOrCredit::Debit,
                 Layer::Settled,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(100),
@@ -556,7 +564,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -586,12 +594,14 @@ mod tests {
             let key = create_test_key();
 
             // Entry on Settled layer, limit enforces Pending layer (which includes Settled)
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(100),
                 DebitOrCredit::Debit,
                 Layer::Settled,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(150),
@@ -600,7 +610,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -624,12 +634,14 @@ mod tests {
         fn new_snapshots_missing_key_in_current_balances() {
             let time = Utc::now();
             let key = create_test_key();
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(100),
                 DebitOrCredit::Debit,
                 Layer::Settled,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(1000),
@@ -638,7 +650,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             // Don't add the key to current_balances
@@ -655,12 +667,14 @@ mod tests {
         fn new_snapshots_multiple_limits_per_entry() {
             let time = Utc::now();
             let key = create_test_key();
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(100),
                 DebitOrCredit::Debit,
                 Layer::Settled,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit1 = create_test_limit(
                 VelocityLimitId::new(),
                 Decimal::from(200),
@@ -675,7 +689,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -704,12 +718,14 @@ mod tests {
             let key = create_test_key();
 
             // Test credit enforcement
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(300),
                 DebitOrCredit::Credit,
                 Layer::Pending,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(500),
@@ -718,7 +734,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();
@@ -741,12 +757,14 @@ mod tests {
             let time = Utc::now();
             let key = create_test_key();
 
-            let entry = create_test_entry(
+            let mut entry = create_test_entry(
                 Decimal::from(75),
                 DebitOrCredit::Debit,
                 Layer::Encumbrance,
                 "USD",
             );
+            // Ensure entry uses the same account_id as the key
+            entry.account_id = key.account_id;
             let limit = create_test_limit(
                 key.limit_id,
                 Decimal::from(100),
@@ -755,7 +773,7 @@ mod tests {
             );
 
             let transaction = create_test_transaction();
-            let account = create_test_account(entry.account_id);
+            let account = create_test_account(key.account_id);
             let context = EvalContext::new(&transaction, [&account].into_iter());
 
             let mut current_balances = HashMap::new();

--- a/cala-ledger/src/velocity/balance/mod.rs
+++ b/cala-ledger/src/velocity/balance/mod.rs
@@ -133,9 +133,9 @@ impl VelocityBalances {
             let mut new_balances = Vec::new();
 
             for (limit, entry) in entries {
-                let new_balance = match &latest_balance {
+                let new_balance = match latest_balance.take() {
                     Some(balance) => {
-                        crate::balance::Snapshots::update_snapshot(time, balance.clone(), entry)
+                        crate::balance::Snapshots::update_snapshot(time, balance, entry)
                     }
                     None => crate::balance::Snapshots::new_snapshot(time, entry.account_id, entry),
                 };

--- a/cala-ledger/src/velocity/balance/mod.rs
+++ b/cala-ledger/src/velocity/balance/mod.rs
@@ -126,17 +126,15 @@ impl VelocityBalances {
         let mut res = HashMap::new();
 
         for (key, entries) in entries_to_add.iter() {
-            let mut latest_balance: Option<BalanceSnapshot> = None;
             let mut new_balances = Vec::new();
-
-            let current = current_balances
+            let mut latest_balance = current_balances
                 .remove(key)
                 .expect("entries_to_add key missing in current_balances");
 
             for (limit, entry) in entries {
                 let ctx = context.context_for_entry(key.account_id, entry);
 
-                let balance = match latest_balance.or_else(|| current.clone()) {
+                let balance = match latest_balance {
                     Some(balance) => balance,
                     None => {
                         let new_snapshot =


### PR DESCRIPTION
## Description

A refactor of the `new_snapshots` function to attempt to make the logic clearer, with a new claude-assisted unit test suite for that function