### PR TITLE
build: add podman compatibility for local dev and CI

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -18,5 +18,7 @@ jobs:
 
       - uses: actions/checkout@v3
       - name: Run e2e tests
+        env:
+          ENGINE_DEFAULT: podman
         run: nix run .#bats
 

--- a/.github/workflows/perf-report.yml
+++ b/.github/workflows/perf-report.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Generate performance data
         id: perf
+        env:
+          ENGINE_DEFAULT: podman
         run: |
           # Run the performance report script and output to file
           nix develop -c ./bin/perf-report.sh perf-report.md

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,5 +17,7 @@ jobs:
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
       - uses: actions/checkout@v3
       - name: Run integration tests
-        run: nix develop -c make start-deps setup-db test-in-ci
+        env:
+          ENGINE_DEFAULT: podman
+        run: nix develop -c bash -c "make podman-service-start start-deps setup-db test-in-ci"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 next-watch:
 	cargo watch -s 'cargo nextest run'
 
+podman-service-start:
+	@./dev/bin/podman-service-start.sh
+
 clean-deps:
 	./dev/bin/clean-deps.sh
 

--- a/dev/bin/podman-get-socket.sh
+++ b/dev/bin/podman-get-socket.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the correct podman socket to use
+# On macOS, podman often uses SSH connections to a VM, so we shouldn't set DOCKER_HOST
+
+# Check if we're on macOS and podman is using SSH connections
+if [[ "$(uname)" == "Darwin" ]]; then
+    # Check if podman is using SSH connections (typical for macOS)
+    if podman system connection list 2>/dev/null | grep -q "ssh://"; then
+        # On macOS with SSH connections, don't set DOCKER_HOST
+        # Return special value to indicate no socket should be used
+        echo "NO_SOCKET"
+        exit 0
+    fi
+fi
+
+# For Linux or other cases, use Unix sockets
+SYSTEM_SOCKET="/run/podman/podman.sock"
+USER_SOCKET="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+
+if [ -S "$SYSTEM_SOCKET" ] && CONTAINER_HOST="unix://$SYSTEM_SOCKET" timeout 3s podman version >/dev/null 2>&1; then
+    echo "unix://$SYSTEM_SOCKET"
+elif [ -S "$USER_SOCKET" ] && CONTAINER_HOST="unix://$USER_SOCKET" timeout 3s podman version >/dev/null 2>&1; then
+    echo "unix://$USER_SOCKET"
+else
+    # Default fallback (will likely fail, but provides a reasonable default)
+    echo "unix://$SYSTEM_SOCKET"
+fi

--- a/dev/bin/podman-service-start.sh
+++ b/dev/bin/podman-service-start.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "--- Configuring Podman ---"
+
+if [ "$(uname)" = "Linux" ]; then
+    echo "Applying Linux-specific podman configuration..."
+    mkdir -p /etc/containers
+    echo '{ "default": [{"type": "insecureAcceptAnything"}]}' > /etc/containers/policy.json || true
+    echo 'unqualified-search-registries = ["docker.io"]' > /etc/containers/registries.conf || true
+    grep -q "host.containers.internal" /etc/hosts || echo "127.0.0.1 host.containers.internal" >> /etc/hosts || true
+else
+    echo "Non-Linux system detected, skipping container configuration"
+fi
+
+echo "--- Podman configuration done ---"
+echo "--- Starting Podman service ---"
+
+if [ "$(uname)" = "Linux" ]; then
+    echo "Checking if podman socket is working..."
+
+    # Try system socket first, then user socket
+    SYSTEM_SOCKET="/run/podman/podman.sock"
+    USER_SOCKET="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/podman/podman.sock"
+
+    if [ -S "$SYSTEM_SOCKET" ] && CONTAINER_HOST="unix://$SYSTEM_SOCKET" timeout 3s podman version >/dev/null 2>&1; then
+        echo "System podman socket already working!"
+    elif [ -S "$USER_SOCKET" ] && CONTAINER_HOST="unix://$USER_SOCKET" timeout 3s podman version >/dev/null 2>&1; then
+        echo "User podman socket already working!"
+    else
+        echo "Starting podman system service..."
+
+        # Try to create system socket directory with sudo, fall back to user socket
+        if sudo mkdir -p /run/podman 2>/dev/null; then
+            echo "Using system socket at $SYSTEM_SOCKET"
+            podman system service --time=0 "unix://$SYSTEM_SOCKET" &
+            SOCKET_PATH="$SYSTEM_SOCKET"
+        else
+            echo "Cannot create system socket, using user socket at $USER_SOCKET"
+            mkdir -p "$(dirname "$USER_SOCKET")"
+            podman system service --time=0 "unix://$USER_SOCKET" &
+            SOCKET_PATH="$USER_SOCKET"
+        fi
+
+        echo "Waiting for socket to be created..."
+        for i in 1 2 3 4 5; do
+            if [ -S "$SOCKET_PATH" ] && CONTAINER_HOST="unix://$SOCKET_PATH" timeout 3s podman version >/dev/null 2>&1; then
+                echo "Socket created and working!"
+                break
+            fi
+            echo "Waiting... ($i/5)"
+            sleep 2
+        done
+    fi
+fi
+
+echo "--- Podman service ready ---"


### PR DESCRIPTION
## Summary
- Add `dev/bin/podman-get-socket.sh` — detects correct podman socket (macOS SSH vs Linux unix)
- Add `dev/bin/podman-service-start.sh` — starts podman service on Linux with socket setup
- Add `podman-service-start` Makefile target
- Update CI workflows (integration, e2e, perf-report) to set `ENGINE_DEFAULT=podman`

Matches the podman compatibility pattern used in lana-bank.

### Local setup
Add to your `.env` (loaded automatically via direnv `dotenv`):
```
ENGINE_DEFAULT=podman
```

## Test plan
- [ ] `ENGINE_DEFAULT=podman make start-deps setup-db` works locally
- [ ] CI passes with podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the container engine and startup path used by CI and local dependency orchestration; failures are likely to manifest as CI infra/test flakiness rather than product/runtime behavior.
> 
> **Overview**
> CI jobs for e2e (`bats.yml`), integration (`test-integration.yml`), and perf report (`perf-report.yml`) now run with `ENGINE_DEFAULT=podman`, and integration CI additionally starts a Podman service before bringing up dependencies.
> 
> Adds a `podman-service-start` Make target plus new `dev/bin/podman-service-start.sh` and `dev/bin/podman-get-socket.sh` helpers to configure Linux Podman defaults and ensure a working Podman socket (with macOS SSH-connection detection).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7376094da6bc0151c1848fd76f875b53c2a209ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->