### PR TITLE
chore: Remove async-graphql integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,83 +92,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-graphql"
-version = "8.0.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992eec3a71c482790dc346a311a3cdcb1e9006b652a0b87e154b42adb0918b4c"
-dependencies = [
- "async-graphql-derive",
- "async-graphql-parser",
- "async-graphql-value",
- "async-trait",
- "asynk-strim",
- "base64",
- "bytes",
- "chrono",
- "futures-channel",
- "futures-util",
- "http",
- "indexmap 2.13.0",
- "lru",
- "mime",
- "multer",
- "num-traits",
- "pin-project-lite",
- "regex",
- "rustc-hash",
- "scc",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "static_assertions_next",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "async-graphql-derive"
-version = "8.0.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0739ca16bca33d4071c1b45f19d902d6894696f997b9b4c9c0b316c509b4f83f"
-dependencies = [
- "async-graphql-parser",
- "darling 0.23.0",
- "heck",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "strum",
- "syn 2.0.117",
- "thiserror",
-]
-
-[[package]]
-name = "async-graphql-parser"
-version = "8.0.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85b5e90b08d72410b40c71a1878d78308a190f3bbb45a82ea000d0dbc4133a8"
-dependencies = [
- "async-graphql-value",
- "pest",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "async-graphql-value"
-version = "8.0.0-rc.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3b3ae38aad471922da0c5be8318b58dcf0b9e0cf570aa5b57d7df4ef5e6c9e"
-dependencies = [
- "bytes",
- "indexmap 2.13.0",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,16 +100,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "asynk-strim"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52697735bdaac441a29391a9e97102c74c6ef0f9b60a40cf109b1b404e29d2f6"
-dependencies = [
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -338,9 +251,6 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "cached"
@@ -411,8 +321,6 @@ name = "cala-ledger"
 version = "0.15.8-dev"
 dependencies = [
  "anyhow",
- "async-graphql",
- "base64",
  "cached",
  "cala-cel-interpreter",
  "cala-ledger-core-types",
@@ -445,7 +353,6 @@ dependencies = [
 name = "cala-ledger-core-types"
 version = "0.15.8-dev"
 dependencies = [
- "async-graphql",
  "cala-cel-interpreter",
  "chrono",
  "derive_builder",
@@ -933,15 +840,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,8 +851,6 @@ version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07f523e4cd9b354b57b458aee369eadba8da68fbfb2af636c7a429c7942160d3"
 dependencies = [
- "async-graphql",
- "base64",
  "chrono",
  "derive_builder",
  "es-entity-macros",
@@ -1778,15 +1674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "lru"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1812,12 +1699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1826,23 +1707,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "multer"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
-dependencies = [
- "bytes",
- "encoding_rs",
- "futures-util",
- "http",
- "httparse",
- "memchr",
- "mime",
- "spin",
- "version_check",
 ]
 
 [[package]]
@@ -2093,16 +1957,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
 
 [[package]]
 name = "petgraph"
@@ -2653,12 +2507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
-
-[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,28 +2562,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "saa"
-version = "5.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c7f49c9d5caa3bf4b3106900484b447b9253fe99670ceb81cb6cb5027855e1"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "scc"
-version = "3.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f657c5c05cdfb286cce8d368937ddda5fab6efb95a1fdcaef5d12ae79bcf8b"
-dependencies = [
- "saa",
- "sdd",
 ]
 
 [[package]]
@@ -2783,12 +2615,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sdd"
-version = "4.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a9d320f26e34632107c1d9c71183931e71471b084a8d5a9ca7c16a3ae49ee2"
 
 [[package]]
 name = "seahash"
@@ -3230,12 +3056,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions_next"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7beae5182595e9a8b683fa98c4317f956c9a2dec3b9716990d20023cc60c766"
-
-[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,18 +3476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "futures",
- "futures-task",
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,12 +3544,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ job = { version = "0.6.22", features = ["es-entity"] }
 obix = { version = "0.2.26", default-features = false }
 
 anyhow = "1.0.99"
-async-graphql = { version = "8.0.0-rc.4", default-features = false, features = ["dataloader", "tracing", "chrono", "tokio"] }
-base64 = { version = "0.22.1" }
 cached = { version = "0.59", features = ["async"] }
 chrono = { version = "0.4.44", features = ["clock", "serde"], default-features = false }
 derive_builder = "0.20.1"

--- a/cala-ledger-core-types/Cargo.toml
+++ b/cala-ledger-core-types/Cargo.toml
@@ -9,14 +9,12 @@ license = "Apache-2.0"
 [features]
 
 fail-on-warnings = []
-graphql = ["es-entity/graphql", "dep:async-graphql"]
 json-schema = ["es-entity/json-schema", "dep:schemars", "cel-interpreter/json-schema"]
 
 [dependencies]
 cel-interpreter = { workspace = true }
 es-entity = { workspace = true }
 
-async-graphql = { workspace = true, optional = true }
 schemars = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/cala-ledger-core-types/src/primitives.rs
+++ b/cala-ledger-core-types/src/primitives.rs
@@ -67,7 +67,6 @@ impl From<AccountSetId> for AccountId {
     strum::Display,
     strum::EnumString,
 )]
-#[cfg_attr(feature = "graphql", derive(async_graphql::Enum))]
 #[sqlx(type_name = "DebitOrCredit", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
@@ -105,7 +104,6 @@ impl From<DebitOrCredit> for CelValue {
 #[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "Status", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "graphql", derive(async_graphql::Enum))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Status {
     #[default]
@@ -115,7 +113,6 @@ pub enum Status {
 
 #[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Hash, sqlx::Type)]
 #[sqlx(type_name = "Layer", rename_all = "snake_case")]
-#[cfg_attr(feature = "graphql", derive(async_graphql::Enum))]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 pub enum Layer {
     #[default]

--- a/cala-ledger/Cargo.toml
+++ b/cala-ledger/Cargo.toml
@@ -12,7 +12,6 @@ categories = ["finance"]
 [features]
 
 fail-on-warnings = []
-graphql = ["es-entity/graphql", "dep:async-graphql", "dep:base64", "cala-types/graphql"]
 json-schema = ["cala-types/json-schema", "job/json-schema", "es-entity/json-schema", "dep:schemars"]
 
 [[bin]]
@@ -27,9 +26,6 @@ cala-tracing = { workspace = true }
 es-entity = { workspace = true }
 job = { workspace = true }
 obix = { workspace = true }
-
-async-graphql = { workspace = true, optional = true }
-base64 = { workspace = true, optional = true }
 
 cached = { workspace = true }
 chrono = { workspace = true }

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -35,26 +35,6 @@ pub mod members_cursor {
         }
     }
 
-    #[cfg(feature = "graphql")]
-    impl async_graphql::connection::CursorType for AccountSetMemberByCreatedAtCursor {
-        type Error = String;
-
-        fn encode_cursor(&self) -> String {
-            use base64::{engine::general_purpose, Engine as _};
-            let json = serde_json::to_string(&self).expect("could not serialize token");
-            general_purpose::STANDARD_NO_PAD.encode(json.as_bytes())
-        }
-
-        fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
-            use base64::{engine::general_purpose, Engine as _};
-            let bytes = general_purpose::STANDARD_NO_PAD
-                .decode(s.as_bytes())
-                .map_err(|e| e.to_string())?;
-            let json = String::from_utf8(bytes).map_err(|e| e.to_string())?;
-            serde_json::from_str(&json).map_err(|e| e.to_string())
-        }
-    }
-
     #[derive(Debug, Serialize, Deserialize)]
     pub struct AccountSetMemberByExternalIdCursor {
         pub id: AccountSetMemberId,
@@ -67,26 +47,6 @@ pub mod members_cursor {
                 id: member.id,
                 external_id: member.external_id.clone(),
             }
-        }
-    }
-
-    #[cfg(feature = "graphql")]
-    impl async_graphql::connection::CursorType for AccountSetMemberByExternalIdCursor {
-        type Error = String;
-
-        fn encode_cursor(&self) -> String {
-            use base64::{engine::general_purpose, Engine as _};
-            let json = serde_json::to_string(&self).expect("could not serialize token");
-            general_purpose::STANDARD_NO_PAD.encode(json.as_bytes())
-        }
-
-        fn decode_cursor(s: &str) -> Result<Self, Self::Error> {
-            use base64::{engine::general_purpose, Engine as _};
-            let bytes = general_purpose::STANDARD_NO_PAD
-                .decode(s.as_bytes())
-                .map_err(|e| e.to_string())?;
-            let json = String::from_utf8(bytes).map_err(|e| e.to_string())?;
-            serde_json::from_str(&json).map_err(|e| e.to_string())
         }
     }
 }


### PR DESCRIPTION
## Summary
- remove the optional `graphql` features from `cala-ledger` and `cala-ledger-core-types`
- drop `async-graphql` / `base64` from Cala manifests and lockfile
- remove async-graphql enum derives and CursorType impls from Cala types

## Verification
- `SQLX_OFFLINE=true cargo check -p cala-ledger-core-types`
- `SQLX_OFFLINE=true cargo check -p cala-ledger`
- `SQLX_OFFLINE=true cargo check -p cala-ledger --all-features`
- `cargo tree -p cala-ledger -e features -i async-graphql` reports no matching package

Companion Lana change moves the GraphQL API representation to Lana-owned wrapper enums.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes the optional GraphQL feature surface (`async-graphql` derives and cursor encoding) and related dependencies, which is potentially breaking for downstream consumers that enabled `graphql` features, but does not change core ledger logic.
> 
> **Overview**
> Removes `async-graphql` integration from `cala-ledger` and `cala-ledger-core-types` by deleting the `graphql` feature flags and all related enum derives and `CursorType` implementations.
> 
> Updates workspace and crate manifests plus `Cargo.lock` to drop `async-graphql`, `base64`, and their transitive dependencies, leaving cursor structs as plain `serde`-serializable types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e3349495170ad7f34f93abb00743805967b6df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->