### PR TITLE
fix(account_set): per-hierarchy locks for membership mutations

### DIFF
--- a/cala-ledger/.sqlx/query-089ea282c32176080fdf70f1d1b62d649ddf49e4333effc13729bbeb395190b7.json
+++ b/cala-ledger/.sqlx/query-089ea282c32176080fdf70f1d1b62d649ddf49e4333effc13729bbeb395190b7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT pg_advisory_xact_lock($1)",
+  "query": "SELECT pg_advisory_xact_lock($1, hashtext($2))",
   "describe": {
     "columns": [
       {
@@ -11,12 +11,13 @@
     ],
     "parameters": {
       "Left": [
-        "Int8"
+        "Int4",
+        "Text"
       ]
     },
     "nullable": [
       null
     ]
   },
-  "hash": "a06e1d9f6f95e4c4c2b98310ebddcc9d963cc033582bf2e945e8bf3a301b4247"
+  "hash": "089ea282c32176080fdf70f1d1b62d649ddf49e4333effc13729bbeb395190b7"
 }

--- a/cala-ledger/.sqlx/query-560691fb005e383aa976c373f991ec2f07fe95719a433a50ddcd278b7ff549ea.json
+++ b/cala-ledger/.sqlx/query-560691fb005e383aa976c373f991ec2f07fe95719a433a50ddcd278b7ff549ea.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT CASE\n              WHEN $1 THEN pg_advisory_xact_lock($2, v.lock_key)\n              ELSE pg_advisory_xact_lock_shared($2, v.lock_key)\n            END\n            FROM UNNEST($3::int4[]) AS v(lock_key)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock_shared",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Int4",
+        "Int4Array"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "560691fb005e383aa976c373f991ec2f07fe95719a433a50ddcd278b7ff549ea"
+}

--- a/cala-ledger/.sqlx/query-db8959beab746efcf959b4d4a81d2455d95e17b69a40044c0d228f47c302f2e6.json
+++ b/cala-ledger/.sqlx/query-db8959beab746efcf959b4d4a81d2455d95e17b69a40044c0d228f47c302f2e6.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH RECURSIVE parents AS (\n              SELECT m.account_set_id\n              FROM cala_account_set_member_account_sets m\n              WHERE m.member_account_set_id = ANY($1)\n\n              UNION\n              SELECT m.account_set_id\n              FROM parents p\n              JOIN cala_account_set_member_account_sets m\n                ON m.member_account_set_id = p.account_set_id\n            )\n            SELECT DISTINCT hashtext(node_id::text) AS \"lock_key!\"\n            FROM (\n              SELECT account_set_id AS node_id FROM parents\n              UNION\n              SELECT UNNEST($1::uuid[])\n            ) nodes\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "lock_key!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "db8959beab746efcf959b4d4a81d2455d95e17b69a40044c0d228f47c302f2e6"
+}

--- a/cala-ledger/src/account_set/error.rs
+++ b/cala-ledger/src/account_set/error.rs
@@ -48,6 +48,11 @@ pub enum AccountSetError {
          only eventually-consistent sets support recalculation"
     )]
     CannotRecalculateNonEcSet { account_set_id: AccountSetId },
+    #[error(
+        "AccountSetError - Gave up locking the account-set hierarchy: \
+         concurrent structure mutations kept growing the ancestor chain"
+    )]
+    HierarchyLockContention,
 }
 
 impl From<AccountSetFindError> for AccountSetError {

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -12,7 +12,154 @@ use crate::{
 
 use super::{entity::*, error::*};
 
-const ADDVISORY_LOCK_ID: i64 = 123456;
+/// `classid` namespace for the per-set hierarchy advisory locks (2-arg
+/// form), keyed on `hashtext(<account set id>)`. Must stay disjoint
+/// from `EC_SET_LOCK_CLASS` (= 1) used by balance locking.
+///
+/// Membership maintenance is a read-then-write over an ancestor chain:
+/// each mutation walks the set-to-set edges upward (the recursive
+/// `parents` CTE) and then writes the transitive-closure rows the walk
+/// justifies. Two concurrent mutations that each miss the other's
+/// uncommitted writes would leave the closure table inconsistent
+/// (write-skew), so every mutation locks its whole scope — the target
+/// set(s) plus all their ancestors — before walking, and the locks are
+/// transaction-scoped so the walk's snapshot stays valid until the
+/// writes commit.
+///
+/// Lock modes:
+///
+/// - Set-structure mutations (`add_member_set` / `remove_member_set`)
+///   take EXCLUSIVE locks on their scope. They mutate the edges that
+///   every walk reads, and read the member rows that account-member
+///   mutations write, so they must exclude everything whose scope
+///   overlaps theirs.
+/// - Account-member mutations (`add_member_account` /
+///   `remove_member_account`) take SHARED locks on their scope plus an
+///   EXCLUSIVE per-member lock ([`MEMBER_LOCK_CLASS`]). Account-member
+///   mutations only read the edges, and their closure writes for
+///   different members are disjoint rows, so they can share a scope;
+///   the per-member lock serializes mutations touching the *same*
+///   member (e.g. an add and a remove in overlapping hierarchies),
+///   whose interleaved inserts/deletes on shared ancestors would
+///   otherwise tear the closure.
+///
+/// Mutations on disjoint hierarchies take disjoint locks and no longer
+/// contend at all (previously a single global advisory lock serialized
+/// every membership mutation ledger-wide).
+const SET_HIERARCHY_LOCK_CLASS: i32 = 2;
+
+/// `classid` namespace for the per-member advisory locks (2-arg form),
+/// keyed on `hashtext(<member account id>)`. See
+/// [`SET_HIERARCHY_LOCK_CLASS`].
+const MEMBER_LOCK_CLASS: i32 = 3;
+
+/// Bound on lock/re-walk rounds in [`lock_membership_scope`]. Each
+/// extra round requires a concurrent structure mutation to have grown
+/// the ancestor chain mid-acquisition, so in practice one verification
+/// round suffices; the bound only guards against livelock under
+/// pathological structure churn.
+const MAX_LOCK_ROUNDS: usize = 5;
+
+/// Locks the membership-mutation scope: `seed_ids` plus all their
+/// ancestors (via [`SET_HIERARCHY_LOCK_CLASS`] locks, SHARED unless
+/// `exclusive`), then `member_account_id` if given (EXCLUSIVE
+/// [`MEMBER_LOCK_CLASS`] lock).
+///
+/// The chain is discovered by walking the edges, but the walk itself
+/// needs the locks to be stable — so acquisition loops: walk, lock the
+/// newly discovered nodes (in canonical lock-key order), re-walk, and
+/// finish once a walk discovers nothing unlocked. A re-walk can only
+/// differ if a concurrent structure mutation committed an edge into the
+/// chain between our walk and our lock acquisition; once every node of
+/// the current chain is locked, further structure mutations touching it
+/// block on us and the chain can no longer change.
+///
+/// Locks acquired in later rounds (and across multiple membership calls
+/// in one transaction) do not follow the canonical order, so conflicting
+/// acquisitions can in rare cases deadlock instead of queueing; Postgres
+/// detects and aborts one transaction (SQLSTATE 40P01), which callers
+/// should treat as retryable. The per-member lock is acquired last —
+/// never wait on chain locks while holding a member lock other
+/// transactions may queue on.
+async fn lock_membership_scope(
+    db: &mut impl es_entity::AtomicOperation,
+    seed_ids: &[AccountSetId],
+    member_account_id: Option<AccountId>,
+    exclusive: bool,
+) -> Result<(), AccountSetError> {
+    let mut held: std::collections::HashSet<i32> = std::collections::HashSet::new();
+    let mut stable = false;
+    for _ in 0..MAX_LOCK_ROUNDS {
+        let chain = sqlx::query!(
+            r#"
+            WITH RECURSIVE parents AS (
+              SELECT m.account_set_id
+              FROM cala_account_set_member_account_sets m
+              WHERE m.member_account_set_id = ANY($1)
+
+              UNION
+              SELECT m.account_set_id
+              FROM parents p
+              JOIN cala_account_set_member_account_sets m
+                ON m.member_account_set_id = p.account_set_id
+            )
+            SELECT DISTINCT hashtext(node_id::text) AS "lock_key!"
+            FROM (
+              SELECT account_set_id AS node_id FROM parents
+              UNION
+              SELECT UNNEST($1::uuid[])
+            ) nodes
+            "#,
+            seed_ids as &[AccountSetId],
+        )
+        .fetch_all(db.as_executor())
+        .await?;
+
+        let mut missing: Vec<i32> = chain
+            .into_iter()
+            .map(|row| row.lock_key)
+            .filter(|key| !held.contains(key))
+            .collect();
+        if missing.is_empty() {
+            stable = true;
+            break;
+        }
+        // Canonical order within the batch so concurrent overlapping
+        // acquisitions queue instead of deadlocking. Sorting has to
+        // happen on the input array: the planner is free to evaluate
+        // the lock calls before any SQL-level sort node.
+        missing.sort_unstable();
+        sqlx::query!(
+            r#"
+            SELECT CASE
+              WHEN $1 THEN pg_advisory_xact_lock($2, v.lock_key)
+              ELSE pg_advisory_xact_lock_shared($2, v.lock_key)
+            END
+            FROM UNNEST($3::int4[]) AS v(lock_key)
+            "#,
+            exclusive,
+            SET_HIERARCHY_LOCK_CLASS,
+            &missing as &[i32],
+        )
+        .execute(db.as_executor())
+        .await?;
+        held.extend(missing);
+    }
+    if !stable {
+        return Err(AccountSetError::HierarchyLockContention);
+    }
+
+    if let Some(account_id) = member_account_id {
+        sqlx::query!(
+            "SELECT pg_advisory_xact_lock($1, hashtext($2))",
+            MEMBER_LOCK_CLASS,
+            account_id.to_string(),
+        )
+        .execute(db.as_executor())
+        .await?;
+    }
+    Ok(())
+}
 
 pub mod members_cursor {
     use cala_types::account_set::{
@@ -367,9 +514,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         account_id: AccountId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
-        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
-            .execute(db.as_executor())
-            .await?;
+        lock_membership_scope(db, &[account_set_id], Some(account_id), false).await?;
         let rows = sqlx::query!(r#"
           WITH RECURSIVE parents AS (
             SELECT m.member_account_set_id, m.account_set_id
@@ -442,9 +587,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         account_id: AccountId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
-        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
-            .execute(db.as_executor())
-            .await?;
+        lock_membership_scope(db, &[account_set_id], Some(account_id), false).await?;
         let rows = sqlx::query!(
             r#"
           WITH RECURSIVE parents AS (
@@ -514,9 +657,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         member_account_set_id: AccountSetId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
-        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
-            .execute(db.as_executor())
-            .await?;
+        lock_membership_scope(db, &[account_set_id, member_account_set_id], None, true).await?;
         let rows = sqlx::query!(r#"
           WITH RECURSIVE parents AS (
             SELECT m.member_account_set_id, m.account_set_id
@@ -599,9 +740,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         member_account_set_id: AccountSetId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
-        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
-            .execute(db.as_executor())
-            .await?;
+        lock_membership_scope(db, &[account_set_id, member_account_set_id], None, true).await?;
         let rows = sqlx::query!(
             r#"
           WITH RECURSIVE parents AS (

--- a/cala-ledger/tests/account_set_membership_locks.rs
+++ b/cala-ledger/tests/account_set_membership_locks.rs
@@ -1,0 +1,395 @@
+//! Concurrency tests for the account-set membership lock protocol.
+//!
+//! Membership mutations lock their scope — the target set(s) plus all
+//! ancestors — instead of a single global lock: account-member
+//! mutations take SHARED scope locks plus an exclusive per-member lock,
+//! set-structure mutations take EXCLUSIVE scope locks. Mutations on
+//! disjoint hierarchies do not contend at all.
+//!
+//! The blocking assertions work by holding one operation's transaction
+//! open and observing whether a second operation completes (bounded by a
+//! generous timeout) or stays pending until the first commits.
+//!
+//! Because these tests hold membership locks open on purpose, they must
+//! not share lock scope with anything else: an open SHARED holder plus a
+//! queued EXCLUSIVE waiter from an unrelated test would stall every later
+//! SHARED request (PostgreSQL queues conflicting requests FIFO). Advisory
+//! locks are scoped per database, so each test creates its own throwaway
+//! database instead of using the shared `PG_CON` one.
+
+mod helpers;
+
+use std::time::Duration;
+
+use rand::distr::{Alphanumeric, SampleString};
+
+use cala_ledger::{account_set::*, *};
+
+/// Generous bound for "this must not block": under the old global
+/// exclusive lock the future would stay pending until the other
+/// transaction commits, so a completion within this window proves the
+/// operations do not exclude each other.
+const MUST_COMPLETE: Duration = Duration::from_secs(5);
+/// Observation window for "this must block": long enough to rule out
+/// scheduling noise, short enough to keep the suite fast.
+const MUST_STILL_BE_PENDING: Duration = Duration::from_millis(300);
+
+/// Creates a dedicated database (isolating this test's advisory locks),
+/// runs migrations, and returns a pool connected to it.
+async fn init_isolated_pool(max_connections: u32) -> anyhow::Result<sqlx::PgPool> {
+    let pg_con = std::env::var("PG_CON")?;
+    let admin_pool = sqlx::PgPool::connect(&pg_con).await?;
+    let db_name = format!(
+        "membership_locks_{}",
+        Alphanumeric
+            .sample_string(&mut rand::rng(), 12)
+            .to_lowercase()
+    );
+    sqlx::query(&format!(r#"CREATE DATABASE "{db_name}""#))
+        .execute(&admin_pool)
+        .await?;
+    let (base, _) = pg_con
+        .rsplit_once('/')
+        .expect("PG_CON has no database path");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(max_connections)
+        .acquire_timeout(Duration::from_secs(60))
+        .connect(&format!("{base}/{db_name}"))
+        .await?;
+    // Unlike `helpers::init_pool` this must not append the job crate's
+    // migrations: they share a version id with cala's own `job_setup`
+    // migration, which double-applies on a freshly created database.
+    sqlx::migrate!().run(&pool).await?;
+    Ok(pool)
+}
+
+async fn init_cala() -> anyhow::Result<CalaLedger> {
+    let pool = init_isolated_pool(10).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    Ok(CalaLedger::init(cala_config).await?)
+}
+
+fn new_set(journal_id: JournalId, name: &str) -> NewAccountSet {
+    NewAccountSet::builder()
+        .id(AccountSetId::new())
+        .name(name)
+        .journal_id(journal_id)
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn account_member_ops_for_different_members_run_concurrently() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, two) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let two = cala.accounts().create(two).await?;
+    // Same set: account-member mutations take their scope SHARED, so
+    // even a shared hierarchy must not serialize different members.
+    let set = cala
+        .account_sets()
+        .create(new_set(journal.id(), "concurrent-members"))
+        .await?;
+
+    // Hold an uncommitted account-member add open...
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, set.id(), one.id())
+        .await?;
+
+    // ...a second add for a *different* member must not wait for it.
+    tokio::time::timeout(
+        MUST_COMPLETE,
+        cala.account_sets().add_member(set.id(), two.id()),
+    )
+    .await
+    .expect("account-member adds for different members must not serialize")?;
+
+    op.commit().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn account_member_ops_for_same_member_serialize() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, _) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let set_one = cala
+        .account_sets()
+        .create(new_set(journal.id(), "same-member-1"))
+        .await?;
+    let set_two = cala
+        .account_sets()
+        .create(new_set(journal.id(), "same-member-2"))
+        .await?;
+
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, set_one.id(), one.id())
+        .await?;
+
+    // An add of the *same* member elsewhere must wait for the open
+    // transaction (per-member exclusive lock).
+    let cala2 = cala.clone();
+    let set_two_id = set_two.id();
+    let member_id = one.id();
+    let mut blocked =
+        tokio::spawn(async move { cala2.account_sets().add_member(set_two_id, member_id).await });
+
+    assert!(
+        tokio::time::timeout(MUST_STILL_BE_PENDING, &mut blocked)
+            .await
+            .is_err(),
+        "same-member add must block while the first transaction is open"
+    );
+
+    op.commit().await?;
+    blocked.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn structure_ops_fence_overlapping_account_member_ops() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, _) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let parent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "fence-parent"))
+        .await?;
+    let child = cala
+        .account_sets()
+        .create(new_set(journal.id(), "fence-child"))
+        .await?;
+
+    // Hold an uncommitted structure mutation open (exclusive scope
+    // locks on child, parent, and parent's ancestors)...
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, parent.id(), child.id())
+        .await?;
+
+    // ...an account-member mutation whose scope overlaps (the child set
+    // is locked exclusive) must wait for it.
+    let cala2 = cala.clone();
+    let child_id = child.id();
+    let member_id = one.id();
+    let mut blocked =
+        tokio::spawn(async move { cala2.account_sets().add_member(child_id, member_id).await });
+
+    assert!(
+        tokio::time::timeout(MUST_STILL_BE_PENDING, &mut blocked)
+            .await
+            .is_err(),
+        "overlapping account-member add must block while the structure mutation is open"
+    );
+
+    op.commit().await?;
+    blocked.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn disjoint_hierarchies_do_not_contend() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, _) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let parent_a = cala
+        .account_sets()
+        .create(new_set(journal.id(), "disjoint-parent-a"))
+        .await?;
+    let child_a = cala
+        .account_sets()
+        .create(new_set(journal.id(), "disjoint-child-a"))
+        .await?;
+    let parent_b = cala
+        .account_sets()
+        .create(new_set(journal.id(), "disjoint-parent-b"))
+        .await?;
+    let child_b = cala
+        .account_sets()
+        .create(new_set(journal.id(), "disjoint-child-b"))
+        .await?;
+    let unrelated = cala
+        .account_sets()
+        .create(new_set(journal.id(), "disjoint-unrelated"))
+        .await?;
+
+    // Hold an uncommitted structure mutation open in hierarchy A...
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, parent_a.id(), child_a.id())
+        .await?;
+
+    // ...a structure mutation in hierarchy B must not wait for it...
+    tokio::time::timeout(
+        MUST_COMPLETE,
+        cala.account_sets().add_member(parent_b.id(), child_b.id()),
+    )
+    .await
+    .expect("disjoint structure mutations must not serialize")?;
+
+    // ...and neither must an account-member mutation on an unrelated set.
+    tokio::time::timeout(
+        MUST_COMPLETE,
+        cala.account_sets().add_member(unrelated.id(), one.id()),
+    )
+    .await
+    .expect("account-member add on a disjoint hierarchy must not serialize")?;
+
+    op.commit().await?;
+    Ok(())
+}
+
+/// Write-skew guard: many concurrent account-member adds into a shared
+/// deep hierarchy must leave a complete transitive closure.
+#[tokio::test]
+async fn concurrent_adds_maintain_transitive_closure() -> anyhow::Result<()> {
+    const N_MEMBERS: usize = 16;
+
+    let pool = init_isolated_pool(20).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    // grandparent <- parent <- leaf
+    let grandparent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "closure-grandparent"))
+        .await?;
+    let parent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "closure-parent"))
+        .await?;
+    let leaf = cala
+        .account_sets()
+        .create(new_set(journal.id(), "closure-leaf"))
+        .await?;
+    cala.account_sets()
+        .add_member(grandparent.id(), parent.id())
+        .await?;
+    cala.account_sets()
+        .add_member(parent.id(), leaf.id())
+        .await?;
+
+    let mut accounts = Vec::new();
+    for _ in 0..N_MEMBERS {
+        let (new_account, _) = helpers::test_accounts();
+        accounts.push(cala.accounts().create(new_account).await?);
+    }
+
+    let mut handles = Vec::new();
+    for account in &accounts {
+        let cala = cala.clone();
+        let leaf_id = leaf.id();
+        let account_id = account.id();
+        handles.push(tokio::spawn(async move {
+            cala.account_sets().add_member(leaf_id, account_id).await
+        }));
+    }
+    for handle in handles {
+        handle.await??;
+    }
+
+    // Every account must have its direct row on the leaf and transitive
+    // rows on every ancestor.
+    for set_id in [leaf.id(), parent.id(), grandparent.id()] {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM cala_account_set_member_accounts
+            WHERE account_set_id = $1 AND member_account_id = ANY($2)
+            "#,
+        )
+        .bind(uuid::Uuid::from(set_id))
+        .bind(
+            accounts
+                .iter()
+                .map(|a| uuid::Uuid::from(a.id()))
+                .collect::<Vec<_>>(),
+        )
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(
+            count as usize, N_MEMBERS,
+            "closure rows missing on set {set_id}"
+        );
+    }
+
+    Ok(())
+}
+
+/// Write-skew guard for the account-add vs. set-attach race: an account
+/// added to a child set concurrently with the child being attached to a
+/// parent must always end up with closure rows on the parent chain,
+/// regardless of which transaction wins.
+#[tokio::test]
+async fn concurrent_attach_and_add_maintain_transitive_closure() -> anyhow::Result<()> {
+    const N_ROUNDS: usize = 12;
+
+    let pool = init_isolated_pool(20).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    for round in 0..N_ROUNDS {
+        let parent = cala
+            .account_sets()
+            .create(new_set(journal.id(), &format!("attach-parent-{round}")))
+            .await?;
+        let child = cala
+            .account_sets()
+            .create(new_set(journal.id(), &format!("attach-child-{round}")))
+            .await?;
+        let (new_account, _) = helpers::test_accounts();
+        let account = cala.accounts().create(new_account).await?;
+
+        let attach = {
+            let cala = cala.clone();
+            let (parent_id, child_id) = (parent.id(), child.id());
+            tokio::spawn(async move { cala.account_sets().add_member(parent_id, child_id).await })
+        };
+        let add = {
+            let cala = cala.clone();
+            let (child_id, account_id) = (child.id(), account.id());
+            tokio::spawn(async move { cala.account_sets().add_member(child_id, account_id).await })
+        };
+        attach.await??;
+        add.await??;
+
+        for set_id in [child.id(), parent.id()] {
+            let count = sqlx::query_scalar::<_, i64>(
+                r#"
+                SELECT COUNT(*) FROM cala_account_set_member_accounts
+                WHERE account_set_id = $1 AND member_account_id = $2
+                "#,
+            )
+            .bind(uuid::Uuid::from(set_id))
+            .bind(uuid::Uuid::from(account.id()))
+            .fetch_one(&pool)
+            .await?;
+            assert_eq!(
+                count, 1,
+                "round {round}: closure row missing on set {set_id}"
+            );
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Addresses #746 — suggestion 1 (fine-grained, per-hierarchy locking). Companion draft: #748 implements the minimal alternative (keep the coarse key, split lock modes); the two are **alternatives**, not stackable as-is.

## Problem

Every account-set membership mutation takes the single global advisory lock `ADDVISORY_LOCK_ID = 123456` in exclusive mode, and — being xact-scoped — holds it until the *enclosing* transaction commits. Callers like lana-bank batch ~10 membership adds inside large transactions (account creation + posting + balances), so under concurrent load every membership-touching transaction in the whole ledger serializes. On lana's staging sim this was the top query by total DB time (1,126 calls, 451 ms avg wait in 3.5 min; observed queue of 1 holder + 7 waiters; worst `add_member_in_op` span 32.8 s of pure lock wait). Full evidence in #746.

## Change

Lock only the hierarchy a mutation actually touches: the target set(s) plus all ancestors, one 2-arg advisory lock per set node (`classid 2`, `hashtext(set_id)`), plus:

- **Account-member mutations** (`add/remove_member_account`): scope locks **SHARED** + an **EXCLUSIVE per-member lock** (`classid 3`, `hashtext(member_account_id)`). They only *read* the edges, and closure writes for different members are disjoint rows — so they no longer exclude each other at all. The per-member lock still serializes add/remove of the *same* member in overlapping hierarchies, whose interleaved inserts/deletes on shared ancestors would otherwise tear the closure.
- **Set-structure mutations** (`add/remove_member_set`): scope locks **EXCLUSIVE** — they mutate the edges every walk reads and read the member rows account-member mutations write.

Mutations on disjoint hierarchies no longer contend at all.

### Why the walk-then-lock loop

The lock scope is discovered by walking the edges, but the walk itself needs the locks to be stable (a structure mutation can commit an edge between our walk and our acquisition). So `lock_membership_scope` loops: walk → lock newly discovered nodes in canonical key order → re-walk → done once a walk discovers nothing unlocked. Once the whole current chain is locked, any structure mutation touching it blocks on us, so the chain can no longer change. Bounded by `MAX_LOCK_ROUNDS`, then `AccountSetError::HierarchyLockContention` (retryable).

### Why the locks stay xact-scoped

Each mutation is a read-then-write over the ancestor chain; the walk's snapshot must stay valid until the writes commit. Releasing earlier reopens the write-skew where a concurrent account-add and set-attach each miss the other's uncommitted rows and the parent chain silently loses closure rows. (This is why "just hold the lock for less time" is not implementable — the hold-to-commit is load-bearing; what this PR shrinks is the *conflict scope*.)

## Tradeoffs (called out in code docs too)

- **Deadlock-instead-of-queue in rare interleavings**: later-round acquisitions and multiple membership calls in one transaction do not follow the canonical lock order, so crossing a concurrent structure mutation can deadlock. Postgres detects and aborts one transaction (SQLSTATE 40P01) — callers should treat it as retryable. The global mutex precluded this by serializing everything; that is the price of the concurrency.
- **Rolling deploys are NOT mutually safe**: old binaries hold the retired global key, new ones the per-node keys — they would not conflict during a mixed rollout. Deploy atomically, or ship an intermediate version that takes both (the mode-split draft PR is exactly such a safe intermediate).
- `hashtext` collisions only cause spurious contention, never unsafety.

## Testing

- New `tests/account_set_membership_locks.rs`:
  - different members don't serialize (fails on `main` by lock-wait timeout);
  - disjoint hierarchies don't contend — including two structure mutations (fails on `main`);
  - same-member ops and overlapping structure-vs-account ops still block (regression guards);
  - two write-skew race guards: 16 concurrent adds into a 3-deep hierarchy, and 12 rounds of racing `attach(parent, child)` vs `add(child, account)` — closure completeness asserted from the table.
  - Each test creates a throwaway database: these tests hold advisory locks open on purpose, and advisory locks are per-database, so sharing `PG_CON`'s database with other suites would cause FIFO-queue interference.
- Full `cala-ledger` suite: 88/88 pass (including `ec_recalc_race` and `add_member_multi_call_no_deadlock_with_posters`).

Draft because: (a) the deadlock-retry and rolling-deploy tradeoffs above deserve maintainer sign-off; (b) we'd like to load-test it against the lana-bank staging environment that reproduces the convoy continuously before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
