### PR TITLE
chore(deps): bump job to 0.6.22, obix to 0.2.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,9 +949,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca19d4f588d8ef9c5edd15949e4d3016ad088be74cabdc150a55798557c612d"
+checksum = "07f523e4cd9b354b57b458aee369eadba8da68fbfb2af636c7a429c7942160d3"
 dependencies = [
  "async-graphql",
  "base64",
@@ -976,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae40a2cf617a4e1a4d41c1c6ffb07b317908176692b33235a4593588f3fcac61"
+checksum = "e48186330c95462026a942f3f1d95beb99e95da0bc4fdcae76a6cf55afee9cae"
 dependencies = [
  "convert_case",
  "darling 0.23.0",
@@ -1637,9 +1637,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.19"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318fa357d6fe3d9820642caa57e940dd8e31ccd8f82b248aeed059e4dcc1cd4b"
+checksum = "1f5984583408d25de1b4a0b4a60d4292bbfc7daf9504ea2b8daad4d266f65400"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a648626fe5b5ea81b57cfc609304f20dbc1dc521bd34eb6e13cca7d2fc78df4"
+checksum = "e962274bd197f8cab9f1efa045fec54a70010b00720ebd13274150d19362fb2a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1937,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.2.25"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4967967f98d84dccfed3a60735e11eca0e8b8e7c7559b84390184b581dc47d05"
+checksum = "f3847e27014116cd3c22b33693571fb4ebe6c4ee46e6687a98b5ffdf4b8867e0"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ cala-tracing = { path = "cala-tracing", version = "0.15.5-dev" }
 cala-ledger = { path = "cala-ledger", version = "0.15.5-dev" }
 
 es-entity = "0.10.34"
-job = { version = "0.6.19", features = ["es-entity"] }
-obix = { version = "0.2.25", default-features = false }
+job = { version = "0.6.22", features = ["es-entity"] }
+obix = { version = "0.2.26", default-features = false }
 
 anyhow = "1.0.99"
 async-graphql = { version = "8.0.0-rc.4", default-features = false, features = ["dataloader", "tracing", "chrono", "tokio"] }

--- a/cala-ledger/.sqlx/query-019135648f4d3371f724322403863b87a60ad88a44541651afaf9f7ef6288435.json
+++ b/cala-ledger/.sqlx/query-019135648f4d3371f724322403863b87a60ad88a44541651afaf9f7ef6288435.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          INSERT INTO job_executions (id, job_type, queue_id, execute_at, alive_at, created_at)\n          VALUES ($1, $2, $3, $4, COALESCE($5, NOW()), COALESCE($5, NOW()))\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "019135648f4d3371f724322403863b87a60ad88a44541651afaf9f7ef6288435"
+}

--- a/cala-ledger/.sqlx/query-02fefaba20bd33d8d5089c5cb8636913018637066ce2b96d200fc208652bdcf8.json
+++ b/cala-ledger/.sqlx/query-02fefaba20bd33d8d5089c5cb8636913018637066ce2b96d200fc208652bdcf8.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE external_id IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "02fefaba20bd33d8d5089c5cb8636913018637066ce2b96d200fc208652bdcf8"
+}

--- a/cala-ledger/.sqlx/query-03f1090931f9509def351baebce13d42474eb2f7ab02f61448c70c19c693c193.json
+++ b/cala-ledger/.sqlx/query-03f1090931f9509def351baebce13d42474eb2f7ab02f61448c70c19c693c193.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE parent_job_id IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "03f1090931f9509def351baebce13d42474eb2f7ab02f61448c70c19c693c193"
+}

--- a/cala-ledger/.sqlx/query-0a2197e6b93cedcaf01e1517daa2d960ef1a55ebd9e6ba56b1928a132970054f.json
+++ b/cala-ledger/.sqlx/query-0a2197e6b93cedcaf01e1517daa2d960ef1a55ebd9e6ba56b1928a132970054f.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE external_id IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "0a2197e6b93cedcaf01e1517daa2d960ef1a55ebd9e6ba56b1928a132970054f"
+}

--- a/cala-ledger/.sqlx/query-0ef759ca363dd6215cacf388c8f2d3a31ee655b14d9f992fd7dcd7ea4559fb49.json
+++ b/cala-ledger/.sqlx/query-0ef759ca363dd6215cacf388c8f2d3a31ee655b14d9f992fd7dcd7ea4559fb49.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE job_executions\n        SET state = 'pending',\n            execute_at = $1,\n            poller_instance_id = NULL\n        WHERE poller_instance_id = $2 AND state = 'running'\n        RETURNING id as \"id!: JobId\", attempt_index\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "attempt_index",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "0ef759ca363dd6215cacf388c8f2d3a31ee655b14d9f992fd7dcd7ea4559fb49"
+}

--- a/cala-ledger/.sqlx/query-0f686e82dacdea670330c9d2e02ab99bc884bcfbab54e1a5fa9b7bcc9a5523eb.json
+++ b/cala-ledger/.sqlx/query-0f686e82dacdea670330c9d2e02ab99bc884bcfbab54e1a5fa9b7bcc9a5523eb.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM job_executions WHERE id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0f686e82dacdea670330c9d2e02ab99bc884bcfbab54e1a5fa9b7bcc9a5523eb"
+}

--- a/cala-ledger/.sqlx/query-12668646228f369ad4658bf658e75e0be951ea12e9bcb4c016f93df1575bc8eb.json
+++ b/cala-ledger/.sqlx/query-12668646228f369ad4658bf658e75e0be951ea12e9bcb4c016f93df1575bc8eb.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "12668646228f369ad4658bf658e75e0be951ea12e9bcb4c016f93df1575bc8eb"
+}

--- a/cala-ledger/.sqlx/query-1a08bbf15dcff44fc1d4ef2342d3187ac7dd14767edbbaee70e938bc2ccbd5b3.json
+++ b/cala-ledger/.sqlx/query-1a08bbf15dcff44fc1d4ef2342d3187ac7dd14767edbbaee70e938bc2ccbd5b3.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE external_id IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "1a08bbf15dcff44fc1d4ef2342d3187ac7dd14767edbbaee70e938bc2ccbd5b3"
+}

--- a/cala-ledger/.sqlx/query-2a09e272fbd5329fbbf19de003ddc923cd863b2cc44cf6965cc77cc1d4ef9301.json
+++ b/cala-ledger/.sqlx/query-2a09e272fbd5329fbbf19de003ddc923cd863b2cc44cf6965cc77cc1d4ef9301.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE code IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "2a09e272fbd5329fbbf19de003ddc923cd863b2cc44cf6965cc77cc1d4ef9301"
+}

--- a/cala-ledger/.sqlx/query-3d84eec41b105db35e4672b32d352cdba492d5b44234a941227391ff4ed5c5ce.json
+++ b/cala-ledger/.sqlx/query-3d84eec41b105db35e4672b32d352cdba492d5b44234a941227391ff4ed5c5ce.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "3d84eec41b105db35e4672b32d352cdba492d5b44234a941227391ff4ed5c5ce"
+}

--- a/cala-ledger/.sqlx/query-446db9f053f56473bb1bfc0a86b626c0bb2b31d058f247151439a3f656b9de4e.json
+++ b/cala-ledger/.sqlx/query-446db9f053f56473bb1bfc0a86b626c0bb2b31d058f247151439a3f656b9de4e.json
@@ -1,0 +1,43 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH eligible AS (\n            SELECT id, queue_id, execute_at, execution_state_json, attempt_index\n            FROM job_executions\n            WHERE state = 'pending'\n            AND job_type = ANY($4)\n            AND NOT EXISTS (\n                SELECT 1 FROM job_executions AS running\n                WHERE running.state = 'running'\n                AND running.queue_id IS NOT NULL\n                AND running.queue_id = job_executions.queue_id\n            )\n        ),\n        min_wait AS (\n            SELECT MIN(execute_at) - $2::timestamptz AS wait_time\n            FROM eligible\n            WHERE execute_at > $2::timestamptz\n        ),\n        candidates AS (\n            SELECT id, execution_state_json AS data_json, attempt_index,\n                   ROW_NUMBER() OVER (\n                       PARTITION BY COALESCE(queue_id, id::text)\n                       ORDER BY execute_at\n                   ) AS rn\n            FROM eligible\n            WHERE execute_at <= $2::timestamptz\n        ),\n        selected_jobs AS (\n            SELECT je.id, c.data_json, c.attempt_index\n            FROM candidates c\n            JOIN job_executions je ON je.id = c.id\n            WHERE c.rn = 1\n            ORDER BY je.execute_at ASC\n            LIMIT $1\n            FOR UPDATE OF je\n        ),\n        updated AS (\n            UPDATE job_executions AS je\n            SET state = 'running', alive_at = $2, execute_at = NULL, poller_instance_id = $3\n            FROM selected_jobs\n            WHERE je.id = selected_jobs.id\n              AND je.state = 'pending'\n            RETURNING je.id, selected_jobs.data_json, je.attempt_index\n        )\n        SELECT * FROM (\n            SELECT\n                u.id AS \"id?: JobId\",\n                u.data_json AS \"data_json?: JsonValue\",\n                u.attempt_index AS \"attempt_index?\",\n                NULL::INTERVAL AS \"max_wait?: PgInterval\"\n            FROM updated u\n            UNION ALL\n            SELECT\n                NULL::UUID AS \"id?: JobId\",\n                NULL::JSONB AS \"data_json?: JsonValue\",\n                NULL::INT AS \"attempt_index?\",\n                mw.wait_time AS \"max_wait?: PgInterval\"\n            FROM min_wait mw\n            WHERE NOT EXISTS (SELECT 1 FROM updated)\n        ) AS result\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id?: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "data_json?: JsonValue",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempt_index?",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "max_wait?: PgInterval",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Timestamptz",
+        "Uuid",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "446db9f053f56473bb1bfc0a86b626c0bb2b31d058f247151439a3f656b9de4e"
+}

--- a/cala-ledger/.sqlx/query-45ab37aaf850388208241c52947f927653550a0093a56f189f0ca2f524e0e7e2.json
+++ b/cala-ledger/.sqlx/query-45ab37aaf850388208241c52947f927653550a0093a56f189f0ca2f524e0e7e2.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND (COALESCE((created_at, id) > ($5, $4), $4 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $6 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "45ab37aaf850388208241c52947f927653550a0093a56f189f0ca2f524e0e7e2"
+}

--- a/cala-ledger/.sqlx/query-485ae108b79620f33b6ee77ed238e2b1d3911d07a380de7cc8b8f196b109aa44.json
+++ b/cala-ledger/.sqlx/query-485ae108b79620f33b6ee77ed238e2b1d3911d07a380de7cc8b8f196b109aa44.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM cala_accounts WHERE external_id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_account_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT parent_job_id, id FROM jobs WHERE ((parent_job_id IS NOT DISTINCT FROM $1) AND (COALESCE(id < $3, true))) ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,9 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
+        "Uuid",
+        "Int8",
+        "Uuid",
         "Bool"
       ]
     },
@@ -43,5 +45,5 @@
       false
     ]
   },
-  "hash": "15cede7bdd82f129b7b084ba634af98700b66599a3c5ce1de8ba534a6696a3cf"
+  "hash": "485ae108b79620f33b6ee77ed238e2b1d3911d07a380de7cc8b8f196b109aa44"
 }

--- a/cala-ledger/.sqlx/query-4aa09bfdf92c1b10f4b533557db33624c22189d93a1aeb5b5357f3cf7c3df0a0.json
+++ b/cala-ledger/.sqlx/query-4aa09bfdf92c1b10f4b533557db33624c22189d93a1aeb5b5357f3cf7c3df0a0.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          DELETE FROM job_executions\n          WHERE id = $1 AND poller_instance_id = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4aa09bfdf92c1b10f4b533557db33624c22189d93a1aeb5b5357f3cf7c3df0a0"
+}

--- a/cala-ledger/.sqlx/query-4ed94ccf82ccc9f8d56e50016d41fede1cef57f46e6b3b07ea414f3066bb911f.json
+++ b/cala-ledger/.sqlx/query-4ed94ccf82ccc9f8d56e50016d41fede1cef57f46e6b3b07ea414f3066bb911f.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM job_executions\n                WHERE id = $1 AND poller_instance_id = $2\n              ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4ed94ccf82ccc9f8d56e50016d41fede1cef57f46e6b3b07ea414f3066bb911f"
+}

--- a/cala-ledger/.sqlx/query-5d7405e5fb8980dcb0e4dbc7f31cd8c59befacfd4ce4bcd3526ff0c096aeaa5c.json
+++ b/cala-ledger/.sqlx/query-5d7405e5fb8980dcb0e4dbc7f31cd8c59befacfd4ce4bcd3526ff0c096aeaa5c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM job_executions WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5d7405e5fb8980dcb0e4dbc7f31cd8c59befacfd4ce4bcd3526ff0c096aeaa5c"
+}

--- a/cala-ledger/.sqlx/query-6c430bf212e5798b04acd38dc841d6a33a829dbacb73d8608572f365d246f08a.json
+++ b/cala-ledger/.sqlx/query-6c430bf212e5798b04acd38dc841d6a33a829dbacb73d8608572f365d246f08a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM cala_transactions WHERE external_id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_transaction_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND (COALESCE(id > $4, true)) ORDER BY id ASC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,10 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
         "Bool"
       ]
     },
@@ -43,5 +46,5 @@
       false
     ]
   },
-  "hash": "1a89af7f191c350a04fb38d19ce9c1fdd5c2147babd34bd150ce20095d921e8a"
+  "hash": "6c430bf212e5798b04acd38dc841d6a33a829dbacb73d8608572f365d246f08a"
 }

--- a/cala-ledger/.sqlx/query-83a57fe9f4eef92fbf7cfb496ae1fb77556e6a2ccc45d4f1380da0695919b330.json
+++ b/cala-ledger/.sqlx/query-83a57fe9f4eef92fbf7cfb496ae1fb77556e6a2ccc45d4f1380da0695919b330.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO job_events (id, recorded_at, sequence, event_type, event) SELECT $1, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "83a57fe9f4eef92fbf7cfb496ae1fb77556e6a2ccc45d4f1380da0695919b330"
+}

--- a/cala-ledger/.sqlx/query-8dfaa15816547fecb125c30444481590b22abd0ed2199ecf0a099991850db17a.json
+++ b/cala-ledger/.sqlx/query-8dfaa15816547fecb125c30444481590b22abd0ed2199ecf0a099991850db17a.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        UPDATE job_executions\n                        SET state = 'pending', execute_at = $1, attempt_index = attempt_index + 1, poller_instance_id = NULL\n                        WHERE state = 'running' AND alive_at < $1::timestamptz\n                        AND job_type = ANY($2)\n                        AND poller_instance_id IS DISTINCT FROM $3\n                        RETURNING id as id\n                        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "TextArray",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8dfaa15816547fecb125c30444481590b22abd0ed2199ecf0a099991850db17a"
+}

--- a/cala-ledger/.sqlx/query-9224c1c459a94c2de75e113a109ea8077430c79520ca26b44f1a7ae74656ad7c.json
+++ b/cala-ledger/.sqlx/query-9224c1c459a94c2de75e113a109ea8077430c79520ca26b44f1a7ae74656ad7c.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        UPDATE job_executions\n                        SET alive_at = $1\n                        WHERE poller_instance_id = $2 AND state = 'running'\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9224c1c459a94c2de75e113a109ea8077430c79520ca26b44f1a7ae74656ad7c"
+}

--- a/cala-ledger/.sqlx/query-97647c873b103f0c060ab3e73e3175cb7288cdc35da02cb706e7cc62936f0523.json
+++ b/cala-ledger/.sqlx/query-97647c873b103f0c060ab3e73e3175cb7288cdc35da02cb706e7cc62936f0523.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE job_type = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "97647c873b103f0c060ab3e73e3175cb7288cdc35da02cb706e7cc62936f0523"
+}

--- a/cala-ledger/.sqlx/query-9ab25bea85f68a606013136bf1d70be5173a6b992936215300ad0737c46bfeec.json
+++ b/cala-ledger/.sqlx/query-9ab25bea85f68a606013136bf1d70be5173a6b992936215300ad0737c46bfeec.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE job_executions\n                SET state = 'pending', execute_at = $2, attempt_index = $3, poller_instance_id = NULL\n                WHERE id = $1 AND poller_instance_id = $4\n              ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int4",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9ab25bea85f68a606013136bf1d70be5173a6b992936215300ad0737c46bfeec"
+}

--- a/cala-ledger/.sqlx/query-a13e1721858db65497f99095b4190c8169002ab3bf17d088c3af7628bcc5b35d.json
+++ b/cala-ledger/.sqlx/query-a13e1721858db65497f99095b4190c8169002ab3bf17d088c3af7628bcc5b35d.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE id = ANY($1)) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "a13e1721858db65497f99095b4190c8169002ab3bf17d088c3af7628bcc5b35d"
+}

--- a/cala-ledger/.sqlx/query-ab55c317dd4a1ec809a076acad473e78f765255e1f5d0b712b7bef9716eb21f3.json
+++ b/cala-ledger/.sqlx/query-ab55c317dd4a1ec809a076acad473e78f765255e1f5d0b712b7bef9716eb21f3.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO jobs (id, job_type, unique_per_type, parent_job_id, created_at) VALUES ($1, $2, $3, $4, COALESCE($5, NOW()))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Bool",
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ab55c317dd4a1ec809a076acad473e78f765255e1f5d0b712b7bef9716eb21f3"
+}

--- a/cala-ledger/.sqlx/query-ae139606654819ffd6895252999151b67d905c5b481f7c7e13cca53cf9b902cd.json
+++ b/cala-ledger/.sqlx/query-ae139606654819ffd6895252999151b67d905c5b481f7c7e13cca53cf9b902cd.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE unique_per_type = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "ae139606654819ffd6895252999151b67d905c5b481f7c7e13cca53cf9b902cd"
+}

--- a/cala-ledger/.sqlx/query-b103a421f81cf9a480b1114c5d13aa1490cde78641aa45310045330148841d72.json
+++ b/cala-ledger/.sqlx/query-b103a421f81cf9a480b1114c5d13aa1490cde78641aa45310045330148841d72.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT parent_job_id, id FROM jobs WHERE ((parent_job_id IS NOT DISTINCT FROM $1) AND (COALESCE(id > $3, true))) ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "b103a421f81cf9a480b1114c5d13aa1490cde78641aa45310045330148841d72"
+}

--- a/cala-ledger/.sqlx/query-c726ced195ea29ea581c934ea668d1c4b293a20faa289147085e680aa6ce379e.json
+++ b/cala-ledger/.sqlx/query-c726ced195ea29ea581c934ea668d1c4b293a20faa289147085e680aa6ce379e.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND (COALESCE((created_at, id) < ($5, $4), $4 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $6 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "c726ced195ea29ea581c934ea668d1c4b293a20faa289147085e680aa6ce379e"
+}

--- a/cala-ledger/.sqlx/query-caf6d17dfbae985a68af1173d30222d220079e05ec0f33854a8f7c2dfeab75a1.json
+++ b/cala-ledger/.sqlx/query-caf6d17dfbae985a68af1173d30222d220079e05ec0f33854a8f7c2dfeab75a1.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        SELECT\n                            job_type,\n                            COUNT(*)::INT4 AS \"count!: i32\",\n                            EXTRACT(EPOCH FROM ($1::timestamptz - MIN(execute_at)))::FLOAT8\n                                AS \"max_pending_duration_secs!: f64\"\n                        FROM job_executions\n                        WHERE state = 'pending'\n                        AND execute_at <= $1::timestamptz\n                        AND job_type = ANY($2)\n                        GROUP BY job_type\n                        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "job_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "count!: i32",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "max_pending_duration_secs!: f64",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "caf6d17dfbae985a68af1173d30222d220079e05ec0f33854a8f7c2dfeab75a1"
+}

--- a/cala-ledger/.sqlx/query-d58d1b9373f3485a2a4d74567f8a2f031bea0951a2938bcf0b2960179e66879a.json
+++ b/cala-ledger/.sqlx/query-d58d1b9373f3485a2a4d74567f8a2f031bea0951a2938bcf0b2960179e66879a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM cala_journals WHERE code = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_journal_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,8 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
+        "Int8",
+        "Uuid",
         "Bool"
       ]
     },
@@ -43,5 +44,5 @@
       false
     ]
   },
-  "hash": "6dbd75e09912bba2834c6e63a02a0f752457a5949f929e99ad1b4b7ad78b8f52"
+  "hash": "d58d1b9373f3485a2a4d74567f8a2f031bea0951a2938bcf0b2960179e66879a"
 }

--- a/cala-ledger/.sqlx/query-dcc6c8810ed74de9da3aef674c749e4814e2b2eb82675e2226371920e19f1c0d.json
+++ b/cala-ledger/.sqlx/query-dcc6c8810ed74de9da3aef674c749e4814e2b2eb82675e2226371920e19f1c0d.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM jobs WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "dcc6c8810ed74de9da3aef674c749e4814e2b2eb82675e2226371920e19f1c0d"
+}

--- a/cala-ledger/.sqlx/query-e666d2e28c76cab9ed701d49d72646ee304f6574e4749f2f1878947b89ce6ae3.json
+++ b/cala-ledger/.sqlx/query-e666d2e28c76cab9ed701d49d72646ee304f6574e4749f2f1878947b89ce6ae3.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          UPDATE job_executions\n          SET execution_state_json = $1\n          WHERE id = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e666d2e28c76cab9ed701d49d72646ee304f6574e4749f2f1878947b89ce6ae3"
+}

--- a/cala-ledger/.sqlx/query-e67fb92be8782f30d872b37b7a8efdaae473009d3dc398aacff73a58eb0e0ad7.json
+++ b/cala-ledger/.sqlx/query-e67fb92be8782f30d872b37b7a8efdaae473009d3dc398aacff73a58eb0e0ad7.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          UPDATE job_executions\n          SET state = 'pending', execute_at = $2, attempt_index = 1, poller_instance_id = NULL\n          WHERE id = $1 AND poller_instance_id = $3\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e67fb92be8782f30d872b37b7a8efdaae473009d3dc398aacff73a58eb0e0ad7"
+}

--- a/cala-ledger/.sqlx/query-fbc824f03c570409514e33278e646748a997db598719347cb267dd1134e92570.json
+++ b/cala-ledger/.sqlx/query-fbc824f03c570409514e33278e646748a997db598719347cb267dd1134e92570.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE (NOT $1 OR parent_job_id IS NOT DISTINCT FROM $2) AND (COALESCE(id < $4, true)) ORDER BY id DESC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "fbc824f03c570409514e33278e646748a997db598719347cb267dd1134e92570"
+}

--- a/cala-ledger/.sqlx/query-fe01de1969256000b4a02e472fbd608a31aa78e73e60e466b7ba47cd9b7a72cd.json
+++ b/cala-ledger/.sqlx/query-fe01de1969256000b4a02e472fbd608a31aa78e73e60e466b7ba47cd9b7a72cd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM cala_account_sets WHERE external_id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN cala_account_set_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT created_at, id FROM jobs WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,9 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -43,5 +45,5 @@
       false
     ]
   },
-  "hash": "8a18c0c671386670f93906697785348b139694d813229b44e26323818d4f4fec"
+  "hash": "fe01de1969256000b4a02e472fbd608a31aa78e73e60e466b7ba47cd9b7a72cd"
 }


### PR DESCRIPTION
Bumps the workspace pins for `job` (0.6.19 → 0.6.22) and `obix` (0.2.25 → 0.2.26) as the next link in the `job → obix → cala → lana-bank` release chain.

`cargo update -p job -p obix` transitively pulled `es-entity` 0.10.34 → 0.10.35 in `Cargo.lock` (the workspace caret pin `es-entity = "0.10.34"` stays compatible and is left unchanged). The new `es-entity` macros emit slightly different SQL, so the `cala-ledger/.sqlx/` offline query cache is regenerated in a follow-up commit — required for `nix flake check` / `make check-code`, which run with `SQLX_OFFLINE=true`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency and generated `sqlx` metadata changes, but the `job`/`obix` upgrades could subtly affect job execution/query behavior at runtime.
> 
> **Overview**
> Bumps workspace dependencies `job` to `0.6.22` and `obix` to `0.2.26`, with `Cargo.lock` also updating `es-entity`/`es-entity-macros` to `0.10.35`.
> 
> Regenerates `cala-ledger/.sqlx/` offline query cache: several existing entity lookups switch to `IS NOT DISTINCT FROM` for null-safe equality, and a set of new cached queries for `jobs`/`job_executions`/`job_events` are added/updated to satisfy `SQLX_OFFLINE` builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1b5fb3ce425a951e58adc98c201a5a0a7ed59f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->