### PR TITLE
chore(deps): bump job to 0.6.28 and obix to 0.2.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,9 +1382,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3e375f0676c4b90dd93bed37c22fafd45af268184ae4e9a32f29fc9ba58ea4"
+checksum = "518512c0122e327140301d066e994339ce74cbbff0d33be40d0292d0c1b57d94"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1cedafa4dfbba968aacdc5a84e99c27fb63511cd6c84dfb08db4db1a728935a"
+checksum = "84f63afe93c8e13398d013aaff17b7d8800b1fea5d0e709e58f64aca9eb36d07"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1632,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0596a13903fad13efce719601251491337f1ce2b834e1920acd1c87c6591225"
+checksum = "73d399ca2be33ad1b067282eaf957a847f1030a1b43178fdd2ef98cde50fabb7"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ cala-types = { path = "cala-ledger-core-types", package = "cala-ledger-core-type
 cala-ledger = { path = "cala-ledger", version = "0.15.12-dev" }
 
 es-entity = "0.10.40"
-job = { version = "0.6.27", features = ["es-entity"] }
-obix = { version = "0.2.27", default-features = false }
+job = { version = "0.6.28", features = ["es-entity"] }
+obix = { version = "0.2.29", default-features = false }
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }


### PR DESCRIPTION
Bumps two workspace dependencies to their latest published versions.

| crate | from | to |
|---|---|---|
| `obix` | 0.2.27 | **0.2.29** |
| `job` | 0.6.26 | **0.6.28** |

## Why

`obix` 0.2.29 **bounds the `persistent_outbox_events` insert**. Previously the `PersistEvents` commit hook merged every `publish_all` call in a transaction and wrote them all at commit as a single `INSERT … SELECT unnest($1::jsonb[])` over *every* payload. At scale — e.g. a cala EC deep-recalc emitting millions of `BalanceCreated/Updated` events — that one statement could OOM a Postgres backend. 0.2.29's hook now drains the buffered events in `batch_size` chunks in a loop, so no single outbox insert is unbounded.

This is the outbox-side counterpart to the balance-history insert bounding tracked separately; together they remove both unbounded inserts on the recalc path.

`job` is bumped to latest alongside.

## Scope

- `Cargo.toml` + `Cargo.lock` only; no other dependencies changed (es-entity etc. untouched).
- No cala source or API changes — the new `obix` `MailboxConfig` uses its default batch size.

## Validation

- `nix flake check` passes (fmt, clippy `--deny warnings`, audit, deny, nix-fmt) — full rebuild against the new deps.
- `cargo nextest run --workspace` → 97/97 green against local Postgres, including the outbox-publishing paths (`transaction_post`, `effective_balance`, `ec_recalc_race`, velocity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the outbox persistence path used on every transactional publish, but behavior change is bounded inserts with defaults and no cala code changes; validation reported green on outbox-heavy tests.
> 
> **Overview**
> Bumps workspace **`job`** (0.6.27 → **0.6.28**) and **`obix`** (0.2.27 → **0.2.29**) in `Cargo.toml` and `Cargo.lock` only; no cala source or API changes.
> 
> The **`obix`** upgrade is the meaningful part: **`PersistEvents`** now inserts into **`persistent_outbox_events` in bounded batches** instead of one unbounded `INSERT … SELECT unnest($1::jsonb[])` at commit. That reduces Postgres OOM risk on large recalcs that flood the outbox (e.g. millions of balance events). Cala still builds **`MailboxConfig`** with defaults, so batch sizing comes from the library.
> 
> **`job`** is updated to the latest published version alongside **`obix`**; **`obix-macros`** moves with **`obix`** in the lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76b80a5b9e5cecb59bbaef88e362d4deb4010ed1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->