### PR TITLE
fix(ci): cap nextest at 2 threads

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+test-threads = 2


### PR DESCRIPTION
cala/integration-test failed 4 consecutive builds (129–132) with mass `pool timed out while waiting for an open connection` errors after 30s — including on a commit identical to a previously-green build. The same code passes `nix run .#nextest` locally.

Root cause: nextest ran ~40+ tests concurrently on the CI worker, each holding pool connections (`ec_recalc_race` pins 40-conn pools; default pools take 10), saturating postgres' default `max_connections=100` once tests linger on a slow/oversubscribed worker.

Fix: `.config/nextest.toml` with `test-threads = 2` — same approach as lana-bank (which uses 1), but cala tests are DB-isolated so full serialization isn't needed, and worst-case concurrent usage (2 × 40-conn `ec_recalc_race` pools) stays under the 100-conn default while keeping runtime roughly half of fully serial.