### PR TITLE
perf(balance): coalesce EC recalc snapshots per set and currency

### DIFF
--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -165,6 +165,15 @@ impl EffectiveBalances {
         Ok(())
     }
 
+    /// Folds member effective-balance deltas into each owning set's
+    /// running snapshot and returns one snapshot per touched
+    /// `(set, currency, effective_date)` — the final coalesced state for
+    /// that date — rather than one snapshot per replayed delta. Both
+    /// `version` (per-date) and `all_time_version` still advance once
+    /// per folded delta, so the emitted row for a date carries the same
+    /// version numbers as the last of the per-delta rows used to, and
+    /// rebuilds of a date can never emit a lower version than a prior
+    /// build of the same date.
     #[instrument(
         name = "cala_ledger.balance.effective.replay_effective_deltas",
         skip_all
@@ -269,6 +278,15 @@ impl EffectiveBalances {
                     });
 
                 if state.last_date != Some(row.effective_date) {
+                    if let Some(prev_date) = state.last_date {
+                        result.push(RecalcEffectiveSnapshot {
+                            account_id,
+                            currency: row.snapshot.currency,
+                            effective_date: prev_date,
+                            snapshot: state.snapshot.clone(),
+                            all_time_version: state.all_time_version,
+                        });
+                    }
                     state.snapshot.version = 0;
                     state.last_date = Some(row.effective_date);
                 }
@@ -298,16 +316,31 @@ impl EffectiveBalances {
                 }
 
                 state.all_time_version += 1;
-
-                result.push(RecalcEffectiveSnapshot {
-                    account_id,
-                    currency: row.snapshot.currency,
-                    effective_date: row.effective_date,
-                    snapshot: running.clone(),
-                    all_time_version: state.all_time_version,
-                });
             }
         }
+
+        // Flush the final pending date of every state touched this run,
+        // in a deterministic order.
+        let mut final_flushes: Vec<_> = states
+            .into_iter()
+            .filter_map(|((account_id, currency), state)| {
+                state
+                    .last_date
+                    .map(|effective_date| RecalcEffectiveSnapshot {
+                        account_id,
+                        currency,
+                        effective_date,
+                        snapshot: state.snapshot,
+                        all_time_version: state.all_time_version,
+                    })
+            })
+            .collect();
+        final_flushes.sort_by(|a, b| {
+            a.account_id
+                .cmp(&b.account_id)
+                .then_with(|| a.currency.cmp(&b.currency))
+        });
+        result.extend(final_flushes);
 
         result
     }

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -291,6 +291,13 @@ impl Balances {
         Ok(())
     }
 
+    /// Folds member balance-history deltas into each owning set's running
+    /// snapshot and returns one snapshot per touched `(set, currency)` —
+    /// the final coalesced state — rather than one snapshot per replayed
+    /// delta. `version` still advances once per folded delta, so version
+    /// gaps in `cala_balance_history` are expected for EC sets and the
+    /// version of a set's balance keeps counting the member deltas it
+    /// has absorbed.
     #[instrument(name = "cala_ledger.balances.replay_member_deltas_batch", skip_all)]
     fn replay_member_deltas_batch(
         journal_id: JournalId,
@@ -300,7 +307,8 @@ impl Balances {
     ) -> Vec<BalanceSnapshot> {
         use rust_decimal::Decimal;
 
-        let mut new_snapshots = Vec::new();
+        let mut touched: Vec<(AccountSetId, Currency)> = Vec::new();
+        let mut touched_seen: HashSet<(AccountSetId, Currency)> = HashSet::new();
 
         for MemberBalanceHistoryRow {
             snapshot,
@@ -401,7 +409,18 @@ impl Balances {
                     running.encumbrance.modified_at = snapshot.encumbrance.modified_at;
                 }
 
-                new_snapshots.push(running.clone());
+                if touched_seen.insert((*set_id, snapshot.currency)) {
+                    touched.push((*set_id, snapshot.currency));
+                }
+            }
+        }
+
+        let mut new_snapshots = Vec::with_capacity(touched.len());
+        for (set_id, currency) in touched {
+            if let Some((_, balances, _)) = set_states.get(&set_id) {
+                if let Some(snapshot) = balances.get(&currency) {
+                    new_snapshots.push(snapshot.clone());
+                }
             }
         }
 
@@ -906,11 +925,11 @@ mod tests {
             let result =
                 Balances::replay_member_deltas_batch(journal_id, set_states, &memberships, history);
 
-            assert_eq!(result.len(), 2);
-            assert_eq!(result[0].version, 1);
-            assert_eq!(result[0].settled.dr_balance, Decimal::from(100));
-            assert_eq!(result[1].version, 2);
-            assert_eq!(result[1].settled.dr_balance, Decimal::from(250));
+            // Both deltas coalesce into a single emitted snapshot carrying
+            // the final accumulated state; version counts the folded deltas.
+            assert_eq!(result.len(), 1);
+            assert_eq!(result[0].version, 2);
+            assert_eq!(result[0].settled.dr_balance, Decimal::from(250));
         }
 
         #[test]

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -592,7 +592,11 @@ async fn eventually_consistent_balances() -> anyhow::Result<()> {
     assert_eq!(inline_bal_2.settled(), ec_bal_2.settled());
     assert_eq!(inline_bal_2.details.version, ec_bal_2.details.version);
 
-    // Verify balance_history counts match across ALL currencies
+    // Coalesced recalc: the EC set writes one history row per currency per
+    // recalculation that consumed new member history (2 recalcs x 2
+    // currencies), while the inline set writes one row per member entry
+    // (4 transactions x 3 recipient entries: settled BTC, settled USD,
+    // pending USD).
     let inline_account_id = AccountId::from(&inline_set.id());
     let ec_account_id = AccountId::from(&ec_set.id());
 
@@ -615,11 +619,16 @@ async fn eventually_consistent_balances() -> anyhow::Result<()> {
     .try_get("cnt")?;
 
     assert_eq!(
-        inline_count, ec_count,
-        "EC set should have same number of balance_history rows as inline set"
+        inline_count, 12,
+        "inline set writes one history row per entry"
+    );
+    assert_eq!(
+        ec_count, 4,
+        "EC set writes one coalesced history row per currency per recalc"
     );
 
-    // Verify each BTC snapshot's running balance matches
+    // The EC set's BTC history must be a coalesced subsequence of the inline
+    // set's: each EC row is identical to the inline row at the same version.
     let inline_history = sqlx::query(
         "SELECT values FROM cala_balance_history WHERE account_id = $1 AND journal_id = $2 AND currency = $3 ORDER BY version",
     )
@@ -639,34 +648,39 @@ async fn eventually_consistent_balances() -> anyhow::Result<()> {
     .await?;
 
     assert_eq!(
-        inline_history.len(),
         ec_history.len(),
-        "BTC history count mismatch"
+        2,
+        "one coalesced BTC history row per recalc"
     );
-    for (inline_row, ec_row) in inline_history.iter().zip(ec_history.iter()) {
-        let i_snap: BalanceSnapshot =
-            serde_json::from_value(inline_row.try_get::<serde_json::Value, _>("values")?)?;
+    let inline_by_version: std::collections::HashMap<u32, BalanceSnapshot> = inline_history
+        .iter()
+        .map(|row| {
+            let snap: BalanceSnapshot =
+                serde_json::from_value(row.try_get::<serde_json::Value, _>("values").unwrap())
+                    .unwrap();
+            (snap.version, snap)
+        })
+        .collect();
+    for ec_row in ec_history.iter() {
         let e_snap: BalanceSnapshot =
             serde_json::from_value(ec_row.try_get::<serde_json::Value, _>("values")?)?;
-        assert_eq!(
-            i_snap.version, e_snap.version,
-            "version mismatch at v{}",
-            i_snap.version
-        );
+        let i_snap = inline_by_version
+            .get(&e_snap.version)
+            .unwrap_or_else(|| panic!("no inline history row at v{}", e_snap.version));
         assert_eq!(
             i_snap.settled.dr_balance, e_snap.settled.dr_balance,
             "settled dr mismatch at v{}",
-            i_snap.version
+            e_snap.version
         );
         assert_eq!(
             i_snap.settled.cr_balance, e_snap.settled.cr_balance,
             "settled cr mismatch at v{}",
-            i_snap.version
+            e_snap.version
         );
         assert_eq!(
             i_snap.entry_id, e_snap.entry_id,
             "entry_id mismatch at v{}",
-            i_snap.version
+            e_snap.version
         );
     }
 


### PR DESCRIPTION
## Motivation

Recalculating an eventually-consistent account set emits one `cala_balance_history` row (+ outbox event) **per replayed member delta**, and one `cala_cumulative_effective_balances` row per delta on the effective side. A batch recalc over a day of postings therefore writes the same row volume as synchronous rollup would have — just later, in giant statements.

Measured on lana-bank staging (galoy-staging-realtime, unsampled traces, 2026-07-01→09): `recalculate_account_set_balances_batch_in_op` runs at p50 1.1s / p90 124s / max 342s, with `insert_new_snapshots` statements of 5k JSONB rows taking up to **302s each** (66% of total job time) — all while holding exclusive EC-class advisory locks that block posters and `add_member` on the affected sets (add_member max 59.9s in the same window).

## Change

`replay_member_deltas_batch` and `replay_effective_deltas` still fold every delta, but now emit only the final coalesced state:

- **current balances**: one row per touched `(set, currency)` per recalc
- **effective balances**: one row per touched `(set, currency, effective_date)` per recalc

For a set with N member deltas per day and daily recalc, this reduces recalc writes from O(N) to O(currencies) rows — and shrinks the exclusive-lock window accordingly.

## Invariants preserved

- `version` / `all_time_version` still advance once per folded delta: a set's version keeps counting absorbed member deltas, `find_all_in_range`'s `last_version - first_version` diff stays correct, and a rebuild of an effective date can never emit a lower version than a prior build of that date (matters for event consumers that rank by version). Version-gapped history is expected for EC sets; no reader orders by contiguity (the member-history LAG window only partitions leaf accounts, which are unaffected).
- Watermark protocol unchanged: every recalc that consumes member history still writes ≥1 row per touched currency, so `latest_seq` advances past all consumed input seqs exactly as before (the doc-comment invariant in `balance/repo.rs` holds).
- Final balances are byte-identical; the EC set's history becomes a coalesced subsequence of what an inline set would write (the updated `eventually_consistent_balances` test asserts this directly).

## Behavioral notes

- A `BalanceCreated` event now only fires when the first recalc for a `(set, currency)` folds exactly one delta; otherwise the first event is `BalanceUpdated` with version > 1. No consumer in cala or lana-bank distinguishes the two (lana's dw pipeline unions them and takes latest-version-per-date).
- Effective-balance recalc rows never published events, so nothing changes there.
- Intraday point-in-time granularity of EC set history (already recalc-timed, not post-timed) becomes one snapshot per recalc run. This is the documented semantic of eventual consistency; leaf accounts and inline (non-EC) sets are untouched.

## Testing

- `cargo nextest run -p cala-ledger`: 82/82 pass, including the `ec_recalc_race` concurrency suite (watermark protocol under concurrent posters) and the inline-vs-EC equivalence tests.
- Unit test `multiple_deltas_accumulate` and integration test `eventually_consistent_balances` updated to encode the coalesced contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core ledger recalc persistence and outbox volume for EC sets; invariants are documented and tested but version-gapped history and fewer `BalanceCreated` events are behavioral shifts for downstream consumers.
> 
> **Overview**
> Eventually-consistent account set recalculation still replays every member delta, but **`replay_member_deltas_batch`** and **`replay_effective_deltas`** now persist only **coalesced** snapshots instead of one row per folded delta.
> 
> For current balances, each recalc writes **one** `cala_balance_history` / current-balance update per touched `(set, currency)` with the final accumulated amounts. For effective balances, it writes **one** row per touched `(set, currency, effective_date)`, flushing prior dates when the effective date changes and a deterministic final flush at the end. **`version`** and **`all_time_version`** still increment once per absorbed delta, so final versions and balances stay aligned with inline sets while history becomes a sparser, version-gapped subsequence.
> 
> Unit and integration tests (`multiple_deltas_accumulate`, `eventually_consistent_balances`) now assert the coalesced row counts and that EC BTC history rows match inline snapshots at the same version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c4452daea3f8e66d1b62568ac2a5d8606f2b643. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->