### PR TITLE
perf(account-set): index member_account_set_id for upward walk

### DIFF
--- a/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
+++ b/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
@@ -79,6 +79,10 @@ CREATE TABLE cala_account_set_member_account_sets (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE(account_set_id, member_account_set_id)
 );
+-- Reverse index for the upward `WITH RECURSIVE parents` walk, which filters and
+-- joins member_account_set_id at every level; the UNIQUE above leads on account_set_id.
+CREATE INDEX idx_cala_account_set_member_account_sets_member_set
+  ON cala_account_set_member_account_sets (member_account_set_id, account_set_id);
 
 CREATE TABLE cala_tx_templates (
   id UUID PRIMARY KEY,


### PR DESCRIPTION
## What

Adds a reverse-composite index on
`cala_account_set_member_account_sets (member_account_set_id, account_set_id)`
so the upward account-set membership walk uses an index-only scan instead
of seq-scanning the whole table.

## Why

The `WITH RECURSIVE parents` traversal in `account_set/repo.rs` walks the
set→set graph **upward**, filtering `WHERE member_account_set_id = $1` and
recursively joining `... ON parent.account_set_id = m.member_account_set_id`.
The only pre-existing index is the `UNIQUE(account_set_id, member_account_set_id)`
constraint, whose leading column (`account_set_id`) serves the *downward*
walk and balance reads — not this direction. So every level of every walk
seq-scanned the whole table: O(n²) as the chart grows.

Surfaced while stress-testing a lana-bank sandbox, where this table was the
top `seq_tup_read` leader.

## Verification

`EXPLAIN ANALYZE` on a 50k-edge account-set tree (4-ary, deep leaf,
8 ancestors):

| plan | recursive step | exec time |
|---|---|---|
| WITH index | Index Only Scan | ~0.065 ms |
| WITHOUT index | Seq Scan ×8 levels (49,999 rows each) | ~12.9 ms |

→ ~200× faster. At the current ~2k-node chart the walk is sub-ms either way
(the planner hash-joins + seq-scans at small sizes), so this is primarily
future-proofing against chart growth — the O(n²) would bite at scale.

## Notes

- Amended the base migration in place (pre-prod), no new migration file.
- `SQLX_OFFLINE=true cargo check --locked` passes; no query text changed, so
  no `sqlx-prepare` needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-performance index with no application logic changes; main caveat is amending the base migration in place, which only applies cleanly in pre-prod environments.
> 
> **Overview**
> Adds a composite index on `cala_account_set_member_account_sets (member_account_set_id, account_set_id)` in the base ledger setup migration, with a short comment tying it to the upward `WITH RECURSIVE parents` queries in account-set repo code.
> 
> The existing `UNIQUE(account_set_id, member_account_set_id)` only helps downward membership lookups; this reverse index lets PostgreSQL use index-only scans when each recursive level filters and joins on `member_account_set_id`, avoiding full table seq scans as the account-set graph grows.
> 
> No Rust or SQL query text changes—schema/index only, amended in place for pre-prod.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29dd858d5a7bbe9b3932875a18b6702d68371200. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->