### PR TITLE
chore(deps): bump job from 0.6.25 to 0.6.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,9 +1382,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed95a4bbfcfc29d8510c696220a20b5af2fea040c0b9e75ffc2258b32dfa8e09"
+checksum = "e0bccc4738be139d63a915ab2af1a039c19a714c2bf05ce441f682ca42cdcd7d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2414,11 +2423,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2433,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cala-types = { path = "cala-ledger-core-types", package = "cala-ledger-core-type
 cala-ledger = { path = "cala-ledger", version = "0.15.11-dev" }
 
 es-entity = "0.10.39"
-job = { version = "0.6.25", features = ["es-entity"] }
+job = { version = "0.6.26", features = ["es-entity"] }
 obix = { version = "0.2.27", default-features = false }
 
 anyhow = "1.0.99"


### PR DESCRIPTION
## Summary

Picks up [GaloyMoney/job#117](https://github.com/GaloyMoney/job/pull/117), which downgrades the graceful-shutdown force-reschedule log from ERROR to WARN at `poller.rs:857`. That single line was producing every false Zenduty page from the `volcano-qa-main-lana-errors` trigger on pod restart bursts — 10 pages in 6 weeks, 4 of them in 24h.

Lock-file refresh also pulls in a minor `serde_with` patch bump (3.18.0 → 3.21.0) as a transitive of `job 0.6.26`, which inherits it via the OTel updates from job#108.

Part of the propagation chain after job#117 merged: cala → obix → lana-bank. drua uses caret `"0.6"` so picks up automatically.

## Test plan

- [ ] CI green on this PR
- [ ] After release, the consumers (lana-bank, etc.) pick up via their own dependency bumps; volcano-qa stops paging on the documented signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no local code changes; main effect is log severity in the job crate during shutdown.
> 
> **Overview**
> Bumps the workspace **`job`** dependency from **0.6.25** to **0.6.26** and refreshes **`Cargo.lock`**. There are no application code changes in this repo—only the version pin and lockfile.
> 
> The meaningful behavior change comes from upstream **`job` 0.6.26** (GaloyMoney/job#117): a graceful-shutdown force-reschedule message is logged at **WARN** instead of **ERROR**, which should stop false error-alert pages on pod restart bursts. The lockfile also picks up a transitive **`serde_with`** patch (3.18.0 → 3.21.0) and adds **`bs58`** as a dependency of that chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7258a7e86856bd082032845cf26f42209561b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->