### PR TITLE
feat(account): expose eventually_consistent on NewAccount builder (sound with streaming rollup)

### DIFF
--- a/cala-ledger/src/account/entity.rs
+++ b/cala-ledger/src/account/entity.rs
@@ -278,7 +278,18 @@ impl NewAccountBuilder {
         self
     }
 
-    pub(crate) fn eventually_consistent(&mut self, eventually_consistent: bool) -> &mut Self {
+    /// Marks the account as eventually consistent: posters skip the
+    /// exclusive per-(journal, account, currency) advisory lock and do not
+    /// maintain `cala_current_balances` rows for it.
+    ///
+    /// Only sound for rollup-only counterparty accounts whose *current
+    /// balance is never read* (e.g. product omnibus accounts that exist so
+    /// double-entry postings have a shared counterparty). Unlike account
+    /// sets, plain accounts have no out-of-band recalculation path, so an
+    /// eventually-consistent account's current balance reads as
+    /// zero/not-found forever — entries and set rollups over those entries
+    /// are unaffected.
+    pub fn eventually_consistent(&mut self, eventually_consistent: bool) -> &mut Self {
         self.eventually_consistent = Some(eventually_consistent);
         self
     }

--- a/cala-ledger/src/account/entity.rs
+++ b/cala-ledger/src/account/entity.rs
@@ -280,15 +280,15 @@ impl NewAccountBuilder {
 
     /// Marks the account as eventually consistent: posters skip the
     /// exclusive per-(journal, account, currency) advisory lock and do not
-    /// maintain `cala_current_balances` rows for it.
+    /// maintain balance snapshots for it — no `cala_current_balances`, no
+    /// `cala_balance_history`, no effective-balance history.
     ///
-    /// Only sound for rollup-only counterparty accounts whose *current
-    /// balance is never read* (e.g. product omnibus accounts that exist so
-    /// double-entry postings have a shared counterparty). Unlike account
-    /// sets, plain accounts have no out-of-band recalculation path, so an
-    /// eventually-consistent account's current balance reads as
-    /// zero/not-found forever — entries and set rollups over those entries
-    /// are unaffected.
+    /// WARNING: this is only sound for accounts that are **not a member of
+    /// any account set**. Set recalculation replays member balance history,
+    /// so an eventually-consistent member's entries silently drop out of
+    /// every ancestor set's recalculated balance. Entries themselves
+    /// (`cala_entries`) are always written; everything derived from balance
+    /// snapshots is not.
     pub fn eventually_consistent(&mut self, eventually_consistent: bool) -> &mut Self {
         self.eventually_consistent = Some(eventually_consistent);
         self

--- a/cala-ledger/src/account/entity.rs
+++ b/cala-ledger/src/account/entity.rs
@@ -280,15 +280,25 @@ impl NewAccountBuilder {
 
     /// Marks the account as eventually consistent: posters skip the
     /// exclusive per-(journal, account, currency) advisory lock and do not
-    /// maintain `cala_current_balances` rows for it.
+    /// maintain its balance inline. The streaming EC rollup job
+    /// (`cala.ec_balance_rollup`, registered in `CalaLedger::init`) is then
+    /// the sole writer of its balance, folding the account's entries into
+    /// `cala_current_balances` and `cala_balance_history` from the outbox
+    /// stream.
     ///
-    /// Only sound for rollup-only counterparty accounts whose *current
-    /// balance is never read* (e.g. product omnibus accounts that exist so
-    /// double-entry postings have a shared counterparty). Unlike account
-    /// sets, plain accounts have no out-of-band recalculation path, so an
-    /// eventually-consistent account's current balance reads as
-    /// zero/not-found forever — entries and set rollups over those entries
-    /// are unaffected.
+    /// Sound for rollup-only counterparty accounts (e.g. product omnibus
+    /// accounts that exist so double-entry postings share a counterparty),
+    /// **including account-set members** — the rollup resolves set closure
+    /// from live membership, not member history. Constraints:
+    ///
+    /// - **Attach before first entry.** A member may only join a set with
+    ///   zero balance history (the attach guard rejects the rest, EC or
+    ///   not): the rollup folds a member's activity from the point it
+    ///   joins, so pre-join balance would be silently dropped.
+    /// - **Readers must tolerate rollup lag.** The balance is eventually
+    ///   consistent — do not read it in post-time enforcement paths.
+    /// - **The rollup job must be running.** If it stalls, EC balances
+    ///   drift silently behind the entry stream.
     pub fn eventually_consistent(&mut self, eventually_consistent: bool) -> &mut Self {
         self.eventually_consistent = Some(eventually_consistent);
         self


### PR DESCRIPTION
## Summary

Account sets can already opt out of synchronous balance rollup (their backing account gets `eventually_consistent` via `BalanceRollup`, #752), but **plain accounts** had no public way to set the flag — the builder setter was `pub(crate)`. This PR makes it public.

## Soundness: fine for set members since cala #811

The first attempt at this (#758, cala 0.16 era) was scoped down because downstream testing in lana-bank proved EC plain accounts unsound **for account-set members**: set recalculation replayed member *balance history* and EC accounts got no history rows, so an EC member's entries silently vanished from set rollups (caught by lana-bank's report-scenario BATS test).

That gap no longer exists. The **streaming EC rollup** (#811, `cala.ec_balance_rollup`, shipped in 0.21.0) is the sole EC-balance writer and synthesizes both `cala_current_balances` and `cala_balance_history` for EC leaf accounts **from the entry stream** — exactly the "synthesize member history from entries" follow-up the revert called for. EC set rollups resolve membership via the live closure, not member history. The `ec_streaming_rollup` test suite covers EC plain leaves inside EC sets (`streaming_rollup_folds_ec_plain_leaf_and_its_ec_set`) and passes (113/113 locally).

The doc comment spells out the remaining constraints:

- **Attach before first entry** — the attach guard (zero balance history at join) is what makes the member-fold sound; it rejects the rest, EC or not.
- **Readers must tolerate rollup lag** — don't read EC balances in post-time enforcement paths.
- **The rollup job must be running** — it is auto-registered in `CalaLedger::init`; if it stalls, EC balances drift behind the entry stream.

## Downstream motivation (revived)

lana-bank's product omnibus accounts — the shared double-entry counterparty every posting in a product funnels through. As non-EC accounts they take an exclusive advisory lock per `(journal, account, currency)` in `find_for_update` inside every posting. Measured on a 10 loans/s release-build soak (2026-08-07, `0.62.0-rc.605`): lock-query mean **338.7 → 439.6 ms/call** over the hour (~55–60% of all DB time), capping throughput at ~3.1 loans/s against the 10/s target. Flipping the omnibus accounts to EC removes them from the lock prelude entirely; balances are maintained by the streaming rollup.
