### PR TITLE
perf(outbox): size mailbox buffers for listener stalls

### DIFF
--- a/cala-ledger/src/outbox/publisher.rs
+++ b/cala-ledger/src/outbox/publisher.rs
@@ -12,6 +12,8 @@ impl OutboxPublisher {
     pub async fn init(pool: &sqlx::PgPool, clock: &ClockHandle) -> Result<Self, sqlx::Error> {
         let config = obix::MailboxConfig::builder()
             .clock(clock.clone())
+            .event_buffer_size(2_000)
+            .event_cache_size(10_000)
             .build()
             .expect("MailboxConfig");
         let outbox = ObixOutbox::init(pool, config).await?;


### PR DESCRIPTION
## Why

Sibling of GaloyMoney/lana-bank#7458 — same measurement, same change, for the cala outbox, which is the **higher-rate of the two streams** (~40 events/s under stress load vs ~8 for lana's).

Stress test on an ephemeral lana-bank sandbox (target 1 loan/sec) found obix's `load_next_page` running **~1.5 times/sec** in steady state, each call returning **~770–840 rows** — full backfill pages. Post-GaloyMoney/obix@58627ca, steady-state delivery is pure `pg_notify` → in-memory cache → broadcast; those page loads only happen on the **`Lagged` recovery path**, when a listener falls more than `event_buffer_size` events behind the broadcast ring buffer and must re-read history from Postgres.

With the default `event_buffer_size = 100`, a listener stalled **~2.6 seconds** at 40 ev/s is permanently behind — and stalls of that size are routine because listener throughput is throttled by obix's per-event checkpoint (a full `DbOp` + `UPDATE job_executions` + `COMMIT` per event).

Measured on the sandbox: 674 (cala stream) + 514 (lana stream) backfill page loads in 13 minutes at 9–12ms mean ≈ 6% of steady-state DB exec time.

## What

| knob | default | now | effect |
|---|---|---|---|
| `event_buffer_size` | 100 | 2,000 | a listener survives a ~50s stall (at 40 ev/s) instead of 2.6s before `Lagged` |
| `event_cache_size` | 1,000 | 10,000 | backfills that still happen are served from the in-memory `OrdMap`, not SQL |

Memory cost is bounded: buffer slots are `Arc` pointers and the cache holds `Arc`'d jsonb payloads — tens of MB per process.

## Scope

Seatbelt, not engine fix: the root throttle is obix's per-event checkpoint in `OutboxEventJobRunner::run` (`src/out/job.rs:164`). Batching that checkpoint raises listener throughput 10–50× and mostly eliminates `Lagged`; these buffers absorb the bursts that remain.

Downstream: lana-bank picks this up on its next cala bump.

## Test plan

- [x] `SQLX_OFFLINE=true cargo check -p cala-ledger`
- [ ] Re-run the lana-bank stress sandbox with the bumped cala and confirm `load_next_page` call rate drops toward zero in steady state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single init-time config change with bounded memory (Arc/jsonb cache); does not alter publish or checkpoint semantics.
> 
> **Overview**
> **Outbox mailbox tuning** in `OutboxPublisher::init`: `event_buffer_size` goes from the obix default (100) to **2,000**, and `event_cache_size` from 1,000 to **10,000**.
> 
> That widens the broadcast ring before a listener is considered permanently behind (~50s vs ~2.6s at ~40 events/s on the cala stream) and lets larger `Lagged` recoveries be served from the in-memory `OrdMap` instead of repeated full SQL backfill pages. No API or publish-path behavior change—only how much burst/stall the process can absorb before expensive `load_next_page` work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e958aff393d856f4085e69af6bd815d39cd7fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->