### PR TITLE
chore(cel): add support for 'has()' macro

### DIFF
--- a/cala-cel-parser/src/ast.rs
+++ b/cala-cel-parser/src/ast.rs
@@ -49,6 +49,7 @@ pub enum Expression {
     Unary(UnaryOp, Box<Expression>),
 
     Member(Box<Expression>, Box<Member>),
+    Has(Box<Expression>),
 
     List(Vec<Expression>),
     Map(Vec<(Expression, Expression)>),
@@ -173,5 +174,42 @@ mod tests {
                 Index(Literal(Int(1)).into()).into(),
             ),
         )
+    }
+
+    #[test]
+    fn has_macro() {
+        assert_parse_eq(
+            "has(a.b)",
+            Has(Member(
+                Ident("a".to_string().into()).into(),
+                Attribute("b".to_string().into()).into(),
+            )
+            .into()),
+        );
+        assert_parse_eq(
+            "has(params.field)",
+            Has(Member(
+                Ident("params".to_string().into()).into(),
+                Attribute("field".to_string().into()).into(),
+            )
+            .into()),
+        );
+        // Test deeply nested has expression
+        assert_parse_eq(
+            "has(a.b.c.d)",
+            Has(Member(
+                Member(
+                    Member(
+                        Ident("a".to_string().into()).into(),
+                        Attribute("b".to_string().into()).into(),
+                    )
+                    .into(),
+                    Attribute("c".to_string().into()).into(),
+                )
+                .into(),
+                Attribute("d".to_string().into()).into(),
+            )
+            .into()),
+        );
     }
 }

--- a/cala-cel-parser/src/cel.lalrpop
+++ b/cala-cel-parser/src/cel.lalrpop
@@ -48,6 +48,7 @@ Primary: Expression = {
             let inner = Expression::Ident(identifier);
             Expression::Member(Box::new(inner), Box::new(Member::FunctionCall(arguments)))
     },
+    "has" "(" <expr:Expression> ")" => Expression::Has(Box::new(expr)),
     "(" <Expression> ")",
     "[" <members:CommaSeparated<Expression>> "]" => Expression::List(<>),
     "{" <fields:CommaSeparated<MapInits>> "}" => Expression::Map(<>),


### PR DESCRIPTION
This adds support for the `has` macro to check if a key exists on a `Map`.