### PR TITLE
fix: add procps to nix pkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
           podman
           podman-compose
           curl
+          procps
         ]
         ++ lib.optionals pkgs.stdenv.isDarwin [
           darwin.apple_sdk.frameworks.SystemConfiguration


### PR DESCRIPTION
We have a failing `bats` test because it uses command `ps`, which is not currently available in the CI image.  

This PR adds `procps` to add the dependency.