### PR TITLE
feat(balance): publish effective balance events to outbox

### DIFF
--- a/cala-ledger-core-types/src/balance.rs
+++ b/cala-ledger-core-types/src/balance.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
@@ -51,4 +51,20 @@ impl BalanceAmount {
             modified_at,
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EffectiveBalanceSnapshot {
+    pub journal_id: JournalId,
+    pub account_id: AccountId,
+    pub currency: Currency,
+    pub effective: NaiveDate,
+    pub version: u32,
+    pub all_time_version: u32,
+    pub created_at: DateTime<Utc>,
+    pub modified_at: DateTime<Utc>,
+    pub entry_id: EntryId,
+    pub settled: BalanceAmount,
+    pub pending: BalanceAmount,
+    pub encumbrance: BalanceAmount,
 }

--- a/cala-ledger-core-types/src/outbox.rs
+++ b/cala-ledger-core-types/src/outbox.rs
@@ -58,4 +58,10 @@ pub enum OutboxEventPayload {
     BalanceUpdated {
         balance: BalanceSnapshot,
     },
+    EffectiveBalanceCreated {
+        balance: EffectiveBalanceSnapshot,
+    },
+    EffectiveBalanceUpdated {
+        balance: EffectiveBalanceSnapshot,
+    },
 }

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -7,12 +7,14 @@ use std::collections::{HashMap, HashSet};
 use tracing::instrument;
 
 use cala_types::{
-    balance::{BalanceAmount, BalanceSnapshot},
+    balance::{BalanceAmount, BalanceSnapshot, EffectiveBalanceSnapshot},
     entry::EntryValues,
     primitives::*,
 };
 
-use crate::primitives::JournalId;
+use crate::{outbox::OutboxPublisher, primitives::JournalId};
+
+use data::EffectiveBalanceData;
 
 use super::{account_balance::*, error::BalanceError, snapshot::UNASSIGNED_ENTRY_ID};
 
@@ -24,9 +26,9 @@ pub struct EffectiveBalances {
     _pool: PgPool,
 }
 impl EffectiveBalances {
-    pub(crate) fn new(pool: &PgPool) -> Self {
+    pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
         Self {
-            repo: EffectiveBalanceRepo::new(pool),
+            repo: EffectiveBalanceRepo::new(pool, publisher),
             _pool: pool.clone(),
         }
     }
@@ -343,10 +345,38 @@ impl EffectiveBalances {
             data.re_calculate_snapshots(created_at);
         }
 
+        let new_balances = Self::new_effective_snapshots(journal_id, all_data);
         self.repo
-            .insert_new_snapshots(op, journal_id, all_data)
+            .insert_new_snapshots(op, journal_id, new_balances)
             .await?;
 
         Ok(())
+    }
+
+    fn new_effective_snapshots(
+        journal_id: JournalId,
+        data: HashMap<(AccountId, Currency), EffectiveBalanceData<'_>>,
+    ) -> Vec<EffectiveBalanceSnapshot> {
+        data.into_values()
+            .flat_map(|d| d.into_updates())
+            .map(
+                |(account_id, currency, effective, snapshot, all_time_version)| {
+                    EffectiveBalanceSnapshot {
+                        journal_id,
+                        account_id,
+                        currency,
+                        effective,
+                        version: snapshot.version,
+                        all_time_version,
+                        created_at: snapshot.created_at,
+                        modified_at: snapshot.modified_at,
+                        entry_id: snapshot.entry_id,
+                        settled: snapshot.settled,
+                        pending: snapshot.pending,
+                        encumbrance: snapshot.encumbrance,
+                    }
+                },
+            )
+            .collect()
     }
 }

--- a/cala-ledger/src/balance/effective/repo.rs
+++ b/cala-ledger/src/balance/effective/repo.rs
@@ -3,10 +3,11 @@ use sqlx::PgPool;
 use std::collections::HashMap;
 use tracing::instrument;
 
-use crate::balance::{account_balance::AccountBalance, error::BalanceError};
+use crate::{balance::{account_balance::AccountBalance, error::BalanceError}, outbox::OutboxPublisher};
 use cala_types::{
-    balance::BalanceSnapshot,
-    primitives::{AccountId, AccountSetId, BalanceId, Currency, DebitOrCredit, EntryId, JournalId},
+    balance::{BalanceSnapshot, EffectiveBalanceSnapshot},
+    outbox::OutboxEventPayload,
+    primitives::{AccountId, AccountSetId,BalanceId, Currency, DebitOrCredit, EntryId, JournalId},
 };
 
 use super::data::*;
@@ -23,11 +24,12 @@ pub(super) struct LatestBeforeEntry {
 #[derive(Debug, Clone)]
 pub(super) struct EffectiveBalanceRepo {
     pool: PgPool,
+    publisher: OutboxPublisher
 }
 
 impl EffectiveBalanceRepo {
-    pub fn new(pool: &PgPool) -> Self {
-        Self { pool: pool.clone() }
+    pub fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
+        Self { pool: pool.clone(), publisher: publisher.clone() }
     }
 
     pub async fn find(
@@ -720,39 +722,37 @@ impl EffectiveBalanceRepo {
 
     #[instrument(
         name = "cala_ledger.balances.effective.insert_new_snapshots",
-        skip(self, op, data)
+        skip(self, op, new_balances)
     )]
     pub(crate) async fn insert_new_snapshots(
         &self,
         op: &mut impl es_entity::AtomicOperation,
         journal_id: JournalId,
-        data: HashMap<(AccountId, Currency), EffectiveBalanceData<'_>>,
+        new_balances: Vec<EffectiveBalanceSnapshot>,
     ) -> Result<(), BalanceError> {
-        let mut journal_ids = Vec::with_capacity(data.len());
-        let mut account_ids = Vec::with_capacity(data.len());
-        let mut currencies = Vec::with_capacity(data.len());
-        let mut effectives = Vec::with_capacity(data.len());
-        let mut versions = Vec::with_capacity(data.len());
-        let mut all_time_versions = Vec::with_capacity(data.len());
-        let mut entry_ids = Vec::with_capacity(data.len());
-        let mut modified_timestamps = Vec::with_capacity(data.len());
-        let mut created_timestamps = Vec::with_capacity(data.len());
-        let mut values = Vec::with_capacity(data.len());
+        let mut journal_ids = Vec::with_capacity(new_balances.len());
+        let mut account_ids = Vec::with_capacity(new_balances.len());
+        let mut currencies = Vec::with_capacity(new_balances.len());
+        let mut effectives = Vec::with_capacity(new_balances.len());
+        let mut versions = Vec::with_capacity(new_balances.len());
+        let mut all_time_versions = Vec::with_capacity(new_balances.len());
+        let mut entry_ids = Vec::with_capacity(new_balances.len());
+        let mut modified_timestamps = Vec::with_capacity(new_balances.len());
+        let mut created_timestamps = Vec::with_capacity(new_balances.len());
+        let mut values = Vec::with_capacity(new_balances.len());
 
-        for (account_id, currency, effective, snapshot, all_time_version) in
-            data.into_values().flat_map(|d| d.into_updates())
-        {
+        for balance in new_balances.iter() {
             journal_ids.push(journal_id);
-            account_ids.push(account_id);
-            currencies.push(currency.code());
-            effectives.push(effective);
-            versions.push(snapshot.version as i32);
-            all_time_versions.push(all_time_version as i32);
-            entry_ids.push(snapshot.entry_id);
-            modified_timestamps.push(snapshot.modified_at);
-            created_timestamps.push(snapshot.created_at);
+            account_ids.push(balance.account_id);
+            currencies.push(balance.currency.code());
+            effectives.push(balance.effective);
+            versions.push(balance.version as i32);
+            all_time_versions.push(balance.all_time_version as i32);
+            entry_ids.push(balance.entry_id);
+            modified_timestamps.push(balance.modified_at);
+            created_timestamps.push(balance.created_at);
             values.push(
-                serde_json::to_value(snapshot).expect("Failed to serialize balance snapshot"),
+                serde_json::to_value(balance).expect("Failed to serialize balance snapshot"),
             );
         }
 
@@ -787,6 +787,19 @@ impl EffectiveBalanceRepo {
         )
         .execute(op.as_executor())
         .await?;
+
+        self.publisher
+            .publish_all(
+                op,
+                new_balances.into_iter().map(|balance| {
+                    if balance.all_time_version == 1 {
+                        OutboxEventPayload::EffectiveBalanceCreated { balance }
+                    } else {
+                        OutboxEventPayload::EffectiveBalanceUpdated { balance }
+                    }
+                }),
+            )
+            .await?;
 
         Ok(())
     }

--- a/cala-ledger/src/balance/effective/repo.rs
+++ b/cala-ledger/src/balance/effective/repo.rs
@@ -10,7 +10,7 @@ use crate::{
 use cala_types::{
     balance::{BalanceSnapshot, EffectiveBalanceSnapshot},
     outbox::OutboxEventPayload,
-    primitives::{AccountId, AccountSetId,BalanceId, Currency, DebitOrCredit, EntryId, JournalId},
+    primitives::{AccountId, AccountSetId, BalanceId, Currency, DebitOrCredit, EntryId, JournalId},
 };
 
 use super::data::*;

--- a/cala-ledger/src/balance/effective/repo.rs
+++ b/cala-ledger/src/balance/effective/repo.rs
@@ -3,7 +3,10 @@ use sqlx::PgPool;
 use std::collections::HashMap;
 use tracing::instrument;
 
-use crate::{balance::{account_balance::AccountBalance, error::BalanceError}, outbox::OutboxPublisher};
+use crate::{
+    balance::{account_balance::AccountBalance, error::BalanceError},
+    outbox::OutboxPublisher,
+};
 use cala_types::{
     balance::{BalanceSnapshot, EffectiveBalanceSnapshot},
     outbox::OutboxEventPayload,
@@ -24,12 +27,15 @@ pub(super) struct LatestBeforeEntry {
 #[derive(Debug, Clone)]
 pub(super) struct EffectiveBalanceRepo {
     pool: PgPool,
-    publisher: OutboxPublisher
+    publisher: OutboxPublisher,
 }
 
 impl EffectiveBalanceRepo {
     pub fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
-        Self { pool: pool.clone(), publisher: publisher.clone() }
+        Self {
+            pool: pool.clone(),
+            publisher: publisher.clone(),
+        }
     }
 
     pub async fn find(
@@ -751,9 +757,8 @@ impl EffectiveBalanceRepo {
             entry_ids.push(balance.entry_id);
             modified_timestamps.push(balance.modified_at);
             created_timestamps.push(balance.created_at);
-            values.push(
-                serde_json::to_value(balance).expect("Failed to serialize balance snapshot"),
-            );
+            values
+                .push(serde_json::to_value(balance).expect("Failed to serialize balance snapshot"));
         }
 
         sqlx::query!(

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -60,7 +60,7 @@ impl Balances {
     pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher, journals: &Journals) -> Self {
         Self {
             repo: BalanceRepo::new(pool, publisher),
-            effective: EffectiveBalances::new(pool),
+            effective: EffectiveBalances::new(pool, publisher),
             journals: journals.clone(),
             _pool: pool.clone(),
         }


### PR DESCRIPTION
## Summary
- Add `EffectiveBalanceSnapshot` type and `EffectiveBalanceCreated`/`EffectiveBalanceUpdated` outbox event variants
- Thread `OutboxPublisher` through to `EffectiveBalanceRepo`
- Publish events after inserting into `cala_cumulative_effective_balances`, matching the existing `BalanceRepo` pattern
- Refactor `insert_new_snapshots` to accept `Vec<EffectiveBalanceSnapshot>` with a `new_effective_snapshots()` conversion method, consistent with `BalanceRepo::new_snapshots()`

## Why
`cala_cumulative_effective_balances` was the only CALA table (out of 6 used by downstream reports) that didn't publish to the outbox. This closes that gap so a downstream relay can forward these events.

## Test plan
- [x] `cargo check` passes
- [ ] Existing tests pass
- [ ] Verify outbox events are published after effective balance inserts

🤖 Generated with [Claude Code](https://claude.com/claude-code)