### PR TITLE
chore: Remove err from instrument on tx_template.prep_entries

### DIFF
--- a/cala-ledger/src/tx_template/mod.rs
+++ b/cala-ledger/src/tx_template/mod.rs
@@ -152,7 +152,6 @@ impl TxTemplates {
             journal_id = %journal_id,
             entries_count = tmpl.entries.len()
         ),
-        err
     )]
     fn prep_entries(
         &self,


### PR DESCRIPTION
This caused an unnecessary alert. This should be handled by higher-level function and not by private low-level one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts `tracing::instrument` behavior to stop emitting error-level events from a private helper, with no functional or data-path changes.
> 
> **Overview**
> Removes the `err` flag from the `#[instrument]` annotation on `tx_template.prep_entries`, so errors returned by this low-level helper are no longer automatically recorded/emitted by that span.
> 
> This shifts error reporting responsibility to higher-level callers and should reduce noisy alerts without changing transaction/entry preparation logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee7d675a36f2470de154a5badb7831fedec1155. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->