### PR TITLE
perf!(account-set): lead member_accounts uniqueness on member_account_id

### DIFF
--- a/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
+++ b/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
@@ -70,13 +70,19 @@ CREATE TABLE cala_account_set_member_accounts (
   member_account_id UUID NOT NULL REFERENCES cala_accounts(id),
   transitive BOOLEAN NOT NULL DEFAULT FALSE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-  UNIQUE(account_set_id, member_account_id)
+  -- Lead the uniqueness constraint on the random member_account_id: all
+  -- concurrent attaches insert into the same few hot account_set_id key
+  -- ranges, which serializes them on leaf-page buffer locks. The pair is
+  -- unique either way, and this column order doubles as the reverse index
+  -- for account->sets resolution (fetch_mappings_in_op on the posting
+  -- path), which filters member_account_id.
+  UNIQUE(member_account_id, account_set_id)
 );
--- Reverse index for account->sets resolution (fetch_mappings_in_op on the
--- posting path), which filters member_account_id; the UNIQUE above leads on
--- account_set_id.
-CREATE INDEX idx_cala_account_set_member_accounts_member_account
-  ON cala_account_set_member_accounts (member_account_id, account_set_id);
+-- Set->members lookups (balance rollup member scans) filter
+-- account_set_id; kept as a plain index so the hot insert path doesn't
+-- also pay unique-check page pinning on a hot leading column.
+CREATE INDEX idx_cala_account_set_member_accounts_set
+  ON cala_account_set_member_accounts (account_set_id);
 
 CREATE TABLE cala_account_set_member_account_sets (
   account_set_id UUID NOT NULL REFERENCES cala_account_sets(id),


### PR DESCRIPTION
## Problem

Concurrent attaches all insert into the same few hot `account_set_id` key ranges of `UNIQUE(account_set_id, member_account_id)`: loan/deposit creation attaches new accounts to the same shared summary/omnibus sets, so random member uuids funnel into a handful of leaf ranges and serialize on `BufferContent` page locks and splits. This made the batched attach (`add_members_in_op`, #784) look bad on a 10-loan/s lana-bank stress sandbox: 43 ms mean per call (#1 DB consumer) vs 2.4 ms for the singular form — the gap is page contention paid 39 rows at a time inside one statement, not the ancestor walk (0.3 ms, clean plan).

## Fix

Flip the constraint to `UNIQUE(member_account_id, account_set_id)`:

- The pair is unique either way.
- The random leading column spreads inserts across the whole btree — no hot ranges.
- The index doubles as the reverse index for account→sets resolution (`fetch_mappings_in_op` on the posting path), so `idx_cala_account_set_member_accounts_member_account` is dropped as redundant.
- Set→members scans (balance rollup member enumeration) get a plain non-unique index on `account_set_id` — kept non-unique so the hot insert path does not pay unique-check page pinning on a hot leading column.

## Evidence (pgbench, 16-way concurrent attaches, 20 hot target sets, 800k member rows)

| Variant | Batch attach stmt |
|---|---|
| `UNIQUE(set, account)` + reverse idx (current) | 7.07 ms |
| `UNIQUE(account, set)` (this PR) | **3.76 ms (-47%)** |
| this PR + plain `INDEX(account_set_id)` (this PR) | 5.02 ms (-29%) |
| 10 singular attaches (current) | 4.9 ms |

Wait sampling under contention: `BufferContent` LWLock dominant before the flip. After the flip the batched attach beats the singular form per row, as intended.

Related: #784 (batched ancestor walk this unblocks), lana-bank #7567 (omnibus sharding).

## ⚠️ Breaking change

This edits the `20231208110808_cala_ledger_setup` migration in place (cala convention, pre-production). Databases that already applied it will fail sqlx checksum validation and won't get the new index without manual remediation: drop the old constraint, add `UNIQUE(member_account_id, account_set_id)`, drop `idx_cala_account_set_member_accounts_member_account`, create `idx_cala_account_set_member_accounts_set` — or reset the schema. Marked with `!` / `BREAKING CHANGE` so the release bumps accordingly.
