### PR TITLE
feat(ledger)!: make account set balance rollup explicit

### DIFF
--- a/cala-ledger-core-types/src/primitives.rs
+++ b/cala-ledger-core-types/src/primitives.rs
@@ -101,6 +101,16 @@ impl From<DebitOrCredit> for CelValue {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BalanceRollup {
+    /// Rolled up inside every posting to a member account, under an
+    /// exclusive lock per (journal, set, currency).
+    Synchronous,
+    /// Skipped at posting time; refreshed by recalculating the sets
+    /// returned from `list_eventually_consistent_ids`.
+    EventuallyConsistent,
+}
+
 #[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, sqlx::Type)]
 #[sqlx(type_name = "Status", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]

--- a/cala-ledger/src/account_set/entity.rs
+++ b/cala-ledger/src/account_set/entity.rs
@@ -207,8 +207,7 @@ pub struct NewAccountSet {
     pub(super) journal_id: JournalId,
     #[builder(default)]
     pub(super) normal_balance_type: DebitOrCredit,
-    #[builder(default)]
-    pub(super) eventually_consistent: bool,
+    pub(super) balance_rollup: BalanceRollup,
     #[builder(setter(strip_option, into), default)]
     pub(super) description: Option<String>,
     #[builder(setter(custom), default)]
@@ -218,6 +217,10 @@ pub struct NewAccountSet {
 impl NewAccountSet {
     pub fn builder() -> NewAccountSetBuilder {
         NewAccountSetBuilder::default()
+    }
+
+    pub(super) fn is_eventually_consistent(&self) -> bool {
+        matches!(self.balance_rollup, BalanceRollup::EventuallyConsistent)
     }
 
     pub(super) fn context_values(&self) -> VelocityContextAccountValues {

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -60,7 +60,7 @@ impl AccountSets {
             .code(new_account_set.id.to_string())
             .normal_balance_type(new_account_set.normal_balance_type)
             .is_account_set(true)
-            .eventually_consistent(new_account_set.eventually_consistent)
+            .eventually_consistent(new_account_set.is_eventually_consistent())
             .velocity_context_values(new_account_set.context_values())
             .build()
             .expect("Failed to build account");
@@ -96,7 +96,7 @@ impl AccountSets {
                 .code(new_account_set.id.to_string())
                 .normal_balance_type(new_account_set.normal_balance_type)
                 .is_account_set(true)
-                .eventually_consistent(new_account_set.eventually_consistent)
+                .eventually_consistent(new_account_set.is_eventually_consistent())
                 .velocity_context_values(new_account_set.context_values())
                 .build()
                 .expect("Failed to build account");

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -26,6 +26,7 @@ async fn errors_on_collision() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("SET ONE")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let set_one = cala.account_sets().create(set_one).await.unwrap();
@@ -34,6 +35,7 @@ async fn errors_on_collision() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("SET TWO")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let set_two = cala.account_sets().create(set_two).await.unwrap();
@@ -42,6 +44,7 @@ async fn errors_on_collision() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("parent")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let parent = cala.account_sets().create(parent).await.unwrap();
@@ -113,6 +116,7 @@ async fn balances() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Recipient Set")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )
@@ -125,6 +129,7 @@ async fn balances() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Sender Set")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )
@@ -137,6 +142,7 @@ async fn balances() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Parent")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )
@@ -242,6 +248,7 @@ async fn account_set_update() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name(initial_name.clone())
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()?;
 
     let mut account_set = cala.account_sets().create(new_account_set).await?;
@@ -277,6 +284,7 @@ async fn members_pagination() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("SET ONE")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let set_one = cala.account_sets().create(set_one).await.unwrap();
@@ -284,6 +292,7 @@ async fn members_pagination() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("SET TWO")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let set_two = cala.account_sets().create(set_two).await.unwrap();
@@ -292,6 +301,7 @@ async fn members_pagination() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("parent")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let parent = cala.account_sets().create(parent).await.unwrap();
@@ -395,6 +405,7 @@ async fn list_members_by_external_id() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Parent Set")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()?,
         )
         .await?;
@@ -507,6 +518,7 @@ async fn eventually_consistent_balances() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Inline Set")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let inline_set = cala.account_sets().create(inline_set).await.unwrap();
@@ -516,7 +528,7 @@ async fn eventually_consistent_balances() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("EC Set")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let ec_set = cala.account_sets().create(ec_set).await.unwrap();
@@ -734,7 +746,7 @@ async fn batch_recalculate_shared_members() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Set A")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let set_a = cala.account_sets().create(set_a).await.unwrap();
@@ -743,7 +755,7 @@ async fn batch_recalculate_shared_members() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Set B")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let set_b = cala.account_sets().create(set_b).await.unwrap();
@@ -752,7 +764,7 @@ async fn batch_recalculate_shared_members() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Root")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let root = cala.account_sets().create(root).await.unwrap();
@@ -892,7 +904,7 @@ async fn deep_recalculate_expands_to_descendants() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Child")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let child = cala.account_sets().create(child).await.unwrap();
@@ -901,7 +913,7 @@ async fn deep_recalculate_expands_to_descendants() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Root")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let root = cala.account_sets().create(root).await.unwrap();
@@ -980,6 +992,7 @@ async fn list_eventually_consistent_ids() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("Inline Set")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let inline_set = cala.account_sets().create(inline_set).await.unwrap();
@@ -990,7 +1003,7 @@ async fn list_eventually_consistent_ids() -> anyhow::Result<()> {
             .id(AccountSetId::new())
             .name(format!("EC Set {i}"))
             .journal_id(journal.id())
-            .eventually_consistent(true)
+            .balance_rollup(BalanceRollup::EventuallyConsistent)
             .build()
             .unwrap();
         let ec_set = cala.account_sets().create(ec_set).await.unwrap();
@@ -1089,6 +1102,7 @@ async fn add_member_errors_when_member_has_history() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Target")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )
@@ -1169,6 +1183,7 @@ async fn remove_member_errors_when_member_has_history() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Target")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )
@@ -1240,6 +1255,7 @@ async fn recalculate_balances_errors_on_non_ec_set() -> anyhow::Result<()> {
                 .id(AccountSetId::new())
                 .name("Inline Set")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )
@@ -1330,7 +1346,7 @@ async fn recalculate_balances_deep_skips_non_ec_descendants() -> anyhow::Result<
                 .id(AccountSetId::new())
                 .name("EC Root")
                 .journal_id(journal.id())
-                .eventually_consistent(true)
+                .balance_rollup(BalanceRollup::EventuallyConsistent)
                 .build()
                 .unwrap(),
         )
@@ -1343,7 +1359,7 @@ async fn recalculate_balances_deep_skips_non_ec_descendants() -> anyhow::Result<
                 .id(AccountSetId::new())
                 .name("EC Child")
                 .journal_id(journal.id())
-                .eventually_consistent(true)
+                .balance_rollup(BalanceRollup::EventuallyConsistent)
                 .build()
                 .unwrap(),
         )
@@ -1356,6 +1372,7 @@ async fn recalculate_balances_deep_skips_non_ec_descendants() -> anyhow::Result<
                 .id(AccountSetId::new())
                 .name("Inline Child")
                 .journal_id(journal.id())
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap(),
         )

--- a/cala-ledger/tests/ec_recalc_race.rs
+++ b/cala-ledger/tests/ec_recalc_race.rs
@@ -83,7 +83,7 @@ async fn ec_recalc_race_under_concurrency() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("EC race set")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let ec_set = cala.account_sets().create(ec_set).await.unwrap();
@@ -295,7 +295,7 @@ async fn ec_recalc_hierarchy_race_under_concurrency() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("EC hierarchy inner set")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let ec_set = cala.account_sets().create(ec_set).await.unwrap();
@@ -306,6 +306,7 @@ async fn ec_recalc_hierarchy_race_under_concurrency() -> anyhow::Result<()> {
         .id(AccountSetId::new())
         .name("EC hierarchy parent set")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let parent_set = cala.account_sets().create(parent_set).await.unwrap();
@@ -477,7 +478,7 @@ async fn add_member_multi_call_no_deadlock_with_posters() -> anyhow::Result<()> 
             .id(AccountSetId::new())
             .name(format!("Deadlock repro parent {i}"))
             .journal_id(journal.id())
-            .eventually_consistent(true)
+            .balance_rollup(BalanceRollup::EventuallyConsistent)
             .build()
             .unwrap();
         parents.push(cala.account_sets().create(set).await.unwrap());

--- a/cala-ledger/tests/effective_balance.rs
+++ b/cala-ledger/tests/effective_balance.rs
@@ -156,6 +156,7 @@ async fn ec_account_set_effective_balance_recalculation() -> anyhow::Result<()> 
         .id(AccountSetId::new())
         .name("Inline Set")
         .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
     let inline_set = cala.account_sets().create(inline_set).await.unwrap();
@@ -165,7 +166,7 @@ async fn ec_account_set_effective_balance_recalculation() -> anyhow::Result<()> 
         .id(AccountSetId::new())
         .name("EC Set")
         .journal_id(journal.id())
-        .eventually_consistent(true)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
         .build()
         .unwrap();
     let ec_set = cala.account_sets().create(ec_set).await.unwrap();

--- a/cala-ledger/tests/helpers.rs
+++ b/cala-ledger/tests/helpers.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)]
 use rand::distr::{Alphanumeric, SampleString};
 
-use cala_ledger::{account::*, account_set::NewAccountSet, journal::*, tx_template::*};
+use cala_ledger::{
+    account::*, account_set::NewAccountSet, journal::*, primitives::BalanceRollup, tx_template::*,
+};
 
 pub async fn init_pool() -> anyhow::Result<sqlx::PgPool> {
     init_pool_with(sqlx::postgres::PgPoolOptions::new()).await
@@ -63,6 +65,7 @@ pub fn test_account_sets(journal_id: uuid::Uuid) -> (NewAccountSet, NewAccountSe
         .id(uuid::Uuid::now_v7())
         .name(format!("Test Sender Account Set {code}"))
         .journal_id(journal_id)
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
 
@@ -71,6 +74,7 @@ pub fn test_account_sets(journal_id: uuid::Uuid) -> (NewAccountSet, NewAccountSe
         .id(uuid::Uuid::now_v7())
         .name(format!("Test Recipient Account Set {code}"))
         .journal_id(journal_id)
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap();
 

--- a/cala-ledger/tests/velocity.rs
+++ b/cala-ledger/tests/velocity.rs
@@ -245,6 +245,7 @@ mod limit_via_account_sets {
             .journal_id(journal_id)
             .metadata(json!({ "closed": true }))
             .unwrap()
+            .balance_rollup(BalanceRollup::Synchronous)
             .build()
             .unwrap();
         let account_set = cala.account_sets().create(new_account_set).await?;
@@ -315,6 +316,7 @@ mod limit_via_account_sets {
             .journal_id(journal_id)
             .metadata(json!({ "closed": true }))
             .unwrap()
+            .balance_rollup(BalanceRollup::Synchronous)
             .build()
             .unwrap();
         let code = Alphanumeric.sample_string(&mut rand::rng(), 32);
@@ -324,6 +326,7 @@ mod limit_via_account_sets {
             .journal_id(journal_id)
             .metadata(json!({ "closed": true }))
             .unwrap()
+            .balance_rollup(BalanceRollup::Synchronous)
             .build()
             .unwrap();
         let res = cala
@@ -428,6 +431,7 @@ mod limit_via_account_sets {
             .id(uuid::Uuid::now_v7())
             .name(format!("Test Account Set {code}"))
             .journal_id(journal_id)
+            .balance_rollup(BalanceRollup::Synchronous)
             .build()
             .unwrap();
         let mut account_set = cala.account_sets().create(new_account_set).await?;
@@ -522,6 +526,7 @@ mod limit_via_account_sets {
             .id(uuid::Uuid::now_v7())
             .name(format!("Test Parent Account Set {code}"))
             .journal_id(journal_id)
+            .balance_rollup(BalanceRollup::Synchronous)
             .build()
             .unwrap();
         let mut parent_account_set = cala
@@ -538,6 +543,7 @@ mod limit_via_account_sets {
             .id(uuid::Uuid::now_v7())
             .name(format!("Test Child Account Set {code}"))
             .journal_id(journal_id)
+            .balance_rollup(BalanceRollup::Synchronous)
             .build()
             .unwrap();
         let child_account_set = cala

--- a/cala-perf/src/lib.rs
+++ b/cala-perf/src/lib.rs
@@ -152,7 +152,11 @@ pub async fn init_accounts_with_account_sets_depth(
             .id(AccountSetId::new())
             .name(format!("Sender Account Set L{}", i + 1))
             .journal_id(journal.id())
-            .eventually_consistent(eventually_consistent)
+            .balance_rollup(if eventually_consistent {
+                BalanceRollup::EventuallyConsistent
+            } else {
+                BalanceRollup::Synchronous
+            })
             .build()
             .unwrap();
         let sender_set = cala.account_sets().create(sender_set).await?;
@@ -166,7 +170,11 @@ pub async fn init_accounts_with_account_sets_depth(
             .id(AccountSetId::new())
             .name(format!("Recipient Account Set L{}", i + 1))
             .journal_id(journal.id())
-            .eventually_consistent(eventually_consistent)
+            .balance_rollup(if eventually_consistent {
+                BalanceRollup::EventuallyConsistent
+            } else {
+                BalanceRollup::Synchronous
+            })
             .build()
             .unwrap();
         let recipient_set = cala.account_sets().create(recipient_set).await?;

--- a/cala-perf/src/main.rs
+++ b/cala-perf/src/main.rs
@@ -1,4 +1,6 @@
-use cala_ledger::{account::AccountId, account_set::*, journal::JournalId, CalaLedger};
+use cala_ledger::{
+    account::AccountId, account_set::*, journal::JournalId, primitives::BalanceRollup, CalaLedger,
+};
 use cala_perf::{init_accounts, init_cala, init_journal, templates::simple_transfer};
 use rand::RngExt;
 
@@ -200,6 +202,7 @@ async fn transactions_with_contention(
                 .id(AccountSetId::new())
                 .name(format!("Contention Set {}", i))
                 .journal_id(journal_id)
+                .balance_rollup(BalanceRollup::Synchronous)
                 .build()
                 .unwrap();
             let created_set = cala.account_sets().create(account_set).await?;


### PR DESCRIPTION
## Summary

`NewAccountSet`'s `eventually_consistent` flag is optional and defaults to `false` — the strategy that rolls the set up inside every posting to a member account while holding an exclusive advisory lock per (journal, set, currency). Omitting the flag is invisible: nothing fails at build, test, or review time; postings just serialize under concurrency. GaloyMoney/lana-bank#7303 is a production-bound instance — one creation site out of ~14 forgot the flag, and every concurrent posting within a credit product (disbursals, payments, the nightly interest-accrual burst) serialized on the product's shared summary sets.

This removes the footgun at the type level: the builder now requires `.balance_rollup(BalanceRollup)`, where `BalanceRollup::{Synchronous, EventuallyConsistent}` is a new primitive whose doc comments spell out the locking cost. Omission is a build error (`UninitializedField("balance_rollup")`); the bool setter is gone with no deprecated alias, so this is a breaking API change for the next minor release.

Persistence is deliberately unchanged: the enum maps to the same `eventually_consistent` bool on the backing account's `AccountConfig`, so serialized account events and the `cala_accounts` column stay compatible — no migration, no event-replay impact. Call sites that previously omitted the flag now pass `Synchronous` explicitly, preserving their behavior.

## Test plan

- [x] `cargo clippy --workspace --all-targets` clean (two pre-existing test warnings untouched)
- [x] `cargo nextest run -p cala-ledger` — 82/82 pass, including the EC recalc race tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public builder API for all account-set creation sites; runtime posting/recalc behavior is unchanged if callers map rollups correctly, but downstream crates must compile against the new required field.
> 
> **Overview**
> **Breaking API change:** `NewAccountSet` no longer accepts an optional `eventually_consistent` bool (default `false`). Callers must set **`.balance_rollup(BalanceRollup::Synchronous | EventuallyConsistent)`** or the builder fails at compile time.
> 
> Adds **`BalanceRollup`** in core primitives with doc comments on synchronous rollup (per-posting locks) vs eventual recalc. Creation still writes the same **`eventually_consistent`** flag on the backing account row—no schema or event migration.
> 
> Tests, helpers, and **`cala-perf`** are updated to pass the rollup explicitly; former implicit synchronous behavior is **`Synchronous`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b31c4afa5e76f5580a368d5e7e2935052d026bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->