### PR TITLE
fix(balance): batch snapshot inserts to avoid deep-recalc OOM

### DIFF
--- a/cala-ledger/src/balance/repo.rs
+++ b/cala-ledger/src/balance/repo.rs
@@ -16,6 +16,13 @@ use crate::outbox::OutboxPublisher;
 
 const EC_SET_LOCK_CLASS: i32 = 1;
 
+/// Maximum balance snapshots written per `INSERT` + outbox publish in
+/// [`BalanceRepo::insert_new_snapshots`]. A deep account-set recalc can produce
+/// one history row per member event; flushing in bounded sub-batches (within
+/// the same transaction) keeps any single statement's working set small so it
+/// cannot OOM-crash a Postgres backend.
+const INSERT_SNAPSHOT_BATCH_SIZE: usize = 5_000;
+
 #[derive(Debug, Clone)]
 pub(super) struct BalanceRepo {
     pool: PgPool,
@@ -366,25 +373,34 @@ impl BalanceRepo {
             tracing::field::display(new_balances.len()),
         );
 
-        let mut journal_ids = Vec::with_capacity(new_balances.len());
-        let mut account_ids = Vec::with_capacity(new_balances.len());
-        let mut entry_ids = Vec::with_capacity(new_balances.len());
-        let mut currencies = Vec::with_capacity(new_balances.len());
-        let mut versions = Vec::with_capacity(new_balances.len());
-        let mut values = Vec::with_capacity(new_balances.len());
+        // Flush in bounded sub-batches within the caller's transaction so a
+        // single set's recalc (which can emit one history row per member event)
+        // never becomes one multi-million-row INSERT + outbox publish large
+        // enough to OOM-crash a Postgres backend. Each sub-batch is a
+        // self-contained statement (history insert + current_balances upsert),
+        // so the balance-history FK is satisfied per sub-batch; the whole set
+        // still commits atomically as one transaction.
+        for chunk in new_balances.chunks(INSERT_SNAPSHOT_BATCH_SIZE) {
+            let mut journal_ids = Vec::with_capacity(chunk.len());
+            let mut account_ids = Vec::with_capacity(chunk.len());
+            let mut entry_ids = Vec::with_capacity(chunk.len());
+            let mut currencies = Vec::with_capacity(chunk.len());
+            let mut versions = Vec::with_capacity(chunk.len());
+            let mut values = Vec::with_capacity(chunk.len());
 
-        for balance in new_balances.iter() {
-            journal_ids.push(balance.journal_id);
-            account_ids.push(balance.account_id);
-            entry_ids.push(balance.entry_id);
-            currencies.push(balance.currency.code());
-            versions.push(balance.version as i32);
-            values
-                .push(serde_json::to_value(balance).expect("Failed to serialize balance snapshot"));
-        }
+            for balance in chunk.iter() {
+                journal_ids.push(balance.journal_id);
+                account_ids.push(balance.account_id);
+                entry_ids.push(balance.entry_id);
+                currencies.push(balance.currency.code());
+                versions.push(balance.version as i32);
+                values.push(
+                    serde_json::to_value(balance).expect("Failed to serialize balance snapshot"),
+                );
+            }
 
-        sqlx::query!(
-            r#"
+            sqlx::query!(
+                r#"
         WITH new_snapshots AS (
             INSERT INTO cala_balance_history (
                 journal_id, account_id, currency, version, latest_entry_id, values
@@ -421,28 +437,33 @@ impl BalanceRepo {
             END,
             latest_seq = GREATEST(c.latest_seq, EXCLUDED.latest_seq)
         "#,
-            &journal_ids as &[JournalId],
-            &account_ids as &[AccountId],
-            &currencies as &[&str],
-            &versions as &[i32],
-            &entry_ids as &[EntryId],
-            &values
-        )
-        .execute(op.as_executor())
-        .await?;
-
-        self.publisher
-            .publish_all(
-                op,
-                new_balances.into_iter().map(|balance| {
-                    if balance.version == 1 {
-                        OutboxEventPayload::BalanceCreated { balance }
-                    } else {
-                        OutboxEventPayload::BalanceUpdated { balance }
-                    }
-                }),
+                &journal_ids as &[JournalId],
+                &account_ids as &[AccountId],
+                &currencies as &[&str],
+                &versions as &[i32],
+                &entry_ids as &[EntryId],
+                &values
             )
+            .execute(op.as_executor())
             .await?;
+
+            self.publisher
+                .publish_all(
+                    op,
+                    chunk.iter().map(|balance| {
+                        if balance.version == 1 {
+                            OutboxEventPayload::BalanceCreated {
+                                balance: balance.clone(),
+                            }
+                        } else {
+                            OutboxEventPayload::BalanceUpdated {
+                                balance: balance.clone(),
+                            }
+                        }
+                    }),
+                )
+                .await?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Problem

Deep recalculation of eventually-consistent (EC) account sets (`recalculate_balances_deep`) can emit one `cala_balance_history` row per member event and, at scale, wrote them **all in a single multi-million-row `INSERT`** (plus one outbox row each). That single statement ran for hundreds of seconds and **OOM-crashed a Postgres backend**, wedging the End-of-Day pipeline.

## Fix (minimal)

Flush `insert_new_snapshots` in bounded sub-batches (`INSERT_SNAPSHOT_BATCH_SIZE = 5000`) **within the same transaction**. Each sub-batch is a self-contained statement (history insert + `cala_current_balances` upsert), so no single statement can OOM a backend, while the whole recalc still commits **atomically as one transaction**.

This is a deliberately minimal mitigation — it bounds per-statement working set without changing the recalc's transaction boundaries, watermark logic, or any read/write semantics. No SQL text changed, so the `.sqlx` cache is untouched.

## Scope

- One file: `cala-ledger/src/balance/repo.rs`.
- No behavior change beyond statement batching; existing tests cover the recalc, poster, effective-balance, and concurrency paths.

## Validation

- `nix flake check` passes (fmt, clippy `--deny warnings`, audit, deny, nix-fmt).
- Relevant `nextest` suites green against a local Postgres — `account_set` (incl. deep-recalc), `effective_balance`, `transaction_post`, and all three `ec_recalc_race` concurrency guardrails (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared poster/recalc persistence path; behavior should be equivalent within one transaction, but partial failure mid-loop could leave fewer outbox rows than history rows until rollback.
> 
> **Overview**
> **`BalanceRepo::insert_new_snapshots`** no longer issues one giant `UNNEST` insert and one bulk outbox publish for the full snapshot vector. It now processes snapshots in chunks of **5,000** (`INSERT_SNAPSHOT_BATCH_SIZE`), each chunk running the same history insert + `cala_current_balances` upsert and a matching **`publish_all`** while staying inside the caller’s single transaction.
> 
> Outbox events are emitted per chunk (with **`balance.clone()`** on each snapshot) instead of consuming the whole `Vec` in one pass. This caps per-statement memory for deep EC set recalcs that can materialize one history row per member event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765bea97c8d0f262c4a25f19f6e7db5da46a3e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->