### PR TITLE
perf: add missing indexes on member_account_id and velocity account_id

### DIFF
--- a/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
+++ b/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
@@ -72,6 +72,7 @@ CREATE TABLE cala_account_set_member_accounts (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE(account_set_id, member_account_id)
 );
+CREATE INDEX idx_cala_account_set_member_accounts_member_id ON cala_account_set_member_accounts (member_account_id);
 
 CREATE TABLE cala_account_set_member_account_sets (
   account_set_id UUID NOT NULL REFERENCES cala_account_sets(id),
@@ -233,6 +234,7 @@ CREATE TABLE cala_velocity_account_controls (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE(account_id, velocity_control_id)
 );
+CREATE INDEX idx_cala_velocity_account_controls_account_id ON cala_velocity_account_controls (account_id);
 
 CREATE TABLE cala_velocity_current_balances (
   journal_id UUID NOT NULL,


### PR DESCRIPTION
## Summary

Add two missing database indexes that are hit on every `post_transaction_in_op` call:

- `idx_cala_account_set_member_accounts_member_id` on `cala_account_set_member_accounts(member_account_id)`
- `idx_cala_velocity_account_controls_account_id` on `cala_velocity_account_controls(account_id)`

## Why these matter

Two queries run on **every single cala transaction post**:

**1. `fetch_mappings_in_op`** — finds which account sets each account belongs to:
```sql
SELECT m.account_set_id, m.member_account_id
FROM cala_account_set_member_accounts m
JOIN cala_account_sets s ON m.account_set_id = s.id
WHERE m.member_account_id = ANY($2)
```

**2. `find_for_enforcement`** — finds velocity controls for accounts:
```sql
SELECT values, velocity_context_values
FROM cala_velocity_account_controls v
JOIN cala_accounts a ON v.account_id = a.id
WHERE account_id = ANY($1)
```

Without indexes, PostgreSQL does a **sequential scan** of the entire table for each query. With 1000 loans in lana-bank, `cala_account_set_member_accounts` has ~14,000 rows (14 accounts per loan). Every transaction post — including every interest accrual — scans all 14,000 rows to find the ~2-3 matching ones.

With the index, it's an index lookup — O(log n) instead of O(n). The benefit grows with data volume. At 10,000 loans with daily accruals, you'd have 140,000+ rows being scanned on every single transaction post.

## Benchmark (lana-bank, 100 loans parallel=10)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| 100 loan creation | 39.4s | 35.3s | -10.4% |
| 10 days interest accrual | 28.9s | 26.6s | -8.0% |

## Test plan
- [ ] Existing cala tests pass
- [ ] lana-bank e2e tests pass with local cala pointed at this branch

---

*Found via autonomous performance investigation using [autoresearch](https://github.com/anthropics/claude-code) on the lana-bank loan workflow*

🤖 Generated with [Claude Code](https://claude.com/claude-code)