### PR TITLE
perf(account-set): index member_account_id for balance-set resolution

### DIFF
--- a/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
+++ b/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
@@ -72,6 +72,11 @@ CREATE TABLE cala_account_set_member_accounts (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   UNIQUE(account_set_id, member_account_id)
 );
+-- Reverse index for account->sets resolution (fetch_mappings_in_op on the
+-- posting path), which filters member_account_id; the UNIQUE above leads on
+-- account_set_id.
+CREATE INDEX idx_cala_account_set_member_accounts_member_account
+  ON cala_account_set_member_accounts (member_account_id, account_set_id);
 
 CREATE TABLE cala_account_set_member_account_sets (
   account_set_id UUID NOT NULL REFERENCES cala_account_sets(id),


### PR DESCRIPTION
## Why

Companion to #761 (which added the reverse index on `cala_account_set_member_account_sets.member_account_set_id`). Same gap, one table over:

`fetch_mappings_in_op` (`cala-ledger/src/account_set/repo.rs`) resolves which account sets each posted account belongs to on the **ledger posting path**, filtering `cala_account_set_member_accounts.member_account_id = ANY(...)`. The only pre-existing index is the `UNIQUE(account_set_id, member_account_id)` constraint, whose leading column (`account_set_id`) serves set→members lookups but not account→sets resolution. A composite btree cannot serve an equality probe on its second column, so every posting seq-scans the whole membership table — and unlike tiny-table planner economics, this does **not** self-correct as the table grows.

## Evidence

From a 1-loan/s lana-bank stress sandbox (cala-ledger 0.17.0, ~40 min of sustained load):

- `cala_account_set_member_accounts`: **31,649 rows** already (grows with every account × set membership; each loan creates several)
- seq scans reading **~3,850 tuples/scan**, **2.85ms mean**, ~2 calls/s sustained — on the same posting path as the advisory-lock-heavy `find_for_update`
- `pg_stat_user_tables`: 281 seq scans / 1.08M `seq_tup_read` for this table

`find_where_account_is_member_in_op` (read API, `WHERE asm.member_account_id = $1 AND transitive IS FALSE`) probes the same column and benefits too.

## Fix

Reverse-composite index `(member_account_id, account_set_id)`, added in place to the setup migration (matching #761's convention). `fetch_mappings_in_op` selects exactly those two columns, so this yields index-only scans. Edited in place per the not-yet-in-production migration policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only additive index in a not-yet-in-production setup migration; no application logic changes, with slightly higher write cost on membership inserts.
> 
> **Overview**
> Adds a **reverse-composite btree index** on `cala_account_set_member_accounts (member_account_id, account_set_id)` in the setup migration, with a short comment tying it to account→set lookups on the posting path.
> 
> The existing `UNIQUE(account_set_id, member_account_id)` only supports set→member queries; lookups that filter by `member_account_id` (e.g. `fetch_mappings_in_op` during posting and `find_where_account_is_member_in_op`) were seq-scanning the membership table. This mirrors the reverse index already added on `cala_account_set_member_account_sets` in #761.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec3228b0f3e8e0584d821dec190f464bc21ca247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->