### PR TITLE
fix(account_set): set balance_rollup on membership-locks test helper

### DIFF
--- a/cala-ledger/tests/account_set_membership_locks.rs
+++ b/cala-ledger/tests/account_set_membership_locks.rs
@@ -77,6 +77,7 @@ fn new_set(journal_id: JournalId, name: &str) -> NewAccountSet {
         .id(AccountSetId::new())
         .name(name)
         .journal_id(journal_id)
+        .balance_rollup(BalanceRollup::Synchronous)
         .build()
         .unwrap()
 }


### PR DESCRIPTION
## Summary

Fixes the `integration-test` pipeline failure (job build `#78`).

4 tests in `cala-ledger::account_set_membership_locks` panicked:

```
thread '...' panicked at cala-ledger/tests/account_set_membership_locks.rs:81:10:
called `Result::unwrap()` on an `Err` value: UninitializedField("balance_rollup")
```

### Root cause
`49b455d3` (`feat(ledger)!: make account set balance rollup explicit #752`) made `balance_rollup` a **required** field on `NewAccountSet` (no `#[builder(default)]`). All other call sites were updated, but the `new_set()` helper in `cala-ledger/tests/account_set_membership_locks.rs` was missed, so every test using it failed at `.build().unwrap()`.

### Fix
Add `.balance_rollup(BalanceRollup::Synchronous)` to the helper, matching the sibling test files (`account_set.rs`, `helpers.rs`, `effective_balance.rs`, …). `BalanceRollup` is already in scope via `use cala_ledger::{account_set::*, *}`.

### Validation
Could not run `cargo test --no-run` locally — this checkout has pre-existing lib-level derive-macro errors (EsRepo / `obix::MailboxTables` type inference) unrelated to this change. CI is the source of truth for compilation here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only helper change; no production ledger or API behavior is modified.
> 
> **Overview**
> Restores **`account_set_membership_locks`** integration tests after `NewAccountSet` started requiring an explicit **`balance_rollup`**.
> 
> The shared **`new_set()`** helper now sets **`.balance_rollup(BalanceRollup::Synchronous)`**, consistent with other ledger test helpers, so **`NewAccountSet::build()`** no longer fails with **`UninitializedField("balance_rollup")`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80de1b3e999a6e8f627d7b4058d5a56c6deb0ab1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->