### PR TITLE
perf(ledger): skip collection args in #[instrument] span fields

### DIFF
--- a/cala-ledger/src/account/mod.rs
+++ b/cala-ledger/src/account/mod.rs
@@ -83,7 +83,7 @@ impl Accounts {
         Ok(self.repo.find_all(account_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_all", skip(self, db, account_ids), fields(account_ids_count = account_ids.len()))]
+    #[instrument(name = "cala_ledger.accounts.find_all_in_op", skip(self, db, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn find_all_in_op<T: From<Account>>(
         &self,
         db: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/account/mod.rs
+++ b/cala-ledger/src/account/mod.rs
@@ -75,7 +75,7 @@ impl Accounts {
         Ok(self.repo.find_by_id(account_id).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_all", skip(self))]
+    #[instrument(name = "cala_ledger.accounts.find_all", skip(self, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn find_all<T: From<Account>>(
         &self,
         account_ids: &[AccountId],
@@ -83,7 +83,7 @@ impl Accounts {
         Ok(self.repo.find_all(account_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_all", skip(self, db))]
+    #[instrument(name = "cala_ledger.accounts.find_all", skip(self, db, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn find_all_in_op<T: From<Account>>(
         &self,
         db: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/account/mod.rs
+++ b/cala-ledger/src/account/mod.rs
@@ -60,7 +60,7 @@ impl Accounts {
         Ok(accounts)
     }
 
-    #[instrument(name = "cala_ledger.accounts.create_all_in_op", skip(self, db))]
+    #[instrument(name = "cala_ledger.accounts.create_all_in_op", skip(self, db, new_accounts), fields(count = new_accounts.len()))]
     pub async fn create_all_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -337,7 +337,7 @@ impl AccountSets {
         Ok(account_set)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find_all", skip(self))]
+    #[instrument(name = "cala_ledger.account_sets.find_all", skip(self, account_set_ids), fields(account_set_ids_count = account_set_ids.len()))]
     pub async fn find_all<T: From<AccountSet>>(
         &self,
         account_set_ids: &[AccountSetId],
@@ -345,7 +345,7 @@ impl AccountSets {
         Ok(self.repo.find_all(account_set_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find_all_in_op", skip(self, op))]
+    #[instrument(name = "cala_ledger.account_sets.find_all_in_op", skip(self, op, account_set_ids), fields(account_set_ids_count = account_set_ids.len()))]
     pub async fn find_all_in_op<T: From<AccountSet>>(
         &self,
         op: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -82,7 +82,7 @@ impl AccountSets {
         Ok(account_sets)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.create_all_in_op", skip(self, db))]
+    #[instrument(name = "cala_ledger.account_sets.create_all_in_op", skip(self, db, new_account_sets), fields(count = new_account_sets.len()))]
     pub async fn create_all_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -536,7 +536,8 @@ impl AccountSets {
 
     #[instrument(
         name = "cala_ledger.account_sets.recalculate_balances_batch",
-        skip(self)
+        skip(self, account_set_ids),
+        fields(account_set_ids_count = account_set_ids.len())
     )]
     pub async fn recalculate_balances_batch(
         &self,
@@ -551,7 +552,8 @@ impl AccountSets {
 
     #[instrument(
         name = "cala_ledger.account_sets.recalculate_balances_batch_in_op",
-        skip(self, op)
+        skip(self, op, account_set_ids),
+        fields(account_set_ids_count = account_set_ids.len())
     )]
     pub async fn recalculate_balances_batch_in_op(
         &self,
@@ -611,7 +613,8 @@ impl AccountSets {
     /// descendant account sets in a single batch.
     #[instrument(
         name = "cala_ledger.account_sets.recalculate_balances_deep",
-        skip(self)
+        skip(self, account_set_ids),
+        fields(account_set_ids_count = account_set_ids.len())
     )]
     pub async fn recalculate_balances_deep(
         &self,
@@ -626,7 +629,8 @@ impl AccountSets {
 
     #[instrument(
         name = "cala_ledger.account_sets.recalculate_balances_deep_in_op",
-        skip(self, op)
+        skip(self, op, account_set_ids),
+        fields(account_set_ids_count = account_set_ids.len())
     )]
     pub async fn recalculate_balances_deep_in_op(
         &self,

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -70,7 +70,7 @@ impl EffectiveBalances {
         }
     }
 
-    #[instrument(name = "cala_ledger.balance.effective.find_all_cumulative", skip(self))]
+    #[instrument(name = "cala_ledger.balance.effective.find_all_cumulative", skip(self, ids), fields(ids_count = ids.len()))]
     pub async fn find_all_cumulative(
         &self,
         ids: &[BalanceId],
@@ -100,7 +100,8 @@ impl EffectiveBalances {
 
     #[instrument(
         name = "cala_ledger.balance.effective.list_cumulative_for_accounts",
-        skip(self)
+        skip(self, account_ids),
+        fields(account_ids_count = account_ids.len())
     )]
     pub async fn list_cumulative_for_accounts(
         &self,
@@ -115,7 +116,7 @@ impl EffectiveBalances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.effective.find_all_in_range", skip(self))]
+    #[instrument(name = "cala_ledger.balance.effective.find_all_in_range", skip(self, ids), fields(ids_count = ids.len()))]
     pub async fn find_all_in_range(
         &self,
         ids: &[BalanceId],
@@ -148,7 +149,8 @@ impl EffectiveBalances {
 
     #[instrument(
         name = "cala_ledger.balance.effective.list_in_range_for_accounts",
-        skip(self)
+        skip(self, account_ids),
+        fields(account_ids_count = account_ids.len())
     )]
     pub async fn list_in_range_for_accounts(
         &self,

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -181,7 +181,11 @@ impl EffectiveBalances {
 
     #[instrument(
         name = "cala_ledger.balance.effective.recalculate_for_account_sets_in_op",
-        skip(self, op)
+        skip(self, op, account_set_ids, memberships),
+        fields(
+            account_set_ids_count = account_set_ids.len(),
+            memberships_count = memberships.len()
+        )
     )]
     pub(crate) async fn recalculate_for_account_sets_in_op(
         &self,

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -97,7 +97,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.find_all", skip(self))]
+    #[instrument(name = "cala_ledger.balance.find_all", skip(self, ids), fields(ids_count = ids.len()))]
     pub async fn find_all(
         &self,
         ids: &[BalanceId],
@@ -120,7 +120,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.list_for_accounts", skip(self))]
+    #[instrument(name = "cala_ledger.balance.list_for_accounts", skip(self, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn list_for_accounts(
         &self,
         journal_id: JournalId,
@@ -133,7 +133,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.find_all_in_op", skip(self, op))]
+    #[instrument(name = "cala_ledger.balance.find_all_in_op", skip(self, op, ids), fields(ids_count = ids.len()))]
     pub async fn find_all_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -158,7 +158,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.list_for_accounts_in_op", skip(self, op))]
+    #[instrument(name = "cala_ledger.balance.list_for_accounts_in_op", skip(self, op, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn list_for_accounts_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -275,7 +275,8 @@ impl Balances {
 
     #[instrument(
         name = "cala_ledger.balances.recalculate_account_set_balances_batch_in_op",
-        skip(self, op),
+        skip(self, op, account_set_ids),
+        fields(account_set_ids_count = account_set_ids.len()),
         err(level = "warn")
     )]
     pub(crate) async fn recalculate_account_set_balances_batch_in_op(

--- a/cala-ledger/src/balance/repo.rs
+++ b/cala-ledger/src/balance/repo.rs
@@ -344,7 +344,7 @@ impl BalanceRepo {
     /// nested-loop join with `v` as the outer side for the tiny inputs
     /// this query receives, preserving UNNEST scan order through to
     /// the function calls in the SELECT list.
-    #[instrument(name = "cala_ledger.balances.find_for_update", skip(self, op))]
+    #[instrument(name = "cala_ledger.balances.find_for_update", skip(self, op, account_ids, currencies), fields(balances_count = account_ids.len()))]
     pub(super) async fn find_for_update(
         &self,
         op: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/journal/mod.rs
+++ b/cala-ledger/src/journal/mod.rs
@@ -46,7 +46,7 @@ impl Journals {
         Ok(journal)
     }
 
-    #[instrument(name = "cala_ledger.journals.find_all", skip(self))]
+    #[instrument(name = "cala_ledger.journals.find_all", skip(self, journal_ids), fields(journal_ids_count = journal_ids.len()))]
     pub async fn find_all<T: From<Journal>>(
         &self,
         journal_ids: &[JournalId],

--- a/cala-ledger/src/transaction/mod.rs
+++ b/cala-ledger/src/transaction/mod.rs
@@ -70,7 +70,7 @@ impl Transactions {
             .await?)
     }
 
-    #[instrument(name = "cala_ledger.transactions.find_all", skip(self))]
+    #[instrument(name = "cala_ledger.transactions.find_all", skip(self, transaction_ids), fields(transaction_ids_count = transaction_ids.len()))]
     pub async fn find_all<T: From<Transaction>>(
         &self,
         transaction_ids: &[TransactionId],

--- a/cala-ledger/src/tx_template/mod.rs
+++ b/cala-ledger/src/tx_template/mod.rs
@@ -59,7 +59,7 @@ impl TxTemplates {
         Ok(tx_template)
     }
 
-    #[instrument(name = "cala_ledger.tx_templates.find_all", skip(self))]
+    #[instrument(name = "cala_ledger.tx_templates.find_all", skip(self, tx_template_ids), fields(tx_template_ids_count = tx_template_ids.len()))]
     pub async fn find_all<T: From<TxTemplate>>(
         &self,
         tx_template_ids: &[TxTemplateId],

--- a/cala-ledger/src/velocity/mod.rs
+++ b/cala-ledger/src/velocity/mod.rs
@@ -193,7 +193,7 @@ impl Velocities {
         Ok(control)
     }
 
-    #[instrument(name = "velocity.update_balances_with_limit_enforcement_in_op", skip(self, db, transaction, entries, account_set_mappings), fields(account_ids_count = account_ids.len(), entries_count = entries.len()), err(level = tracing::Level::WARN))]
+    #[instrument(name = "velocity.update_balances_with_limit_enforcement_in_op", skip(self, db, transaction, entries, account_ids, account_set_mappings), fields(account_ids_count = account_ids.len(), entries_count = entries.len()), err(level = tracing::Level::WARN))]
     pub(crate) async fn update_balances_with_limit_enforcement_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/velocity/mod.rs
+++ b/cala-ledger/src/velocity/mod.rs
@@ -250,7 +250,7 @@ impl Velocities {
         self.limits.list_for_control(op, control_id).await
     }
 
-    #[instrument(name = "velocity.find_all_limits", skip(self), fields(count = limit_ids.len()), err(level = tracing::Level::WARN))]
+    #[instrument(name = "velocity.find_all_limits", skip(self, limit_ids), fields(count = limit_ids.len()), err(level = tracing::Level::WARN))]
     pub async fn find_all_limits<T: From<VelocityLimit>>(
         &self,
         limit_ids: &[VelocityLimitId],
@@ -258,7 +258,7 @@ impl Velocities {
         Ok(self.limits.find_all(limit_ids).await?)
     }
 
-    #[instrument(name = "velocity.find_all_controls", skip(self), fields(count = control_ids.len()))]
+    #[instrument(name = "velocity.find_all_controls", skip(self, control_ids), fields(count = control_ids.len()))]
     pub async fn find_all_controls<T: From<VelocityControl>>(
         &self,
         control_ids: &[VelocityControlId],


### PR DESCRIPTION
## Why

Found during a 5h stress test of lana-bank (3 loans/s, simulated time) against cala-ledger 0.18.3. Two CPU flamegraphs (`/debug/pprof`) showed a large share of the server's burn in **Debug-formatting collections for tracing spans**:

- Steady state: allocator churn dominated, with span-field formatting a major contributor.
- During the EOD `recalculate-account-set-balances` job: **~80% of the recalc thread's samples** were in `core::fmt::write` → `HashMap::fmt` / `Vec::fmt` → `AccountSetId`/`Uuid` Debug — i.e. formatting `memberships: &HashMap<AccountId, Vec<AccountSetId>>` (millions of entries at that table size) and `account_set_ids`, *inside the transaction that holds the EC-set exclusive advisory locks*. The formatting directly stretched lock hold time while ~19 poster sessions sat blocked on `pg_advisory_xact_lock_shared` for 50+ minutes.

`#[instrument]` Debug-records every un-skipped argument, and both the console fmt layer and the OTel layer format eagerly at span creation — so these were pure CPU taxes on the hottest paths.

## What

Skip the collection args; record `*_count = len()` fields instead, following the existing `create_all` / `update_balances_in_op` precedent:

| Function | Was formatting |
|---|---|
| `effective::recalculate_for_account_sets_in_op` | `account_set_ids`, `memberships` (the giant one) |
| `balances::recalculate_account_set_balances_batch_in_op` | `account_set_ids` |
| `account_sets::recalculate_balances_{batch,deep}{,_in_op}` | `account_set_ids` (thousands after deep walk) |
| `balances::find_for_update` | `(account_ids, currencies)` tuple, every posting |
| `velocity::update_balances_with_limit_enforcement_in_op` | `account_ids` (already had `account_ids_count` field but wasn't skipped) |
| `accounts::create_all_in_op`, `account_sets::create_all_in_op` | `Vec<NewAccount>` / `Vec<NewAccountSet>` batches |

Second commit applies the same rule to the remaining read-path `find_all` / `list_*` facades (`accounts`, `account_sets`, `balances` + in-op variants, `journals`, `transactions`, `tx_templates`, `balance.effective.*`, `velocity.find_all_{limits,controls}`), so the convention is now uniform: no collection argument is Debug-recorded into a span anywhere in cala-ledger (verified by a sweep of every `#[instrument]` in the crate). `velocity.find_all_{limits,controls}` had the same count-field-but-not-skipped oversight. Not purely theoretical here either: `find_all_in_op` is invoked with a full recalc chunk's account set (hundreds to thousands of ids).

No behavior change beyond span field content.

## Verification

- `SQLX_OFFLINE=true cargo check -p cala-ledger --all-features` ✅
- `cargo clippy -p cala-ledger --all-features` clean ✅
- `cargo fmt --check` clean ✅
- Attribute-only change; DB-backed tests left to CI.

## Also included

Third commit fixes a copy/paste bug found while here: `accounts.find_all_in_op` used the same span name as non-op `find_all` (`cala_ledger.accounts.find_all`), making the two indistinguishable in traces — renamed to `cala_ledger.accounts.find_all_in_op` per the `account_sets`/`balance` convention. Verified it was the only duplicated span name in the crate. **Note:** if any dashboards/alerts aggregate on the old shared name, they'll now see the two spans split.
