### PR TITLE
feat: bound concurrent postings with an optional semaphore

### DIFF
--- a/cala-ledger/src/ledger/config.rs
+++ b/cala-ledger/src/ledger/config.rs
@@ -12,6 +12,14 @@ pub struct CalaLedgerConfig {
     pub(super) exec_migrations: bool,
     #[builder(setter(into, strip_option), default)]
     pub(super) pool: Option<sqlx::PgPool>,
+    /// Bound on how many `post_transaction*` calls may be in flight at
+    /// once. Postings serialize on hot shared accounts via advisory
+    /// locks; without a bound the queue forms inside Postgres where
+    /// each waiter pins a connection, an open transaction and a
+    /// snapshot. With a bound, excess posters wait in-process instead.
+    /// `None` (default) keeps the previous unbounded behavior.
+    #[builder(setter(into, strip_option), default)]
+    pub(super) max_concurrent_postings: Option<usize>,
     #[builder(setter(into), default = "Clock::handle().clone()")]
     pub(super) clock: ClockHandle,
 }

--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -35,6 +35,7 @@ pub struct CalaLedger {
     velocities: Velocities,
     balances: Balances,
     publisher: OutboxPublisher,
+    posting_permits: Option<std::sync::Arc<tokio::sync::Semaphore>>,
 }
 
 impl CalaLedger {
@@ -72,6 +73,9 @@ impl CalaLedger {
         let balances = Balances::new(&pool, &publisher, &journals);
         let velocities = Velocities::new(&pool, &clock);
         let account_sets = AccountSets::new(&pool, &publisher, &accounts, &balances, &clock);
+        let posting_permits = config
+            .max_concurrent_postings
+            .map(|n| std::sync::Arc::new(tokio::sync::Semaphore::new(n)));
         Ok(Self {
             accounts,
             account_sets,
@@ -84,7 +88,30 @@ impl CalaLedger {
             velocities,
             pool,
             clock,
+            posting_permits,
         })
+    }
+
+    /// Wait for a posting permit when `max_concurrent_postings` is
+    /// configured. The permit is held until the returned guard drops.
+    /// Posters beyond the bound queue in-process (no connection, no
+    /// open transaction) instead of piling up on the balance-poster
+    /// advisory locks inside Postgres.
+    #[instrument(
+        name = "cala_ledger.posting_permit.acquire",
+        skip(self),
+        fields(bounded = self.posting_permits.is_some())
+    )]
+    async fn acquire_posting_permit(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
+        match &self.posting_permits {
+            Some(sem) => Some(
+                sem.clone()
+                    .acquire_owned()
+                    .await
+                    .expect("posting semaphore is never closed"),
+            ),
+            None => None,
+        }
     }
 
     pub fn pool(&self) -> &PgPool {
@@ -145,9 +172,10 @@ impl CalaLedger {
         tx_template_code: &str,
         params: impl Into<Params> + std::fmt::Debug,
     ) -> Result<Transaction, LedgerError> {
+        let _permit = self.acquire_posting_permit().await;
         let mut db = es_entity::DbOp::init_with_clock(&self.pool, &self.clock).await?;
         let transaction = self
-            .post_transaction_in_op(&mut db, tx_id, tx_template_code, params)
+            .post_transaction_in_op_ungated(&mut db, tx_id, tx_template_code, params)
             .await?;
         db.commit().await?;
         Ok(transaction)
@@ -159,6 +187,21 @@ impl CalaLedger {
         fields(transaction_id, external_id)
     )]
     pub async fn post_transaction_in_op(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        tx_id: TransactionId,
+        tx_template_code: &str,
+        params: impl Into<Params> + std::fmt::Debug,
+    ) -> Result<Transaction, LedgerError> {
+        // NOTE: callers composing several posts into one op acquire and
+        // release one permit per post, so a single task never holds more
+        // than one permit and cannot self-deadlock.
+        let _permit = self.acquire_posting_permit().await;
+        self.post_transaction_in_op_ungated(db, tx_id, tx_template_code, params)
+            .await
+    }
+
+    async fn post_transaction_in_op_ungated(
         &self,
         db: &mut impl es_entity::AtomicOperation,
         tx_id: TransactionId,

--- a/cala-ledger/tests/transaction_post.rs
+++ b/cala-ledger/tests/transaction_post.rs
@@ -81,3 +81,78 @@ async fn transaction_post() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn transaction_post_with_bounded_concurrency() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .max_concurrent_postings(1usize)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let (sender, receiver) = helpers::test_accounts();
+    let sender_account = cala.accounts().create(sender).await?;
+    let recipient_account = cala.accounts().create(receiver).await?;
+
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    cala.tx_templates()
+        .create(helpers::currency_conversion_template(&tx_code))
+        .await?;
+
+    let make_params = |journal_id: JournalId| {
+        let mut params = Params::new();
+        params.insert("journal_id", journal_id);
+        params.insert("sender", sender_account.id());
+        params.insert("recipient", recipient_account.id());
+        params
+    };
+
+    // A single permit must cover the full post_transaction path (the
+    // outer call and the inner in_op call must not each take a permit).
+    cala.post_transaction(TransactionId::new(), &tx_code, make_params(journal.id()))
+        .await?;
+
+    // Same for a caller-composed op posting twice sequentially.
+    let mut op = cala.begin_operation().await?;
+    cala.post_transaction_in_op(
+        &mut op,
+        TransactionId::new(),
+        &tx_code,
+        make_params(journal.id()),
+    )
+    .await?;
+    cala.post_transaction_in_op(
+        &mut op,
+        TransactionId::new(),
+        &tx_code,
+        make_params(journal.id()),
+    )
+    .await?;
+    op.commit().await?;
+
+    // Concurrent posters complete even with the bound in place.
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let cala = cala.clone();
+        let tx_code = tx_code.clone();
+        let mut params = make_params(journal.id());
+        handles.push(tokio::spawn(async move {
+            cala.post_transaction(TransactionId::new(), &tx_code, std::mem::take(&mut params))
+                .await
+        }));
+    }
+    for handle in handles {
+        handle.await??;
+    }
+
+    let recipient_balance = cala
+        .balances()
+        .find(journal.id(), recipient_account.id(), "BTC".parse().unwrap())
+        .await?;
+    assert_eq!(recipient_balance.settled(), Decimal::from(1290 * 7));
+
+    Ok(())
+}


### PR DESCRIPTION
## Why

Under sustained posting load (lana stress test, 2 loans/s target), the balance-poster lock prelude in `BalanceRepo::find_for_update` was the #1 DB-time consumer by far: ~95% of all DB time, windowed mean **683ms at hour 1 rising to 976ms at hour 4**, with 100% buffer hits — i.e. pure advisory-lock wait. Every hot shared account (omnibus, top-of-chart sets) serializes postings on `pg_advisory_xact_lock(journal|account|currency)`, and when arrival rate exceeds the serialized service rate, the queue forms **inside Postgres**, where each waiter pins:

- a pool connection,
- an open transaction / MVCC snapshot (impedes vacuum under sustained load),
- an app task that is invisible to any app-level backpressure.

That pileup is what turned a throughput ceiling into a stability incident (liveness-probe kill ~20 min into the soak).

## What

New `CalaLedgerConfig::max_concurrent_postings: Option<usize>` (default `None` = unchanged behavior). When set, `CalaLedger` holds a `tokio::sync::Semaphore` and every posting acquires a permit first, moving the queue in-process: waiters hold no connection, no snapshot, and their wait shows up in traces under the `cala_ledger.posting_permit.acquire` span.

Gating covers both entry points exactly once:

- `post_transaction` acquires **before** creating its `DbOp` (waiters don't even hold a connection), then delegates to an ungated inner fn.
- `post_transaction_in_op` acquires per call; a caller composing several posts into one op acquires/releases one permit at a time, so no self-deadlock (covered by the new test with `max_concurrent_postings(1)`).

Explicitly **not** claimed: this does not raise the serialization ceiling of a hot account (that's the `eventually_consistent` escape hatch + shorter hold times). It keeps the system stable *at* the ceiling instead of collapsing below it, and makes saturation observable.

## Test

- New `transaction_post_with_bounded_concurrency`: limit 1, single post, two sequential posts in one composed op, then 4 concurrent posters; asserts final balance. Would deadlock if any path double-acquired.
- Full `cala-ledger` suite: 95/95 pass.

## Follow-ups (not in this PR)

- Wire a `LANA__LEDGER__MAX_CONCURRENT_POSTINGS` (or similar) through lana-app once a cala release includes this.
- Validate on a stress-testing sandbox: expect windowed mean of the `find_for_update` lock query to drop from ~1s to ~raw hold time, no liveness events, achieved loans/s flat across the 4h soak.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core posting path and can throttle throughput when the limit is set too low, but default is off and behavior is opt-in with explicit backpressure intent.
> 
> **Overview**
> Adds **`CalaLedgerConfig::max_concurrent_postings`** (`Option<usize>`, default `None` for unchanged behavior). When set, **`CalaLedger`** keeps a **`tokio::sync::Semaphore`** and acquires a permit before posting work touches the DB.
> 
> **`post_transaction`** waits for a permit **before** opening a `DbOp`, then runs the existing logic via a new **`post_transaction_in_op_ungated`** helper so the outer path does not double-acquire. **`post_transaction_in_op`** acquires one permit per call (release between sequential posts in a composed op) to avoid self-deadlock.
> 
> Excess posters queue in-process instead of stacking on Postgres advisory-lock wait with pinned connections and transactions; permit wait is visible under **`cala_ledger.posting_permit.acquire`**.
> 
> Adds **`transaction_post_with_bounded_concurrency`** (`max_concurrent_postings(1)`: standalone post, two posts in one op, four concurrent posters, balance assertion).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a3b37c745a6a61b8e6a2553481749ee78a861d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->