### PR TITLE
chore(ledger): stop publishing BalanceCreated/BalanceUpdated outbox events

### DIFF
--- a/cala-ledger-core-types/src/outbox.rs
+++ b/cala-ledger-core-types/src/outbox.rs
@@ -52,12 +52,6 @@ pub enum OutboxEventPayload {
     EntryCreated {
         entry: EntryValues,
     },
-    BalanceCreated {
-        balance: BalanceSnapshot,
-    },
-    BalanceUpdated {
-        balance: BalanceSnapshot,
-    },
     EffectiveBalanceCreated {
         balance: EffectiveBalanceSnapshot,
     },

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -61,7 +61,7 @@ pub struct Balances {
 impl Balances {
     pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher, journals: &Journals) -> Self {
         Self {
-            repo: BalanceRepo::new(pool, publisher),
+            repo: BalanceRepo::new(pool),
             effective: EffectiveBalances::new(pool, publisher),
             journals: journals.clone(),
             _pool: pool.clone(),

--- a/cala-ledger/src/balance/repo.rs
+++ b/cala-ledger/src/balance/repo.rs
@@ -5,7 +5,6 @@ use std::collections::{HashMap, HashSet};
 
 use cala_types::{
     balance::BalanceSnapshot,
-    outbox::OutboxEventPayload,
     primitives::{
         AccountId, AccountSetId, BalanceId, Currency, DebitOrCredit, EntryId, JournalId, Status,
     },
@@ -16,11 +15,10 @@ use super::{
     cursor::{AccountBalanceByCurrencyCursor, AccountBalanceCursor},
     error::BalanceError,
 };
-use crate::outbox::OutboxPublisher;
 
 const EC_SET_LOCK_CLASS: i32 = 1;
 
-/// Maximum balance snapshots written per `INSERT` + outbox publish in
+/// Maximum balance snapshots written per `INSERT` in
 /// [`BalanceRepo::insert_new_snapshots`]. A deep account-set recalc can produce
 /// one history row per member event; flushing in bounded sub-batches (within
 /// the same transaction) keeps any single statement's working set small so it
@@ -30,15 +28,11 @@ const INSERT_SNAPSHOT_BATCH_SIZE: usize = 5_000;
 #[derive(Debug, Clone)]
 pub(super) struct BalanceRepo {
     pool: PgPool,
-    publisher: OutboxPublisher,
 }
 
 impl BalanceRepo {
-    pub fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
-        Self {
-            pool: pool.clone(),
-            publisher: publisher.clone(),
-        }
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
     }
 
     pub async fn find(
@@ -719,23 +713,6 @@ impl BalanceRepo {
             )
             .execute(op.as_executor())
             .await?;
-
-            self.publisher
-                .publish_all(
-                    op,
-                    chunk.iter().map(|balance| {
-                        if balance.version == 1 {
-                            OutboxEventPayload::BalanceCreated {
-                                balance: balance.clone(),
-                            }
-                        } else {
-                            OutboxEventPayload::BalanceUpdated {
-                                balance: balance.clone(),
-                            }
-                        }
-                    }),
-                )
-                .await?;
         }
 
         Ok(())


### PR DESCRIPTION
## Why

Every row written to `cala_balance_history` also produced a `BalanceCreated`/`BalanceUpdated` persistent outbox event — one per `(account, currency)` touched by a posting, and one per replayed member-history row during account-set balance recalculation. Under stress testing (10 loans/s) this is the largest single contributor to `cala_persistent_outbox_events` growth: on QA the balance events alone are **~10x the entry count** and exceed all consumed event types combined.

**Nothing consumes them:**
- lana's only cala outbox consumer (`DwCalaRelayHandler` in `lana/dw-outbox-relay`) explicitly skips these payloads
- no `stg_balance_*` dbt staging model exists — account-set balances in the DW are re-derived from leaf effective-balance events (`int_account_set_balance_intervals`)
- cala itself never reads them back

## What

- Remove the `publish_all` call from `BalanceRepo::insert_new_snapshots` (posting path + EC set recalc fan-out)
- Drop `BalanceCreated`/`BalanceUpdated` from `OutboxEventPayload`
- `BalanceRepo` no longer holds an `OutboxPublisher`

Effective-balance events (`EffectiveBalanceCreated/Updated`) are unaffected — they are consumed by the DW pipeline.