### PR TITLE
chore(deps): bump job to 0.6.35 and obix to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,9 +1407,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.6.34"
+version = "0.6.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c899505511de0440db7be17d7fb615b49aeddc6537d53280441a47cd2302396d"
+checksum = "39448f226d50f033db27ed58401ce4b7e2414a5fff95b3a956e36e451b00bbc6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9516985689c24a135934424e0159f6cc9a192d18b06e3e60414dc0558f9eb12"
+checksum = "5e23e5699fbc15a1c6fa0a39fb49f5e175ecf2c2a3e03957498debd1ca7350e1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e721527a00313531fffed34f7a42b802b3f9e73314a6982555a60bf04a3fb648"
+checksum = "62404a571f1888d94abacd595e0714c0ca7e34ac1b69d5c925164db1d3caa25f"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ cala-types = { path = "cala-ledger-core-types", package = "cala-ledger-core-type
 cala-ledger = { path = "cala-ledger", version = "0.18.7-dev" }
 
 es-entity = "0.11.9"
-job = { version = "0.6.34", features = ["es-entity"] }
-obix = { version = "0.4.1", default-features = false }
+job = { version = "0.6.35", features = ["es-entity"] }
+obix = { version = "0.4.2", default-features = false }
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }


### PR DESCRIPTION
Bumps `job` to 0.6.35 (SKIP LOCKED poll query) and `obix` to 0.4.2.