### PR TITLE
feat(ledger)!: require effective date when voiding a transaction

### DIFF
--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -219,15 +219,20 @@ impl CalaLedger {
         Ok(transaction)
     }
 
+    /// Voids a transaction by posting a new transaction with reversed entries on the
+    /// given effective date — typically the original transaction's effective date while
+    /// the accounting period is still open, or the current date once it is closed. The
+    /// date may not precede the original transaction's effective date.
     #[instrument(name = "cala_ledger.void_transaction", skip(self))]
     pub async fn void_transaction(
         &self,
         voiding_tx_id: TransactionId,
         existing_tx_id: TransactionId,
+        effective: chrono::NaiveDate,
     ) -> Result<Transaction, LedgerError> {
         let mut db = self.begin_operation().await?;
         let transaction = self
-            .void_transaction_in_op(&mut db, voiding_tx_id, existing_tx_id)
+            .void_transaction_in_op(&mut db, voiding_tx_id, existing_tx_id, effective)
             .await?;
         db.commit().await?;
         Ok(transaction)
@@ -243,6 +248,7 @@ impl CalaLedger {
         db: &mut impl es_entity::AtomicOperationWithTime,
         voiding_tx_id: TransactionId,
         existing_tx_id: TransactionId,
+        effective: chrono::NaiveDate,
     ) -> Result<Transaction, LedgerError> {
         let new_entries = self
             .entries
@@ -256,6 +262,7 @@ impl CalaLedger {
                 voiding_tx_id,
                 existing_tx_id,
                 new_entries.iter().map(|entry| entry.id),
+                effective,
             )
             .await?;
 

--- a/cala-ledger/src/transaction/entity.rs
+++ b/cala-ledger/src/transaction/entity.rs
@@ -79,9 +79,17 @@ impl Transaction {
         new_tx_id: TransactionId,
         entry_ids: Vec<EntryId>,
         created_at: chrono::DateTime<chrono::Utc>,
+        effective: chrono::NaiveDate,
     ) -> Result<NewTransaction, TransactionError> {
         if self.is_voided() {
             return Err(TransactionError::AlreadyVoided(self.id));
+        }
+
+        if effective < self.values.effective {
+            return Err(TransactionError::VoidEffectiveBeforeOriginal {
+                effective,
+                original_effective: self.values.effective,
+            });
         }
 
         self.values.voided_by = Some(new_tx_id);
@@ -100,7 +108,7 @@ impl Transaction {
             .tx_template_id(values.tx_template_id)
             .void_of(values.id)
             .entry_ids(entry_ids.into_iter().collect())
-            .effective(created_at.date_naive())
+            .effective(effective)
             .journal_id(values.journal_id)
             .correlation_id(values.correlation_id.clone())
             .created_at(created_at);
@@ -278,15 +286,51 @@ mod tests {
         let new_tx_id = TransactionId::new();
         let entry_ids = vec![EntryId::new()];
         let created_at = chrono::Utc::now();
+        let effective = transaction.effective();
 
-        let new_tx = transaction.void(new_tx_id, entry_ids.clone(), created_at);
+        let new_tx = transaction.void(new_tx_id, entry_ids.clone(), created_at, effective);
         assert!(new_tx.is_ok());
         assert!(transaction.is_voided());
 
         let new_tx = new_tx.unwrap();
         assert_eq!(new_tx.void_of, Some(transaction.id));
+        assert_eq!(new_tx.effective, effective);
 
-        let new_tx = transaction.void(new_tx_id, entry_ids, created_at);
+        let new_tx = transaction.void(new_tx_id, entry_ids, created_at, effective);
         assert!(matches!(new_tx, Err(TransactionError::AlreadyVoided(_))));
+    }
+
+    #[test]
+    fn void_transaction_accepts_effective_after_original() {
+        let mut transaction = transaction();
+        let effective = transaction.effective() + chrono::Days::new(3);
+
+        let new_tx = transaction
+            .void(
+                TransactionId::new(),
+                vec![EntryId::new()],
+                chrono::Utc::now(),
+                effective,
+            )
+            .unwrap();
+        assert_eq!(new_tx.effective, effective);
+    }
+
+    #[test]
+    fn void_transaction_rejects_effective_before_original() {
+        let mut transaction = transaction();
+        let effective = transaction.effective() - chrono::Days::new(1);
+
+        let new_tx = transaction.void(
+            TransactionId::new(),
+            vec![EntryId::new()],
+            chrono::Utc::now(),
+            effective,
+        );
+        assert!(matches!(
+            new_tx,
+            Err(TransactionError::VoidEffectiveBeforeOriginal { .. })
+        ));
+        assert!(!transaction.is_voided());
     }
 }

--- a/cala-ledger/src/transaction/error.rs
+++ b/cala-ledger/src/transaction/error.rs
@@ -28,6 +28,13 @@ pub enum TransactionError {
     DuplicateId(String),
     #[error("TransactionError - AlreadyVoided: transaction '{0}' is already voided")]
     AlreadyVoided(TransactionId),
+    #[error(
+        "TransactionError - VoidEffectiveBeforeOriginal: effective date '{effective}' is before the original transaction's effective date '{original_effective}'"
+    )]
+    VoidEffectiveBeforeOriginal {
+        effective: chrono::NaiveDate,
+        original_effective: chrono::NaiveDate,
+    },
 }
 
 impl TransactionError {

--- a/cala-ledger/src/transaction/mod.rs
+++ b/cala-ledger/src/transaction/mod.rs
@@ -45,10 +45,16 @@ impl Transactions {
         voiding_tx_id: TransactionId,
         existing_tx_id: TransactionId,
         entry_ids: impl IntoIterator<Item = EntryId>,
+        effective: chrono::NaiveDate,
     ) -> Result<Transaction, TransactionError> {
         let mut existing_tx = self.repo.find_by_id_in_op(&mut *db, existing_tx_id).await?;
 
-        let new_tx = existing_tx.void(voiding_tx_id, entry_ids.into_iter().collect(), db.now())?;
+        let new_tx = existing_tx.void(
+            voiding_tx_id,
+            entry_ids.into_iter().collect(),
+            db.now(),
+            effective,
+        )?;
 
         self.repo.update_in_op(db, &mut existing_tx).await?;
         let voided_tx = self.repo.create_in_op(db, new_tx).await?;

--- a/cala-ledger/tests/clock.rs
+++ b/cala-ledger/tests/clock.rs
@@ -143,7 +143,9 @@ async fn void_transaction_uses_clock_time() -> anyhow::Result<()> {
     clock_ctrl.advance(advance_duration).await;
 
     let voiding_tx_id = TransactionId::new();
-    let voided_tx = cala.void_transaction(voiding_tx_id, original_tx_id).await?;
+    let voided_tx = cala
+        .void_transaction(voiding_tx_id, original_tx_id, void_time.date_naive())
+        .await?;
 
     assert_eq!(original_tx.created_at(), original_time);
     assert_eq!(voided_tx.created_at(), void_time);

--- a/cala-ledger/tests/transaction_void.rs
+++ b/cala-ledger/tests/transaction_void.rs
@@ -1,8 +1,10 @@
 mod helpers;
 
+use chrono::NaiveDate;
 use rand::distr::{Alphanumeric, SampleString};
+use rust_decimal_macros::dec;
 
-use cala_ledger::{tx_template::*, *};
+use cala_ledger::{error::LedgerError, transaction::error::TransactionError, tx_template::*, *};
 
 #[tokio::test]
 async fn transaction_post() -> anyhow::Result<()> {
@@ -39,7 +41,11 @@ async fn transaction_post() -> anyhow::Result<()> {
 
     let voiding_tx_id = TransactionId::new();
     let voided_tx = cala
-        .void_transaction(voiding_tx_id, existing_tx_id)
+        .void_transaction(
+            voiding_tx_id,
+            existing_tx_id,
+            chrono::Utc::now().date_naive(),
+        )
         .await
         .unwrap();
 
@@ -59,6 +65,88 @@ async fn transaction_post() -> anyhow::Result<()> {
 
         assert_eq!(-original_entry.values().units, voided_entry.values().units);
     }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn transaction_void_with_effective() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let new_journal = helpers::test_journal_with_effective_balances();
+    let journal = cala.journals().create(new_journal).await.unwrap();
+
+    let (sender, receiver) = helpers::test_accounts();
+    let sender_account = cala.accounts().create(sender).await.unwrap();
+    let recipient_account = cala.accounts().create(receiver).await.unwrap();
+
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    let new_template = helpers::currency_conversion_template(&tx_code);
+    cala.tx_templates().create(new_template).await.unwrap();
+
+    let effective = NaiveDate::from_ymd_opt(2025, 5, 5).unwrap();
+
+    let mut params = Params::new();
+    params.insert("journal_id", journal.id().to_string());
+    params.insert("sender", sender_account.id());
+    params.insert("recipient", recipient_account.id());
+    params.insert("effective", effective);
+
+    let existing_tx_id = TransactionId::new();
+    cala.post_transaction(existing_tx_id, &tx_code, params)
+        .await
+        .unwrap();
+
+    let res = cala
+        .void_transaction(
+            TransactionId::new(),
+            existing_tx_id,
+            effective - chrono::Days::new(1),
+        )
+        .await;
+    assert!(matches!(
+        res,
+        Err(LedgerError::TransactionError(
+            TransactionError::VoidEffectiveBeforeOriginal { .. }
+        ))
+    ));
+
+    let voiding_tx_id = TransactionId::new();
+    let voided_tx = cala
+        .void_transaction(voiding_tx_id, existing_tx_id, effective)
+        .await
+        .unwrap();
+    assert_eq!(voided_tx.effective(), effective);
+
+    let recipient_balance = cala
+        .balances()
+        .effective()
+        .find_cumulative(
+            journal.id(),
+            recipient_account.id(),
+            Currency::BTC,
+            effective,
+        )
+        .await?;
+    assert_eq!(recipient_balance.settled(), dec!(0));
+
+    let recipient_balance = cala
+        .balances()
+        .effective()
+        .find_cumulative(
+            journal.id(),
+            recipient_account.id(),
+            Currency::USD,
+            effective,
+        )
+        .await?;
+    assert_eq!(recipient_balance.settled(), dec!(0));
+    assert_eq!(recipient_balance.pending(), dec!(0));
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

`void_transaction` hardcoded the reversal's effective date to the void day (`Transaction::void` used `created_at.date_naive()`), with no way to override it. Voiding a backdated transaction therefore left the effective-balance timeline asymmetric: the original delta stayed on its effective date while the reversal landed on the void date — both periods' activity was permanently distorted. Standard correction accounting wants same-period reversal while the period is open, current-period reversal once it is closed.

Rather than keeping the void-day default alongside a new variant, the effective date is now a required parameter: dating a reversal is an accounting decision the caller should make explicitly, and a silent "today" default is exactly the footgun this removes.

## Changes

- `CalaLedger::void_transaction` / `void_transaction_in_op` take an explicit `effective: NaiveDate` for the reversal entries.
- `Transaction::void` rejects an effective date earlier than the original transaction's with a new `TransactionError::VoidEffectiveBeforeOriginal` — a reversal dated before the thing it reverses is never coherent.
- `Transactions::create_voided_tx_in_op` gains the same required parameter.

**BREAKING**: all three methods change signature. Callers wanting the previous behaviour pass their clock's current date.

Everything downstream is untouched on purpose: the reversal flows through the normal posting path, so a backdated void gets the same effective-balance cascade (rollforward of later cumulative snapshots) as any backdated post, and velocity controls evaluate `transaction.effective` from the actual transaction values — meaning period-close controls (e.g. lana-bank's closing velocity control) correctly block voids into closed periods.

## Tests

- Unit: void on the original effective date; effective after original accepted; effective before original rejected without mutating the entity.
- Integration (`transaction_void_with_effective`): posts on an effective date, asserts the too-early void is rejected, then voids on the original date and asserts cumulative effective balances (BTC + USD, settled + pending) net to zero on that date.
- Full `cala-ledger` suite passes (85/85); event schemas unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)