### PR TITLE
chore(deps): bump cached 0.59 → 1.1 + update import path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,17 +248,14 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cached"
-version = "0.59.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b6f5d101f0f6322c8646a45b7c581a673e476329040d97565815c2461dd0c4"
+checksum = "4863037a22757575c62f4f52c71bc833c7989c696c35eda5c83a4f36599b2bbd"
 dependencies = [
  "ahash 0.8.12",
- "async-trait",
  "cached_proc_macro",
  "cached_proc_macro_types",
- "futures",
  "hashbrown 0.16.1",
- "once_cell",
  "parking_lot",
  "thiserror",
  "tokio",
@@ -267,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro"
-version = "0.27.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ebcf9c75f17a17d55d11afc98e46167d4790a263f428891b8705ab2f793eca3"
+checksum = "8b7a89b3ceb2f9166826b0d21b670a8720dbaeb3397428d1c7603e0ffacdfd37"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -279,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "cached_proc_macro_types"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+checksum = "26cf465651fa6ad902a2d327ba60c3a6bc61c6a2f4ad70d091cf20dfda0074ef"
 
 [[package]]
 name = "cala-cel-interpreter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ job = { version = "0.6.25", features = ["es-entity"] }
 obix = { version = "0.2.27", default-features = false }
 
 anyhow = "1.0.99"
-cached = { version = "0.59", features = ["async"] }
+cached = { version = "1.1", features = ["async"] }
 chrono = { version = "0.4.44", features = ["clock", "serde"], default-features = false }
 derive_builder = "0.20.1"
 sqlx = { version = "0.8.3", features = [ "runtime-tokio-rustls", "postgres", "rust_decimal", "uuid", "chrono", "json" ] }

--- a/cala-cel-parser/src/lib.rs
+++ b/cala-cel-parser/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(feature = "fail-on-warnings", deny(warnings))]
 #![cfg_attr(feature = "fail-on-warnings", deny(clippy::all))]
 
-use cached::proc_macro::cached;
+use cached::macros::cached;
 use tracing::instrument;
 
 pub mod ast;

--- a/cala-ledger/src/tx_template/repo.rs
+++ b/cala-ledger/src/tx_template/repo.rs
@@ -1,4 +1,4 @@
-use cached::proc_macro::cached;
+use cached::macros::cached;
 
 use es_entity::*;
 use sqlx::PgPool;


### PR DESCRIPTION
## Summary

- Bumps workspace `cached` from `0.59` to `1.1`
- Renames `use cached::proc_macro::cached` → `use cached::macros::cached` in the 2 affected call sites (cala-cel-parser, cala-ledger tx-template repo)
- Closes #728

## Why

[Dependabot #728](https://github.com/GaloyMoney/cala/pull/728) bumped `cached` to 1.1 but failed CI on `Check Code` with:

\`\`\`
error[E0432]: unresolved import \`cached::proc_macro\`
 --> cala-cel-parser/src/lib.rs:4:13
4 | use cached::proc_macro::cached;
  |             ^^^^^^^^^^ could not find \`proc_macro\` in \`cached\`
\`\`\`

`cached` 1.0 moved the proc-macro re-export module from `proc_macro` to `macros`. This PR applies the rename in both affected files and bumps the workspace dep, replacing #728.

## Verification

- `SQLX_OFFLINE=true cargo check --workspace` — clean
- `#[cached(size = 10000)]` (cala-cel-parser) and `#[cached(key = ..., result = true, sync_writes = "default")]` (cala-ledger) attribute syntaxes both still valid in `cached` 1.x — no semantic migration needed for the CEL parse cache or the versioned tx-template lookup

## Test plan

- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency and import-path change; caching call sites and macro attributes are unchanged.
> 
> **Overview**
> Upgrades the workspace **`cached`** dependency from **0.59** to **1.1** (including lockfile updates for `cached`, `cached_proc_macro`, and `cached_proc_macro_types`).
> 
> `cached` 1.x moved the `#[cached]` proc-macro import from `cached::proc_macro` to **`cached::macros`**. This PR applies that rename in **`cala-cel-parser`** (CEL parse cache) and **`cala-ledger`** tx-template version lookup cache; existing attribute options are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c109de011fd60b9533979951e6b565bab40cf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->