### PR TITLE
fix(ci): sync Cargo.lock after version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cala-cel-interpreter"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "anyhow",
  "cala-cel-parser",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "cala-cel-parser"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "cached",
  "lalrpop",
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "anyhow",
  "cached",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger-core-types"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "cala-cel-interpreter",
  "chrono",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "cala-ledger-example-rust"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "anyhow",
  "cala-ledger",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "cala-perf"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "anyhow",
  "cala-ledger",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "cala-tracing"
-version = "0.15.9"
+version = "0.15.10-dev"
 dependencies = [
  "anyhow",
  "opentelemetry",


### PR DESCRIPTION
## Summary
- update the workspace package versions in Cargo.lock from 0.15.9 to 0.15.10-dev
- keep the fix limited to the automated dev-version bump that broke --locked cargo commands

## Why
The dev-version commit updated the workspace Cargo.toml files but left Cargo.lock with the old local package versions. CI then failed when Cargo was asked to run with --locked.

## Validation
- nix develop -c cargo metadata --format-version=1 --all-features --locked
- nix flake check

Note: nix flake check was run on a Darwin host and omitted incompatible Linux systems locally; the locked metadata command exercises the specific CI failure mode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk lockfile-only change that aligns local workspace crate versions with the recent dev version bump, primarily affecting reproducible/`--locked` builds in CI.
> 
> **Overview**
> Updates `Cargo.lock` to reflect the workspace crate version bump from `0.15.9` to `0.15.10-dev` (e.g., `cala-ledger`, `cala-cel-*`, `cala-tracing`).
> 
> This brings the lockfile back in sync with the workspace manifests so `cargo --locked` operations (and CI) no longer fail due to mismatched local package versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ebd001adc2eaf32828dc087173f8ee9381ce3af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->