### PR TITLE
perf(ledger): demote inner-path spans to debug level

### DIFF
--- a/cala-ledger/src/account/mod.rs
+++ b/cala-ledger/src/account/mod.rs
@@ -31,7 +31,7 @@ impl Accounts {
         }
     }
 
-    #[instrument(name = "cala_ledger.accounts.create", skip_all)]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.create", skip_all)]
     pub async fn create(&self, new_account: NewAccount) -> Result<Account, AccountError> {
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
         let account = self.create_in_op(&mut op, new_account).await?;
@@ -39,7 +39,11 @@ impl Accounts {
         Ok(account)
     }
 
-    #[instrument(name = "cala_ledger.accounts.create_in_op", skip(self, db))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts.create_in_op",
+        skip(self, db)
+    )]
     pub async fn create_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -49,7 +53,7 @@ impl Accounts {
         Ok(account)
     }
 
-    #[instrument(name = "cala_ledger.accounts.create_all", skip_all)]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.create_all", skip_all)]
     pub async fn create_all(
         &self,
         new_accounts: Vec<NewAccount>,
@@ -60,7 +64,7 @@ impl Accounts {
         Ok(accounts)
     }
 
-    #[instrument(name = "cala_ledger.accounts.create_all_in_op", skip(self, db, new_accounts), fields(count = new_accounts.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.create_all_in_op", skip(self, db, new_accounts), fields(count = new_accounts.len()))]
     pub async fn create_all_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -70,12 +74,12 @@ impl Accounts {
         Ok(accounts)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find", skip_all)]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.find", skip_all)]
     pub async fn find(&self, account_id: AccountId) -> Result<Account, AccountError> {
         Ok(self.repo.find_by_id(account_id).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_all", skip(self, account_ids), fields(account_ids_count = account_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.find_all", skip(self, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn find_all<T: From<Account>>(
         &self,
         account_ids: &[AccountId],
@@ -83,7 +87,7 @@ impl Accounts {
         Ok(self.repo.find_all(account_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_all_in_op", skip(self, db, account_ids), fields(account_ids_count = account_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.find_all_in_op", skip(self, db, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn find_all_in_op<T: From<Account>>(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -92,17 +96,25 @@ impl Accounts {
         Ok(self.repo.find_all_in_op(db, account_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_by_external_id", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts.find_by_external_id",
+        skip(self)
+    )]
     pub async fn find_by_external_id(&self, external_id: String) -> Result<Account, AccountError> {
         Ok(self.repo.find_by_external_id(Some(external_id)).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.find_by_code", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts.find_by_code",
+        skip(self)
+    )]
     pub async fn find_by_code(&self, code: String) -> Result<Account, AccountError> {
         Ok(self.repo.find_by_code(code).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.list", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.list", skip(self))]
     pub async fn list(
         &self,
         query: es_entity::PaginatedQueryArgs<AccountByNameCursor>,
@@ -110,7 +122,11 @@ impl Accounts {
         Ok(self.repo.list_by_name(query, Default::default()).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts.lock_in_op", skip(self, db))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts.lock_in_op",
+        skip(self, db)
+    )]
     pub async fn lock_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -123,7 +139,11 @@ impl Accounts {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.accounts.unlock_in_op", skip(self, db))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts.unlock_in_op",
+        skip(self, db)
+    )]
     pub async fn unlock_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -136,7 +156,11 @@ impl Accounts {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.accounts.persist", skip(self, account))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts.persist",
+        skip(self, account)
+    )]
     pub async fn persist(&self, account: &mut Account) -> Result<(), AccountError> {
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
         self.persist_in_op(&mut op, account).await?;
@@ -144,7 +168,7 @@ impl Accounts {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.accounts.persist_in_op", skip_all)]
+    #[instrument(level = "debug", name = "cala_ledger.accounts.persist_in_op", skip_all)]
     pub async fn persist_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -158,6 +182,7 @@ impl Accounts {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.accounts.update_velocity_context_values_in_op",
         skip_all
     )]

--- a/cala-ledger/src/account/repo.rs
+++ b/cala-ledger/src/account/repo.rs
@@ -50,6 +50,7 @@ impl AccountRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account.update_velocity_context_values_in_op",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -37,7 +37,7 @@ impl AccountSets {
             clock: clock.clone(),
         }
     }
-    #[instrument(name = "cala_ledger.account_sets.create", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.create", skip(self))]
     pub async fn create(
         &self,
         new_account_set: NewAccountSet,
@@ -48,7 +48,11 @@ impl AccountSets {
         Ok(account_set)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.create_in_op", skip(self, db))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.create_in_op",
+        skip(self, db)
+    )]
     pub async fn create_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -71,7 +75,7 @@ impl AccountSets {
         Ok(account_set)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.create_all", skip(self, new_account_sets), fields(count = new_account_sets.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.create_all", skip(self, new_account_sets), fields(count = new_account_sets.len()))]
     pub async fn create_all(
         &self,
         new_account_sets: Vec<NewAccountSet>,
@@ -82,7 +86,7 @@ impl AccountSets {
         Ok(account_sets)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.create_all_in_op", skip(self, db, new_account_sets), fields(count = new_account_sets.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.create_all_in_op", skip(self, db, new_account_sets), fields(count = new_account_sets.len()))]
     pub async fn create_all_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -109,7 +113,11 @@ impl AccountSets {
         Ok(account_sets)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.persist", skip(self, account_set))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.persist",
+        skip(self, account_set)
+    )]
     pub async fn persist(&self, account_set: &mut AccountSet) -> Result<(), AccountSetError> {
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
         self.persist_in_op(&mut op, account_set).await?;
@@ -118,6 +126,7 @@ impl AccountSets {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.account_sets.persist_in_op",
         skip(self, db, account_set)
     )]
@@ -135,7 +144,7 @@ impl AccountSets {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.account_sets.add_member", skip(self, member), fields(account_set_id = %account_set_id))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.add_member", skip(self, member), fields(account_set_id = %account_set_id))]
     pub async fn add_member(
         &self,
         account_set_id: AccountSetId,
@@ -150,6 +159,7 @@ impl AccountSets {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.account_sets.add_member_in_op",
         skip(self, op, member),
         fields(
@@ -259,7 +269,7 @@ impl AccountSets {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.account_sets.remove_member", skip(self, member), fields(account_set_id = %account_set_id))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.remove_member", skip(self, member), fields(account_set_id = %account_set_id))]
     pub async fn remove_member(
         &self,
         account_set_id: AccountSetId,
@@ -274,6 +284,7 @@ impl AccountSets {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.account_sets.remove_member_in_op",
         skip(self, op, member),
         fields(account_set_id = %account_set_id),
@@ -337,7 +348,7 @@ impl AccountSets {
         Ok(account_set)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find_all", skip(self, account_set_ids), fields(account_set_ids_count = account_set_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.find_all", skip(self, account_set_ids), fields(account_set_ids_count = account_set_ids.len()))]
     pub async fn find_all<T: From<AccountSet>>(
         &self,
         account_set_ids: &[AccountSetId],
@@ -345,7 +356,7 @@ impl AccountSets {
         Ok(self.repo.find_all(account_set_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find_all_in_op", skip(self, op, account_set_ids), fields(account_set_ids_count = account_set_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.find_all_in_op", skip(self, op, account_set_ids), fields(account_set_ids_count = account_set_ids.len()))]
     pub async fn find_all_in_op<T: From<AccountSet>>(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -354,12 +365,16 @@ impl AccountSets {
         Ok(self.repo.find_all_in_op(op, account_set_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.account_sets.find", skip(self))]
     pub async fn find(&self, account_set_id: AccountSetId) -> Result<AccountSet, AccountSetError> {
         Ok(self.repo.find_by_id(account_set_id).await?)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find_in_op", skip(self, op))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.find_in_op",
+        skip(self, op)
+    )]
     pub async fn find_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -368,7 +383,11 @@ impl AccountSets {
         Ok(self.repo.find_by_id_in_op(op, account_set_id).await?)
     }
 
-    #[instrument(name = "cala_ledger.accounts_sets.find_by_external_id", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.accounts_sets.find_by_external_id",
+        skip(self)
+    )]
     pub async fn find_by_external_id(
         &self,
         external_id: String,
@@ -376,7 +395,11 @@ impl AccountSets {
         Ok(self.repo.find_by_external_id(Some(external_id)).await?)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.find_where_member", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.find_where_member",
+        skip(self)
+    )]
     pub async fn find_where_member(
         &self,
         member: impl Into<AccountSetMemberId> + std::fmt::Debug,
@@ -397,7 +420,11 @@ impl AccountSets {
         }
     }
 
-    #[instrument(name = "cala_ledger.account_sets.list_for_name", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.list_for_name",
+        skip(self)
+    )]
     pub async fn list_for_name(
         &self,
         name: String,
@@ -412,7 +439,11 @@ impl AccountSets {
             .await?)
     }
 
-    #[instrument(name = "cala_ledger.account_sets.list_for_name_in_op", skip(self, op))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.list_for_name_in_op",
+        skip(self, op)
+    )]
     pub async fn list_for_name_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -429,6 +460,7 @@ impl AccountSets {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.account_sets.find_where_member_in_op",
         skip(self, op)
     )]
@@ -670,6 +702,7 @@ impl AccountSets {
     /// to batch-recalculate balances for EC account sets (e.g. via
     /// [`Self::recalculate_balances_deep`]).
     #[instrument(
+        level = "debug",
         name = "cala_ledger.account_sets.list_eventually_consistent_ids",
         skip(self)
     )]
@@ -682,6 +715,7 @@ impl AccountSets {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.account_sets.list_eventually_consistent_ids_in_op",
         skip(self, op)
     )]

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -161,6 +161,7 @@ impl AccountSetRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_set.list_children_by_created_at_in_op",
         skip_all,
         err(level = "warn")
@@ -417,6 +418,7 @@ impl AccountSetRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_set.add_member_account_and_return_parents",
         skip_all,
         err(level = "warn")
@@ -490,6 +492,7 @@ impl AccountSetRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_set.remove_member_account_and_return_parents",
         skip_all,
         err(level = "warn")
@@ -560,6 +563,7 @@ impl AccountSetRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_set.add_member_set_and_return_parents",
         skip_all,
         err(level = "warn")
@@ -646,6 +650,7 @@ impl AccountSetRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_set.remove_member_set_and_return_parents",
         skip_all,
         err(level = "warn")
@@ -824,6 +829,7 @@ impl AccountSetRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_set.fetch_mappings_in_op",
         skip_all,
         err(level = "warn")
@@ -869,6 +875,7 @@ impl AccountSetRepo {
     // account-set ids — not fully hydrated `AccountSet` entities — which keeps
     // periodic reconciliation jobs cheap as the number of EC account sets grows.
     #[instrument(
+        level = "debug",
         name = "account_set.list_eventually_consistent_ids_in_op",
         skip_all,
         err(level = "warn")
@@ -915,6 +922,7 @@ impl AccountSetRepo {
     /// out at the SQL level so callers (the recalc deep walk) don't try
     /// to recalc them.
     #[instrument(
+        level = "debug",
         name = "account_set.find_all_ec_descendant_set_ids",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -38,7 +38,11 @@ impl EffectiveBalances {
         }
     }
 
-    #[instrument(name = "cala_ledger.balance.effective.find_cumulative", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balance.effective.find_cumulative",
+        skip(self)
+    )]
     pub async fn find_cumulative(
         &self,
         journal_id: JournalId,
@@ -51,7 +55,11 @@ impl EffectiveBalances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.effective.find_in_range", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balance.effective.find_in_range",
+        skip(self)
+    )]
     pub async fn find_in_range(
         &self,
         journal_id: JournalId,
@@ -70,7 +78,7 @@ impl EffectiveBalances {
         }
     }
 
-    #[instrument(name = "cala_ledger.balance.effective.find_all_cumulative", skip(self, ids), fields(ids_count = ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.effective.find_all_cumulative", skip(self, ids), fields(ids_count = ids.len()))]
     pub async fn find_all_cumulative(
         &self,
         ids: &[BalanceId],
@@ -80,6 +88,7 @@ impl EffectiveBalances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.effective.list_cumulative_for_account",
         skip(self)
     )]
@@ -99,6 +108,7 @@ impl EffectiveBalances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.effective.list_cumulative_for_accounts",
         skip(self, account_ids),
         fields(account_ids_count = account_ids.len())
@@ -116,7 +126,7 @@ impl EffectiveBalances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.effective.find_all_in_range", skip(self, ids), fields(ids_count = ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.effective.find_all_in_range", skip(self, ids), fields(ids_count = ids.len()))]
     pub async fn find_all_in_range(
         &self,
         ids: &[BalanceId],
@@ -128,6 +138,7 @@ impl EffectiveBalances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.effective.list_in_range_for_account",
         skip(self)
     )]
@@ -148,6 +159,7 @@ impl EffectiveBalances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.effective.list_in_range_for_accounts",
         skip(self, account_ids),
         fields(account_ids_count = account_ids.len())
@@ -182,6 +194,7 @@ impl EffectiveBalances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.effective.recalculate_for_account_sets_in_op",
         skip(self, op, account_set_ids, memberships),
         fields(
@@ -256,6 +269,7 @@ impl EffectiveBalances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.effective.replay_effective_deltas",
         skip_all
     )]

--- a/cala-ledger/src/balance/effective/repo.rs
+++ b/cala-ledger/src/balance/effective/repo.rs
@@ -53,7 +53,12 @@ impl EffectiveBalanceRepo {
             .await
     }
 
-    #[instrument(name = "effective_balance.find_in_op", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "effective_balance.find_in_op",
+        skip_all,
+        err(level = "warn")
+    )]
     pub async fn find_in_op(
         &self,
         op: impl es_entity::IntoOneTimeExecutor<'_>,
@@ -93,7 +98,12 @@ impl EffectiveBalanceRepo {
         }
     }
 
-    #[instrument(name = "effective_balance.find_range", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "effective_balance.find_range",
+        skip_all,
+        err(level = "warn")
+    )]
     pub(super) async fn find_range(
         &self,
         journal_id: JournalId,
@@ -167,7 +177,11 @@ impl EffectiveBalanceRepo {
         Ok((first, last, last_version - first_version))
     }
 
-    #[instrument(name = "cala_ledger.balances.effective.find_all", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balances.effective.find_all",
+        skip_all
+    )]
     pub(super) async fn find_all(
         &self,
         ids: &[BalanceId],
@@ -230,7 +244,11 @@ impl EffectiveBalanceRepo {
         Ok(ret)
     }
 
-    #[instrument(name = "cala_ledger.balances.effective.list_for_account", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balances.effective.list_for_account",
+        skip_all
+    )]
     pub(super) async fn list_for_account(
         &self,
         journal_id: JournalId,
@@ -296,7 +314,11 @@ impl EffectiveBalanceRepo {
         })
     }
 
-    #[instrument(name = "cala_ledger.balances.effective.list_for_accounts", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balances.effective.list_for_accounts",
+        skip_all
+    )]
     pub(super) async fn list_for_accounts(
         &self,
         journal_id: JournalId,
@@ -388,7 +410,11 @@ impl EffectiveBalanceRepo {
         })
     }
 
-    #[instrument(name = "cala_ledger.balances.effective.find_range_all", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balances.effective.find_range_all",
+        skip_all
+    )]
     pub(super) async fn find_range_all(
         &self,
         ids: &[BalanceId],
@@ -497,6 +523,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.effective.list_range_for_account",
         skip_all
     )]
@@ -630,6 +657,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.effective.list_range_for_accounts",
         skip_all
     )]
@@ -795,6 +823,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.effective.find_for_update",
         skip(self, op)
     )]
@@ -901,6 +930,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "effective_balance.fetch_member_effective_history",
         skip_all,
         err(level = "warn")
@@ -969,6 +999,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "effective_balance.fetch_effective_history_from_date",
         skip_all,
         err(level = "warn")
@@ -1037,6 +1068,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "effective_balance.delete_at_or_after",
         skip_all,
         err(level = "warn")
@@ -1066,6 +1098,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "effective_balance.load_latest_before",
         skip_all,
         err(level = "warn")
@@ -1115,6 +1148,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "effective_balance.insert_recalc_snapshots",
         skip(self, op, snapshots)
     )]
@@ -1187,6 +1221,7 @@ impl EffectiveBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.effective.insert_new_snapshots",
         skip(self, op, new_balances)
     )]

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -72,7 +72,7 @@ impl Balances {
         &self.effective
     }
 
-    #[instrument(name = "cala_ledger.balance.find", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.find", skip(self))]
     pub async fn find(
         &self,
         journal_id: JournalId,
@@ -84,7 +84,11 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.find_in_op", skip(self, op))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balance.find_in_op",
+        skip(self, op)
+    )]
     pub async fn find_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -97,7 +101,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.find_all", skip(self, ids), fields(ids_count = ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.find_all", skip(self, ids), fields(ids_count = ids.len()))]
     pub async fn find_all(
         &self,
         ids: &[BalanceId],
@@ -105,7 +109,11 @@ impl Balances {
         self.repo.find_all(ids).await
     }
 
-    #[instrument(name = "cala_ledger.balance.list_for_account", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balance.list_for_account",
+        skip(self)
+    )]
     pub async fn list_for_account(
         &self,
         journal_id: JournalId,
@@ -120,7 +128,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.list_for_accounts", skip(self, account_ids), fields(account_ids_count = account_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.list_for_accounts", skip(self, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn list_for_accounts(
         &self,
         journal_id: JournalId,
@@ -133,7 +141,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.find_all_in_op", skip(self, op, ids), fields(ids_count = ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.find_all_in_op", skip(self, op, ids), fields(ids_count = ids.len()))]
     pub async fn find_all_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -142,7 +150,11 @@ impl Balances {
         self.repo.find_all_in_op(op, ids).await
     }
 
-    #[instrument(name = "cala_ledger.balance.list_for_account_in_op", skip(self, op))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balance.list_for_account_in_op",
+        skip(self, op)
+    )]
     pub async fn list_for_account_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -158,7 +170,7 @@ impl Balances {
             .await
     }
 
-    #[instrument(name = "cala_ledger.balance.list_for_accounts_in_op", skip(self, op, account_ids), fields(account_ids_count = account_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balance.list_for_accounts_in_op", skip(self, op, account_ids), fields(account_ids_count = account_ids.len()))]
     pub async fn list_for_accounts_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -173,6 +185,7 @@ impl Balances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.update_balances_in_op",
         skip(self, op, entries, account_set_mappings),
         fields(journal_id = %journal_id, entries_count = entries.len()),
@@ -252,6 +265,7 @@ impl Balances {
     /// `cala_balance_history` for `journal_id`, under the lock prelude
     /// described on `BalanceRepo::member_has_balance_history_in_op`.
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balance.member_has_balance_history_in_op",
         skip(self, op),
         fields(
@@ -274,6 +288,7 @@ impl Balances {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.recalculate_account_set_balances_batch_in_op",
         skip(self, op, account_set_ids),
         fields(account_set_ids_count = account_set_ids.len()),
@@ -352,7 +367,11 @@ impl Balances {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.balances.replay_member_deltas_batch", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balances.replay_member_deltas_batch",
+        skip_all
+    )]
     fn replay_member_deltas_batch(
         journal_id: JournalId,
         mut set_states: HashMap<AccountSetId, SetRecalcState>,
@@ -469,7 +488,7 @@ impl Balances {
         new_snapshots
     }
 
-    #[instrument(name = "cala_ledger.balances.new_snapshots", skip_all)]
+    #[instrument(level = "debug", name = "cala_ledger.balances.new_snapshots", skip_all)]
     fn new_snapshots(
         time: DateTime<Utc>,
         mut current_balances: HashMap<(AccountId, Currency), Option<BalanceSnapshot>>,

--- a/cala-ledger/src/balance/repo.rs
+++ b/cala-ledger/src/balance/repo.rs
@@ -51,7 +51,7 @@ impl BalanceRepo {
             .await
     }
 
-    #[instrument(name = "balance.find_in_op", skip_all)]
+    #[instrument(level = "debug", name = "balance.find_in_op", skip_all)]
     pub async fn find_in_op(
         &self,
         op: impl es_entity::IntoOneTimeExecutor<'_>,
@@ -91,7 +91,12 @@ impl BalanceRepo {
         }
     }
 
-    #[instrument(name = "balance.find_all", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "balance.find_all",
+        skip_all,
+        err(level = "warn")
+    )]
     pub(super) async fn find_all(
         &self,
         ids: &[BalanceId],
@@ -99,7 +104,12 @@ impl BalanceRepo {
         self.find_all_in_op(&self.pool, ids).await
     }
 
-    #[instrument(name = "balance.list_for_account", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "balance.list_for_account",
+        skip_all,
+        err(level = "warn")
+    )]
     pub(super) async fn list_for_account(
         &self,
         journal_id: JournalId,
@@ -113,7 +123,12 @@ impl BalanceRepo {
             .await
     }
 
-    #[instrument(name = "balance.list_for_accounts", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "balance.list_for_accounts",
+        skip_all,
+        err(level = "warn")
+    )]
     pub(super) async fn list_for_accounts(
         &self,
         journal_id: JournalId,
@@ -125,7 +140,12 @@ impl BalanceRepo {
             .await
     }
 
-    #[instrument(name = "balance.find_all_in_op", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "balance.find_all_in_op",
+        skip_all,
+        err(level = "warn")
+    )]
     pub(super) async fn find_all_in_op(
         &self,
         op: impl es_entity::IntoOneTimeExecutor<'_>,
@@ -181,7 +201,12 @@ impl BalanceRepo {
         Ok(ret)
     }
 
-    #[instrument(name = "balance.list_for_account_in_op", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "balance.list_for_account_in_op",
+        skip_all,
+        err(level = "warn")
+    )]
     pub(super) async fn list_for_account_in_op(
         &self,
         op: impl es_entity::IntoOneTimeExecutor<'_>,
@@ -237,6 +262,7 @@ impl BalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "balance.list_for_accounts_in_op",
         skip_all,
         err(level = "warn")
@@ -344,7 +370,7 @@ impl BalanceRepo {
     /// nested-loop join with `v` as the outer side for the tiny inputs
     /// this query receives, preserving UNNEST scan order through to
     /// the function calls in the SELECT list.
-    #[instrument(name = "cala_ledger.balances.find_for_update", skip(self, op, account_ids, currencies), fields(balances_count = account_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.balances.find_for_update", skip(self, op, account_ids, currencies), fields(balances_count = account_ids.len()))]
     pub(super) async fn find_for_update(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -415,6 +441,7 @@ impl BalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.lock_accounts_exclusive_in_op",
         skip_all,
         err(level = "warn")
@@ -470,6 +497,7 @@ impl BalanceRepo {
     /// `add_member_in_op` transactions from contending with posters
     /// on hot parent sets.
     #[instrument(
+        level = "debug",
         name = "cala_ledger.balances.member_has_balance_history_in_op",
         skip_all,
         err(level = "warn")
@@ -516,6 +544,7 @@ impl BalanceRepo {
     }
 
     #[instrument(
+    level = "debug",
     name = "cala_ledger.balances.insert_new_snapshots",
     skip(self, op, new_balances)
     fields(n_new_balances)
@@ -627,6 +656,7 @@ impl BalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "balance.load_account_set_balances_batch",
         skip_all,
         err(level = "warn")
@@ -680,6 +710,7 @@ impl BalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "balance.fetch_batch_member_history",
         skip_all,
         err(level = "warn")
@@ -746,6 +777,7 @@ impl BalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "balance.fetch_member_account_mappings",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/cel_context.rs
+++ b/cala-ledger/src/cel_context.rs
@@ -2,7 +2,7 @@ pub use cel_interpreter::CelContext;
 use es_entity::clock::ClockHandle;
 use tracing::instrument;
 
-#[instrument(name = "cel_context.initialize", skip(clock))]
+#[instrument(level = "debug", name = "cel_context.initialize", skip(clock))]
 pub(crate) fn initialize(clock: ClockHandle) -> CelContext {
     let mut ctx = CelContext::new_with_clock(clock);
     ctx.add_variable("SETTLED", "SETTLED");

--- a/cala-ledger/src/entry/mod.rs
+++ b/cala-ledger/src/entry/mod.rs
@@ -28,7 +28,7 @@ impl Entries {
         }
     }
 
-    #[instrument(name = "cala_ledger.entries.find_all", skip_all)]
+    #[instrument(level = "debug", name = "cala_ledger.entries.find_all", skip_all)]
     pub async fn find_all(
         &self,
         entry_ids: &[EntryId],
@@ -36,7 +36,11 @@ impl Entries {
         Ok(self.repo.find_all(entry_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.entries.list_for_account_id", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.entries.list_for_account_id",
+        skip_all
+    )]
     pub async fn list_for_account_id(
         &self,
         account_id: AccountId,
@@ -49,7 +53,11 @@ impl Entries {
             .await?)
     }
 
-    #[instrument(name = "cala_ledger.entries.list_for_account_set_id", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.entries.list_for_account_set_id",
+        skip_all
+    )]
     pub async fn list_for_account_set_id(
         &self,
         account_id: AccountSetId,
@@ -61,7 +69,11 @@ impl Entries {
             .await
     }
 
-    #[instrument(name = "cala_ledger.entries.list_for_journal_id", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.entries.list_for_journal_id",
+        skip_all
+    )]
     pub async fn list_for_journal_id(
         &self,
         journal_id: JournalId,
@@ -74,7 +86,11 @@ impl Entries {
             .await?)
     }
 
-    #[instrument(name = "cala_ledger.entries.list_for_transaction_id", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.entries.list_for_transaction_id",
+        skip_all
+    )]
     pub async fn list_for_transaction_id(
         &self,
         transaction_id: TransactionId,
@@ -96,7 +112,11 @@ impl Entries {
         Ok(entries)
     }
 
-    #[instrument(name = "cala_ledger.entries.create_all_in_op", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.entries.create_all_in_op",
+        skip_all
+    )]
     pub(crate) async fn create_all_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/src/entry/repo.rs
+++ b/cala-ledger/src/entry/repo.rs
@@ -39,6 +39,7 @@ impl EntryRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "entry.list_for_account_set_id_by_created_at",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/journal/mod.rs
+++ b/cala-ledger/src/journal/mod.rs
@@ -46,7 +46,7 @@ impl Journals {
         Ok(journal)
     }
 
-    #[instrument(name = "cala_ledger.journals.find_all", skip(self, journal_ids), fields(journal_ids_count = journal_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.journals.find_all", skip(self, journal_ids), fields(journal_ids_count = journal_ids.len()))]
     pub async fn find_all<T: From<Journal>>(
         &self,
         journal_ids: &[JournalId],
@@ -54,7 +54,7 @@ impl Journals {
         Ok(self.repo.find_all(journal_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.journals.find_by_id", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.journals.find_by_id", skip(self))]
     pub async fn find(&self, journal_id: JournalId) -> Result<Journal, JournalError> {
         Ok(self.repo.find_by_id(journal_id).await?)
     }
@@ -77,7 +77,7 @@ impl Journals {
         Ok(())
     }
 
-    #[instrument(name = "cala_ledger.journal.find_by_code", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.journal.find_by_code", skip(self))]
     pub async fn find_by_code(&self, code: String) -> Result<Journal, JournalError> {
         Ok(self.repo.find_by_code(Some(code)).await?)
     }

--- a/cala-ledger/src/param/mod.rs
+++ b/cala-ledger/src/param/mod.rs
@@ -26,7 +26,7 @@ impl Params {
         self.values.insert(k.into(), v.into());
     }
 
-    #[instrument(name = "params.into_context", skip(self, clock, defs), fields(params_count = self.values.len()), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "params.into_context", skip(self, clock, defs), fields(params_count = self.values.len()), err(level = tracing::Level::WARN))]
     pub(crate) fn into_context(
         mut self,
         clock: &ClockHandle,

--- a/cala-ledger/src/transaction/mod.rs
+++ b/cala-ledger/src/transaction/mod.rs
@@ -28,7 +28,11 @@ impl Transactions {
         }
     }
 
-    #[instrument(name = "cala_ledger.transactions.create_in_op", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.transactions.create_in_op",
+        skip_all
+    )]
     pub(crate) async fn create_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -38,7 +42,11 @@ impl Transactions {
         Ok(transaction)
     }
 
-    #[instrument(name = "cala_ledger.transactions.find_by_external_id", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.transactions.find_by_external_id",
+        skip(self)
+    )]
     pub async fn find_by_external_id(
         &self,
         external_id: String,
@@ -46,7 +54,11 @@ impl Transactions {
         Ok(self.repo.find_by_external_id(Some(external_id)).await?)
     }
 
-    #[instrument(name = "cala_ledger.transactions.find_by_id", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.transactions.find_by_id",
+        skip(self)
+    )]
     pub async fn find_by_id(
         &self,
         transaction_id: TransactionId,
@@ -54,7 +66,11 @@ impl Transactions {
         Ok(self.repo.find_by_id(transaction_id).await?)
     }
 
-    #[instrument(name = "cala_ledger.transactions.list_for_template_id", skip(self))]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.transactions.list_for_template_id",
+        skip(self)
+    )]
     pub async fn list_for_template_id(
         &self,
         template_id: TxTemplateId,
@@ -70,7 +86,7 @@ impl Transactions {
             .await?)
     }
 
-    #[instrument(name = "cala_ledger.transactions.find_all", skip(self, transaction_ids), fields(transaction_ids_count = transaction_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.transactions.find_all", skip(self, transaction_ids), fields(transaction_ids_count = transaction_ids.len()))]
     pub async fn find_all<T: From<Transaction>>(
         &self,
         transaction_ids: &[TransactionId],

--- a/cala-ledger/src/tx_template/mod.rs
+++ b/cala-ledger/src/tx_template/mod.rs
@@ -59,7 +59,7 @@ impl TxTemplates {
         Ok(tx_template)
     }
 
-    #[instrument(name = "cala_ledger.tx_templates.find_all", skip(self, tx_template_ids), fields(tx_template_ids_count = tx_template_ids.len()))]
+    #[instrument(level = "debug", name = "cala_ledger.tx_templates.find_all", skip(self, tx_template_ids), fields(tx_template_ids_count = tx_template_ids.len()))]
     pub async fn find_all<T: From<TxTemplate>>(
         &self,
         tx_template_ids: &[TxTemplateId],
@@ -67,7 +67,7 @@ impl TxTemplates {
         Ok(self.repo.find_all(tx_template_ids).await?)
     }
 
-    #[instrument(name = "cala_ledger.tx_templates.list", skip(self))]
+    #[instrument(level = "debug", name = "cala_ledger.tx_templates.list", skip(self))]
     pub async fn list(
         &self,
         cursor: es_entity::PaginatedQueryArgs<TxTemplateByCodeCursor>,
@@ -77,12 +77,13 @@ impl TxTemplates {
         Ok(self.repo.list_by_code(cursor, direction).await?)
     }
 
-    #[instrument(name = "cala_ledger.tx_templates.find_by_code", skip(self), fields(code = %code.as_ref()), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "cala_ledger.tx_templates.find_by_code", skip(self), fields(code = %code.as_ref()), err(level = tracing::Level::WARN))]
     pub async fn find_by_code(&self, code: impl AsRef<str>) -> Result<TxTemplate, TxTemplateError> {
         Ok(self.repo.find_by_code(code.as_ref().to_string()).await?)
     }
 
     #[instrument(
+        level = "debug",
         name = "cala_ledger.tx_template.prepare_transaction_in_op",
         skip(self, db)
     )]
@@ -143,6 +144,7 @@ impl TxTemplates {
     }
 
     #[instrument(
+        level = "debug",
         name = "tx_template.prep_entries",
         skip(self, tmpl, ctx),
         fields(

--- a/cala-ledger/src/tx_template/repo.rs
+++ b/cala-ledger/src/tx_template/repo.rs
@@ -48,6 +48,7 @@ impl TxTemplateRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "tx_template.find_latest_version_in_op",
         skip_all,
         err(level = "warn")
@@ -83,6 +84,7 @@ impl TxTemplateRepo {
     sync_writes = "default"
 )]
 #[instrument(
+    level = "debug",
     name = "tx_template.find_versioned_cached",
     skip(op),
     fields(template_id = %id, version = version),

--- a/cala-ledger/src/velocity/account_control/repo.rs
+++ b/cala-ledger/src/velocity/account_control/repo.rs
@@ -21,7 +21,12 @@ impl AccountControlRepo {
         }
     }
 
-    #[instrument(name = "account_control.create_in_op", skip_all, err(level = "warn"))]
+    #[instrument(
+        level = "debug",
+        name = "account_control.create_in_op",
+        skip_all,
+        err(level = "warn")
+    )]
     pub async fn create_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -40,6 +45,7 @@ impl AccountControlRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "account_control.find_for_enforcement",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/velocity/account_control/value.rs
+++ b/cala-ledger/src/velocity/account_control/value.rs
@@ -45,7 +45,7 @@ pub struct AccountVelocityLimit {
 }
 
 impl AccountVelocityLimit {
-    #[instrument(name = "velocity_limit.window_for_enforcement", skip(self, ctx, entry), fields(limit_id = %self.limit_id, entry_id = %entry.id), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "velocity_limit.window_for_enforcement", skip(self, ctx, entry), fields(limit_id = %self.limit_id, entry_id = %entry.id), err(level = tracing::Level::WARN))]
     pub fn window_for_enforcement(
         &self,
         ctx: &CelContext,
@@ -73,7 +73,7 @@ impl AccountVelocityLimit {
         Ok(Some(map.into()))
     }
 
-    #[instrument(name = "velocity_limit.enforce", skip(self, ctx, snapshot), fields(limit_id = %self.limit_id, account_id = %snapshot.account_id, currency = %snapshot.currency, velocity.limit, velocity.requested, velocity.layer, velocity.direction), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "velocity_limit.enforce", skip(self, ctx, snapshot), fields(limit_id = %self.limit_id, account_id = %snapshot.account_id, currency = %snapshot.currency, velocity.limit, velocity.requested, velocity.layer, velocity.direction), err(level = tracing::Level::WARN))]
     pub fn enforce(
         &self,
         ctx: &CelContext,

--- a/cala-ledger/src/velocity/balance/repo.rs
+++ b/cala-ledger/src/velocity/balance/repo.rs
@@ -29,6 +29,7 @@ impl VelocityBalanceRepo {
         }
     }
     #[instrument(
+        level = "debug",
         name = "velocity_balance.find_for_update",
         skip_all,
         err(level = "warn")
@@ -178,6 +179,7 @@ impl VelocityBalanceRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "velocity_balance.insert_new_snapshots",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/velocity/limit/repo.rs
+++ b/cala-ledger/src/velocity/limit/repo.rs
@@ -22,7 +22,11 @@ impl VelocityLimitRepo {
         Self { pool: pool.clone() }
     }
 
-    #[instrument(name = "velocity_limit.add_limit_to_control", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "velocity_limit.add_limit_to_control",
+        skip_all
+    )]
     pub async fn add_limit_to_control(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -41,6 +45,7 @@ impl VelocityLimitRepo {
     }
 
     #[instrument(
+        level = "debug",
         name = "velocity_limit.list_for_control",
         skip_all,
         err(level = "warn")

--- a/cala-ledger/src/velocity/mod.rs
+++ b/cala-ledger/src/velocity/mod.rs
@@ -108,7 +108,7 @@ impl Velocities {
         Ok(self.controls.find_by_id_in_op(db, control).await?)
     }
 
-    #[instrument(name = "velocity.attach_control_to_account", skip(self), fields(control_id = %control, account_id = %account_id))]
+    #[instrument(level = "debug", name = "velocity.attach_control_to_account", skip(self), fields(control_id = %control, account_id = %account_id))]
     pub async fn attach_control_to_account(
         &self,
         control: VelocityControlId,
@@ -123,7 +123,7 @@ impl Velocities {
         Ok(control)
     }
 
-    #[instrument(name = "velocity.attach_control_to_account_set", skip(self), fields(control_id = %control, account_set_id = %account_set_id))]
+    #[instrument(level = "debug", name = "velocity.attach_control_to_account_set", skip(self), fields(control_id = %control, account_set_id = %account_set_id))]
     pub async fn attach_control_to_account_set(
         &self,
         control: VelocityControlId,
@@ -143,7 +143,7 @@ impl Velocities {
         Ok(control)
     }
 
-    #[instrument(name = "velocity.attach_control_to_account_in_op", skip(self, db), fields(control_id = %control_id, account_id = %account_id))]
+    #[instrument(level = "debug", name = "velocity.attach_control_to_account_in_op", skip(self, db), fields(control_id = %control_id, account_id = %account_id))]
     pub async fn attach_control_to_account_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -155,7 +155,7 @@ impl Velocities {
             .await
     }
 
-    #[instrument(name = "velocity.attach_control_to_account_set_in_op", skip(self, db), fields(control_id = %control_id, account_set_id = %account_set_id))]
+    #[instrument(level = "debug", name = "velocity.attach_control_to_account_set_in_op", skip(self, db), fields(control_id = %control_id, account_set_id = %account_set_id))]
     pub async fn attach_control_to_account_set_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -167,7 +167,7 @@ impl Velocities {
             .await
     }
 
-    #[instrument(name = "velocity.attach_control_internal", skip(self, db, account_id), fields(control_id = %control_id, account_id = tracing::field::Empty))]
+    #[instrument(level = "debug", name = "velocity.attach_control_internal", skip(self, db, account_id), fields(control_id = %control_id, account_id = tracing::field::Empty))]
     async fn attach_control_to_account_or_account_set_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -193,7 +193,7 @@ impl Velocities {
         Ok(control)
     }
 
-    #[instrument(name = "velocity.update_balances_with_limit_enforcement_in_op", skip(self, db, transaction, entries, account_ids, account_set_mappings), fields(account_ids_count = account_ids.len(), entries_count = entries.len()), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "velocity.update_balances_with_limit_enforcement_in_op", skip(self, db, transaction, entries, account_ids, account_set_mappings), fields(account_ids_count = account_ids.len(), entries_count = entries.len()), err(level = tracing::Level::WARN))]
     pub(crate) async fn update_balances_with_limit_enforcement_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
@@ -228,7 +228,7 @@ impl Velocities {
             .await
     }
 
-    #[instrument(name = "velocity.list_limits_for_control", skip(self), fields(control_id = %control_id))]
+    #[instrument(level = "debug", name = "velocity.list_limits_for_control", skip(self), fields(control_id = %control_id))]
     pub async fn list_limits_for_control(
         &self,
         control_id: VelocityControlId,
@@ -241,7 +241,7 @@ impl Velocities {
         Ok(limits)
     }
 
-    #[instrument(name = "velocity.list_limits_for_control_in_op", skip(self, op), fields(control_id = %control_id), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "velocity.list_limits_for_control_in_op", skip(self, op), fields(control_id = %control_id), err(level = tracing::Level::WARN))]
     pub async fn list_limits_for_control_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
@@ -250,7 +250,7 @@ impl Velocities {
         self.limits.list_for_control(op, control_id).await
     }
 
-    #[instrument(name = "velocity.find_all_limits", skip(self, limit_ids), fields(count = limit_ids.len()), err(level = tracing::Level::WARN))]
+    #[instrument(level = "debug", name = "velocity.find_all_limits", skip(self, limit_ids), fields(count = limit_ids.len()), err(level = tracing::Level::WARN))]
     pub async fn find_all_limits<T: From<VelocityLimit>>(
         &self,
         limit_ids: &[VelocityLimitId],
@@ -258,7 +258,7 @@ impl Velocities {
         Ok(self.limits.find_all(limit_ids).await?)
     }
 
-    #[instrument(name = "velocity.find_all_controls", skip(self, control_ids), fields(count = control_ids.len()))]
+    #[instrument(level = "debug", name = "velocity.find_all_controls", skip(self, control_ids), fields(count = control_ids.len()))]
     pub async fn find_all_controls<T: From<VelocityControl>>(
         &self,
         control_ids: &[VelocityControlId],


### PR DESCRIPTION
## Why

Follow-up to #777 (which fixed the Debug-recorded collection args). This PR tackles the volume side of the same problem: nearly all of cala-ledger's ~166 `#[instrument]` callsites sit at the default INFO level, so every repo call, facade, and per-statement operation on the hot path creates a span on every future poll — and every closed span becomes an OTel export record.

Evidence from a 5-hour lana-bank stress-test sandbox at 3 loans/sec (~170k postings, 28k loans), CPU profiles of the server (`/debug/pprof`):

- `Instrumented::poll` on the stack of ~62% of samples; tracing/TLS machinery ~5-8% of flat CPU directly.
- The **OTel `BatchSpanProcessor` thread was the single hottest thread** (~19% of samples) building/prost-encoding export batches.
- Per-span allocation churn feeds the top flat categories: `malloc/free` 15% + musl malloc lock (`__lock`/`__unlock`) 5%.
- The app ran pinned at ~5-6.5 cores. That CPU saturation stretched posting transactions (observed `idle in transaction` between statements), which directly lengthened cala's advisory-lock holds — and those locks are the steady-state throughput ceiling (achieved ~2.2 loans/s vs 3 target, lock-query mean ~700 ms = ~95% of DB time).

## What

Demote **139 inner-path spans to `level = "debug"`**, keeping INFO only at unit-of-work boundaries and rare operations:

| Kept at INFO | Demoted to DEBUG |
|---|---|
| `cala_ledger.init` | all repo-layer spans (`*/repo.rs`) |
| `post_transaction(_in_op)` | `update_balances_in_op` + recalc internals (`balances.recalculate_*`, `effective.*`, `replay_*`) |
| `account_sets.recalculate_balances{,_batch,_deep}{,_in_op}` | find/list facades everywhere |
| `tx_template` create/validate | account/account_set create, persist, add/remove member |
| `journals` create/persist | entries, transactions |
| velocity limit/control config APIs | velocity attach/enforce internals, `cel_context`, `params` |

Spans are **demoted, not deleted**:

- Full fidelity remains available at runtime via `RUST_LOG=info,cala_ledger=debug`.
- Boundary spans keep the trace context (and the statement `traceparent` annotation) intact for slow-query correlation.
- A level-disabled callsite degrades to a cached interest check per call instead of span creation + subscriber work + OTel export.

## Validation

- `cargo check -p cala-ledger` clean, `cargo fmt` applied.
- All **94 `cargo nextest run -p cala-ledger` tests pass**.
- Expected effect (to be re-measured on a stress sandbox): lower app CPU per posting → shorter advisory-lock holds → higher achieved loans/s at the same target rate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only attribute changes on `#[instrument]`; no ledger logic or API behavior changes.
> 
> **Overview**
> Reduces **tracing/OTel overhead on the posting hot path** by setting `level = "debug"` on ~139 `#[instrument]` spans across `cala-ledger` (accounts, account sets, balances, entries, velocity, repos, etc.). Repo-layer and per-statement operations no longer emit INFO spans on every poll when the default filter is `info`.
> 
> **INFO is unchanged** on unit-of-work boundaries: `cala_ledger.init`, `post_transaction` / `post_transaction_in_op`, account-set `recalculate_balances*` APIs, journal create/persist, and tx-template create/validate paths. Everything demoted stays available with `RUST_LOG=info,cala_ledger=debug`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5dc41ba651e574cfeff3a4bec81219f2d88e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->