### PR TITLE
fix(account_set): stop serializing account-member ops on the global membership lock

### DIFF
--- a/cala-ledger/.sqlx/query-089ea282c32176080fdf70f1d1b62d649ddf49e4333effc13729bbeb395190b7.json
+++ b/cala-ledger/.sqlx/query-089ea282c32176080fdf70f1d1b62d649ddf49e4333effc13729bbeb395190b7.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_advisory_xact_lock($1, hashtext($2))",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "089ea282c32176080fdf70f1d1b62d649ddf49e4333effc13729bbeb395190b7"
+}

--- a/cala-ledger/.sqlx/query-0adaf45623673e3453f08755801f533c15c19b5350e5d6fa1a92dd1486391830.json
+++ b/cala-ledger/.sqlx/query-0adaf45623673e3453f08755801f533c15c19b5350e5d6fa1a92dd1486391830.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT pg_advisory_xact_lock_shared($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock_shared",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "0adaf45623673e3453f08755801f533c15c19b5350e5d6fa1a92dd1486391830"
+}

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -12,7 +12,67 @@ use crate::{
 
 use super::{entity::*, error::*};
 
+/// Coarse advisory lock guarding the account-set membership graph
+/// (`cala_account_set_member_accounts` and
+/// `cala_account_set_member_account_sets`).
+///
+/// Membership maintenance is a read-then-write over the whole ancestor
+/// chain: each mutation walks the set-to-set edges (the recursive
+/// `parents` CTE) and then writes the transitive-closure rows the walk
+/// justifies. Two concurrent mutations that each miss the other's
+/// uncommitted writes would leave the closure table inconsistent
+/// (write-skew), so the walk's snapshot has to stay valid until the
+/// writes commit — which is why every lock here is transaction-scoped
+/// and held to commit; releasing earlier would reopen the race.
+///
+/// Lock protocol:
+///
+/// - Set-structure mutations (`add_member_set` / `remove_member_set`)
+///   take this lock EXCLUSIVE. They mutate the edges that every walk
+///   reads, and read the member rows that account-member mutations
+///   write, so they must exclude everything.
+/// - Account-member mutations (`add_member_account` /
+///   `remove_member_account`) take this lock SHARED plus an EXCLUSIVE
+///   per-member lock (`MEMBER_LOCK_CLASS`, keyed on the member account
+///   id). Shared-vs-exclusive fences them against structure mutations,
+///   while account-member mutations for *different* members run
+///   concurrently — their closure writes are disjoint rows. The
+///   per-member lock serializes mutations touching the *same* member
+///   (e.g. an add and a remove in overlapping hierarchies), whose
+///   interleaved inserts/deletes on shared ancestors would otherwise
+///   tear the closure.
+///
+/// Ordering: the coarse lock is always acquired before the per-member
+/// lock. An operation must never wait on the coarse lock while holding
+/// a per-member lock — under PostgreSQL's FIFO lock queueing that can
+/// form a wait cycle with a queued exclusive (structure) waiter.
 const ADDVISORY_LOCK_ID: i64 = 123456;
+
+/// `classid` namespace for the per-member advisory locks (2-arg form),
+/// keyed on `hashtext(<member account id>)`. Must stay disjoint from
+/// `EC_SET_LOCK_CLASS` (= 1) used by balance locking.
+const MEMBER_LOCK_CLASS: i32 = 2;
+
+/// Takes the account-member half of the membership lock protocol (see
+/// [`ADDVISORY_LOCK_ID`]): SHARED coarse lock, then EXCLUSIVE
+/// per-member lock. Two statements so the acquisition order is
+/// guaranteed.
+async fn lock_for_account_member_op(
+    db: &mut impl es_entity::AtomicOperation,
+    account_id: AccountId,
+) -> Result<(), AccountSetError> {
+    sqlx::query!("SELECT pg_advisory_xact_lock_shared($1)", ADDVISORY_LOCK_ID)
+        .execute(db.as_executor())
+        .await?;
+    sqlx::query!(
+        "SELECT pg_advisory_xact_lock($1, hashtext($2))",
+        MEMBER_LOCK_CLASS,
+        account_id.to_string(),
+    )
+    .execute(db.as_executor())
+    .await?;
+    Ok(())
+}
 
 pub mod members_cursor {
     use cala_types::account_set::{
@@ -367,9 +427,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         account_id: AccountId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
-        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
-            .execute(db.as_executor())
-            .await?;
+        lock_for_account_member_op(db, account_id).await?;
         let rows = sqlx::query!(r#"
           WITH RECURSIVE parents AS (
             SELECT m.member_account_set_id, m.account_set_id
@@ -442,9 +500,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         account_id: AccountId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
-        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
-            .execute(db.as_executor())
-            .await?;
+        lock_for_account_member_op(db, account_id).await?;
         let rows = sqlx::query!(
             r#"
           WITH RECURSIVE parents AS (
@@ -514,6 +570,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         member_account_set_id: AccountSetId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
+        // Structure mutation: EXCLUSIVE coarse lock (see ADDVISORY_LOCK_ID).
         sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
             .execute(db.as_executor())
             .await?;
@@ -599,6 +656,7 @@ impl AccountSetRepo {
         account_set_id: AccountSetId,
         member_account_set_id: AccountSetId,
     ) -> Result<(DateTime<Utc>, Vec<AccountSetId>), AccountSetError> {
+        // Structure mutation: EXCLUSIVE coarse lock (see ADDVISORY_LOCK_ID).
         sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
             .execute(db.as_executor())
             .await?;

--- a/cala-ledger/tests/account_set_membership_locks.rs
+++ b/cala-ledger/tests/account_set_membership_locks.rs
@@ -1,0 +1,288 @@
+//! Concurrency tests for the account-set membership lock protocol.
+//!
+//! Account-member mutations (add/remove an *account* to/from a set) take
+//! the coarse membership lock SHARED plus an exclusive per-member lock,
+//! so mutations for different members run concurrently. Set-structure
+//! mutations (add/remove a member *set*) take the coarse lock EXCLUSIVE
+//! and fence everything.
+//!
+//! The blocking assertions work by holding one operation's transaction
+//! open and observing whether a second operation completes (bounded by a
+//! generous timeout) or stays pending until the first commits.
+//!
+//! Because these tests hold membership locks open on purpose, they must
+//! not share lock scope with anything else: an open SHARED holder plus a
+//! queued EXCLUSIVE waiter from an unrelated test would stall every later
+//! SHARED request (PostgreSQL queues conflicting requests FIFO). Advisory
+//! locks are scoped per database, so each test creates its own throwaway
+//! database instead of using the shared `PG_CON` one.
+
+mod helpers;
+
+use std::time::Duration;
+
+use rand::distr::{Alphanumeric, SampleString};
+
+use cala_ledger::{account_set::*, *};
+
+/// Generous bound for "this must not block": under the old global
+/// exclusive lock the future would stay pending until the other
+/// transaction commits, so a completion within this window proves the
+/// operations do not exclude each other.
+const MUST_COMPLETE: Duration = Duration::from_secs(5);
+/// Observation window for "this must block": long enough to rule out
+/// scheduling noise, short enough to keep the suite fast.
+const MUST_STILL_BE_PENDING: Duration = Duration::from_millis(300);
+
+/// Creates a dedicated database (isolating this test's advisory locks),
+/// runs migrations, and returns a pool connected to it.
+async fn init_isolated_pool(max_connections: u32) -> anyhow::Result<sqlx::PgPool> {
+    let pg_con = std::env::var("PG_CON")?;
+    let admin_pool = sqlx::PgPool::connect(&pg_con).await?;
+    let db_name = format!(
+        "membership_locks_{}",
+        Alphanumeric
+            .sample_string(&mut rand::rng(), 12)
+            .to_lowercase()
+    );
+    sqlx::query(&format!(r#"CREATE DATABASE "{db_name}""#))
+        .execute(&admin_pool)
+        .await?;
+    let (base, _) = pg_con
+        .rsplit_once('/')
+        .expect("PG_CON has no database path");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(max_connections)
+        .acquire_timeout(Duration::from_secs(60))
+        .connect(&format!("{base}/{db_name}"))
+        .await?;
+    // Unlike `helpers::init_pool` this must not append the job crate's
+    // migrations: they share a version id with cala's own `job_setup`
+    // migration, which double-applies on a freshly created database.
+    sqlx::migrate!().run(&pool).await?;
+    Ok(pool)
+}
+
+async fn init_cala() -> anyhow::Result<CalaLedger> {
+    let pool = init_isolated_pool(10).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    Ok(CalaLedger::init(cala_config).await?)
+}
+
+fn new_set(journal_id: JournalId, name: &str) -> NewAccountSet {
+    NewAccountSet::builder()
+        .id(AccountSetId::new())
+        .name(name)
+        .journal_id(journal_id)
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn account_member_ops_for_different_members_run_concurrently() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, two) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let two = cala.accounts().create(two).await?;
+    let set_one = cala
+        .account_sets()
+        .create(new_set(journal.id(), "concurrent-members-1"))
+        .await?;
+    let set_two = cala
+        .account_sets()
+        .create(new_set(journal.id(), "concurrent-members-2"))
+        .await?;
+
+    // Hold an uncommitted account-member add open...
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, set_one.id(), one.id())
+        .await?;
+
+    // ...a second add for a *different* member must not wait for it.
+    tokio::time::timeout(
+        MUST_COMPLETE,
+        cala.account_sets().add_member(set_two.id(), two.id()),
+    )
+    .await
+    .expect("account-member adds for different members must not serialize")?;
+
+    op.commit().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn account_member_ops_for_same_member_serialize() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, _) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let set_one = cala
+        .account_sets()
+        .create(new_set(journal.id(), "same-member-1"))
+        .await?;
+    let set_two = cala
+        .account_sets()
+        .create(new_set(journal.id(), "same-member-2"))
+        .await?;
+
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, set_one.id(), one.id())
+        .await?;
+
+    // An add of the *same* member elsewhere must wait for the open
+    // transaction (per-member exclusive lock).
+    let cala2 = cala.clone();
+    let set_two_id = set_two.id();
+    let member_id = one.id();
+    let mut blocked =
+        tokio::spawn(async move { cala2.account_sets().add_member(set_two_id, member_id).await });
+
+    assert!(
+        tokio::time::timeout(MUST_STILL_BE_PENDING, &mut blocked)
+            .await
+            .is_err(),
+        "same-member add must block while the first transaction is open"
+    );
+
+    op.commit().await?;
+    blocked.await??;
+    Ok(())
+}
+
+#[tokio::test]
+async fn structure_ops_fence_account_member_ops() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, _) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let parent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "fence-parent"))
+        .await?;
+    let child = cala
+        .account_sets()
+        .create(new_set(journal.id(), "fence-child"))
+        .await?;
+    let unrelated = cala
+        .account_sets()
+        .create(new_set(journal.id(), "fence-unrelated"))
+        .await?;
+
+    // Hold an uncommitted structure mutation open (exclusive coarse lock)...
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_in_op(&mut op, parent.id(), child.id())
+        .await?;
+
+    // ...any account-member mutation must wait for it, even on an
+    // unrelated set: structure changes fence the whole membership graph.
+    let cala2 = cala.clone();
+    let unrelated_id = unrelated.id();
+    let member_id = one.id();
+    let mut blocked = tokio::spawn(async move {
+        cala2
+            .account_sets()
+            .add_member(unrelated_id, member_id)
+            .await
+    });
+
+    assert!(
+        tokio::time::timeout(MUST_STILL_BE_PENDING, &mut blocked)
+            .await
+            .is_err(),
+        "account-member add must block while a structure mutation is open"
+    );
+
+    op.commit().await?;
+    blocked.await??;
+    Ok(())
+}
+
+/// Write-skew guard: many concurrent account-member adds into a shared
+/// deep hierarchy must leave a complete transitive closure.
+#[tokio::test]
+async fn concurrent_adds_maintain_transitive_closure() -> anyhow::Result<()> {
+    const N_MEMBERS: usize = 16;
+
+    let pool = init_isolated_pool(20).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    // grandparent <- parent <- leaf
+    let grandparent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "closure-grandparent"))
+        .await?;
+    let parent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "closure-parent"))
+        .await?;
+    let leaf = cala
+        .account_sets()
+        .create(new_set(journal.id(), "closure-leaf"))
+        .await?;
+    cala.account_sets()
+        .add_member(grandparent.id(), parent.id())
+        .await?;
+    cala.account_sets()
+        .add_member(parent.id(), leaf.id())
+        .await?;
+
+    let mut accounts = Vec::new();
+    for _ in 0..N_MEMBERS {
+        let (new_account, _) = helpers::test_accounts();
+        accounts.push(cala.accounts().create(new_account).await?);
+    }
+
+    let mut handles = Vec::new();
+    for account in &accounts {
+        let cala = cala.clone();
+        let leaf_id = leaf.id();
+        let account_id = account.id();
+        handles.push(tokio::spawn(async move {
+            cala.account_sets().add_member(leaf_id, account_id).await
+        }));
+    }
+    for handle in handles {
+        handle.await??;
+    }
+
+    // Every account must have its direct row on the leaf and transitive
+    // rows on every ancestor.
+    for set_id in [leaf.id(), parent.id(), grandparent.id()] {
+        let count = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT COUNT(*) FROM cala_account_set_member_accounts
+            WHERE account_set_id = $1 AND member_account_id = ANY($2)
+            "#,
+        )
+        .bind(uuid::Uuid::from(set_id))
+        .bind(
+            accounts
+                .iter()
+                .map(|a| uuid::Uuid::from(a.id()))
+                .collect::<Vec<_>>(),
+        )
+        .fetch_one(&pool)
+        .await?;
+        assert_eq!(
+            count as usize, N_MEMBERS,
+            "closure rows missing on set {set_id}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Addresses #746 — suggestion 2, investigated. This is the **minimal alternative** to the per-hierarchy locking draft #747; the two are alternatives, not stackable as-is.

## Problem

Every account-set membership mutation takes the single global advisory lock `ADDVISORY_LOCK_ID = 123456` in exclusive mode and — being xact-scoped — holds it until the *enclosing* transaction commits. Callers like lana-bank batch ~10 membership adds inside large transactions, so all membership-touching transactions ledger-wide serialize. On lana's staging sim this was the top query by total DB time (451 ms avg wait, queue of 1 holder + 7 waiters, worst span 32.8 s of pure lock wait). Full evidence in #746.

## What we learned about "shorten the hold time"

#746's second suggestion was to shrink the hold window (acquire later / isolate the closure maintenance). That turns out to be structurally blocked:

- **The xact-scope is load-bearing.** Each mutation is a read-then-write over the ancestor chain; the walk's snapshot must stay valid until the writes commit, otherwise a concurrent account-add and set-attach each miss the other's uncommitted rows (write-skew) and the parent chain silently loses closure rows. The lock cannot be released before commit.
- **Deferring the mutation to commit time** (es-entity commit hooks would support it) breaks same-transaction posting: entry fan-out to parent sets reads the closure table, and callers add an account to its sets and post to it in the same transaction. The closure rows must exist before the post.

So the implementable version of "make the convoy window small" is: keep the coarse key, but stop hot-path holders from excluding *each other*.

## Change

Split the protocol by mutation type (~15 lines in `account_set/repo.rs`):

- **Set-structure mutations** (`add/remove_member_set`): unchanged — EXCLUSIVE coarse lock. They mutate the edges every walk reads and read the member rows account-member mutations write, so they must exclude everything.
- **Account-member mutations** (`add/remove_member_account`): coarse lock **SHARED** + an **EXCLUSIVE per-member advisory lock** (2-arg, `classid 2`, `hashtext(member_account_id)`). Account-member mutations only read the edges, and closure writes for different members are disjoint rows, so they can safely run concurrently. The per-member lock serializes add/remove of the *same* member in overlapping hierarchies, whose interleaved inserts/deletes on shared ancestors would otherwise tear the closure.

The hot path (lana: hundreds of account adds per minute from facility/customer creation) stops convoying; only genuine structure changes (chart edits, product provisioning) still serialize globally.

Acquisition order is fixed (coarse first, then member — two statements): waiting on the coarse lock while holding a member lock could form a wait cycle with a queued exclusive waiter under PostgreSQL's FIFO lock queueing.

## Why this is deploy-safe and low-risk

- **Rolling deploys stay safe**: old binaries take the coarse lock exclusive for account-member ops, which correctly (if conservatively) serializes against both modes used by new binaries. (The per-hierarchy PR does not have this property — this PR can also serve as its safe intermediate version.)
- **No new deadlock surface** for the realistic workload: member locks only conflict on the same member id; structure ops take no member locks; re-granting an already-held shared lock does not queue.
- Same-member duplicate adds still surface as `MemberAlreadyAdded` via the existing unique constraint, exactly as before.

## Testing

- New `tests/account_set_membership_locks.rs`:
  - adds for different members don't serialize (fails on `main` by lock-wait timeout);
  - same-member ops still serialize; structure ops still fence account-member ops (regression guards);
  - write-skew race guard: 16 concurrent adds into a 3-deep hierarchy, closure completeness asserted from the table.
  - Each test creates a throwaway database: these tests hold advisory locks open on purpose, and advisory locks are per-database, so sharing `PG_CON`'s database with other suites would cause FIFO-queue interference.
- Full `cala-ledger` suite: 86/86 pass (including `ec_recalc_race` and `add_member_multi_call_no_deadlock_with_posters`).

Draft because we'd like to load-test against the lana-bank staging environment that reproduces the convoy continuously before merging, and because the maintainers should pick between this and the per-hierarchy draft #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
