### PR TITLE
perf(outbox): raise event buffer 2k -> 50k

### DIFF
--- a/cala-ledger/src/outbox/publisher.rs
+++ b/cala-ledger/src/outbox/publisher.rs
@@ -12,7 +12,7 @@ impl OutboxPublisher {
     pub async fn init(pool: &sqlx::PgPool, clock: &ClockHandle) -> Result<Self, sqlx::Error> {
         let config = obix::MailboxConfig::builder()
             .clock(clock.clone())
-            .event_buffer_size(2_000)
+            .event_buffer_size(50_000)
             .event_cache_size(10_000)
             .build()
             .expect("MailboxConfig");


### PR DESCRIPTION
## What

Raises the cala persistent outbox `event_buffer_size` from 2,000 to 50,000 — one constant in `cala-ledger/src/outbox/publisher.rs`.

## Why

From a 4-hour lana stress test at 2 loans/s (sandbox `sb-st7-2lps`, lana image `0.62.0-rc.420`):

- The lana server was CPU-saturated the whole run (AVG 6.3–6.7 cores against a 6-core request).
- When an outbox listener stalls longer than the broadcast buffer covers, obix serves it from Postgres instead of memory (`load_next_page`, 10k-row pages) — burning the same CPU that caused the stall, a feedback loop:
  - cala outbox backfill query: **38ms → 56ms** mean per call (hour 1 → hour 4), ~3,300 rows/call, ~1 call/s sustained
  - app-side `handle_backfill_request` CPU share: **4.9% → 8.4%**
- Cala's outbox emits ~116 events/s at that load, so 2,000 slots is only ~17s of stall tolerance.

50,000 slots rides out several minutes of listener stall; events are ~1–2KB in a single shared ring (~50–100MB worst case; the test server used ~400Mi of 3Gi).

Sibling lana PR (core outbox, same bump): https://github.com/GaloyMoney/lana-bank/pull/7545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Single config change but it increases worst-case in-memory outbox buffering (~50–100MB) and affects how long stalled listeners can catch up from memory vs DB.
> 
> **Overview**
> Raises the **obix mailbox `event_buffer_size`** used when initializing `OutboxPublisher` from **2,000 to 50,000** (`cala-ledger/src/outbox/publisher.rs`). `event_cache_size` stays at 10,000.
> 
> This gives the in-memory broadcast ring more headroom when outbox consumers lag, so obix is less likely to fall back to **Postgres `load_next_page` backfill** (and the CPU feedback loop seen under stress at ~116 events/s).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e304a818c6699893bb3f2919579f85f3fda9602. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->