### PR TITLE
chore(ledger): stop publishing unused config-time outbox events

### DIFF
--- a/cala-ledger-core-types/src/outbox.rs
+++ b/cala-ledger-core-types/src/outbox.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    account::*, account_set::*, balance::*, entry::*, journal::*, primitives::*, transaction::*,
-    tx_template::*,
-};
+use crate::{account::*, account_set::*, balance::*, entry::*, primitives::*, transaction::*};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -13,17 +10,6 @@ pub enum OutboxEventPayload {
     AccountCreated {
         account: AccountValues,
     },
-    AccountUpdated {
-        account: AccountValues,
-        fields: Vec<String>,
-    },
-    AccountSetCreated {
-        account_set: AccountSetValues,
-    },
-    AccountSetUpdated {
-        account_set: AccountSetValues,
-        fields: Vec<String>,
-    },
     AccountSetMemberCreated {
         account_set_id: AccountSetId,
         member_id: AccountSetMemberId,
@@ -31,16 +17,6 @@ pub enum OutboxEventPayload {
     AccountSetMemberRemoved {
         account_set_id: AccountSetId,
         member_id: AccountSetMemberId,
-    },
-    JournalCreated {
-        journal: JournalValues,
-    },
-    JournalUpdated {
-        journal: JournalValues,
-        fields: Vec<String>,
-    },
-    TxTemplateCreated {
-        tx_template: TxTemplateValues,
     },
     TransactionCreated {
         transaction: TransactionValues,

--- a/cala-ledger/src/account/mod.rs
+++ b/cala-ledger/src/account/mod.rs
@@ -203,13 +203,7 @@ impl From<&AccountEvent> for OutboxEventPayload {
             AccountEvent::Initialized { values: account } => OutboxEventPayload::AccountCreated {
                 account: account.clone(),
             },
-            AccountEvent::Updated {
-                values: account,
-                fields,
-            } => OutboxEventPayload::AccountUpdated {
-                account: account.clone(),
-                fields: fields.clone(),
-            },
+            AccountEvent::Updated { .. } => OutboxEventPayload::Empty,
         }
     }
 }

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -808,19 +808,3 @@ impl AccountSets {
             .await
     }
 }
-
-impl From<&AccountSetEvent> for OutboxEventPayload {
-    fn from(event: &AccountSetEvent) -> Self {
-        match event {
-            AccountSetEvent::Initialized {
-                values: account_set,
-            } => OutboxEventPayload::AccountSetCreated {
-                account_set: account_set.clone(),
-            },
-            AccountSetEvent::Updated { values, fields } => OutboxEventPayload::AccountSetUpdated {
-                account_set: values.clone(),
-                fields: fields.clone(),
-            },
-        }
-    }
-}

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -131,7 +131,6 @@ use members_cursor::*;
         ),
     ),
     tbl_prefix = "cala",
-    post_persist_hook = "publish",
     persist_event_context = false
 )]
 pub(super) struct AccountSetRepo {
@@ -965,17 +964,5 @@ impl AccountSetRepo {
         .await?;
 
         Ok(rows.into_iter().map(|r| r.id).collect())
-    }
-
-    async fn publish(
-        &self,
-        op: &mut impl es_entity::AtomicOperation,
-        entity: &AccountSet,
-        new_events: es_entity::LastPersisted<'_, AccountSetEvent>,
-    ) -> Result<(), sqlx::Error> {
-        self.publisher
-            .publish_entity_events(op, entity, new_events)
-            .await?;
-        Ok(())
     }
 }

--- a/cala-ledger/src/journal/mod.rs
+++ b/cala-ledger/src/journal/mod.rs
@@ -8,8 +8,6 @@ use tracing::instrument;
 
 use std::collections::HashMap;
 
-use crate::outbox::*;
-
 pub use entity::*;
 use error::*;
 use repo::*;
@@ -22,9 +20,9 @@ pub struct Journals {
 }
 
 impl Journals {
-    pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher, clock: &ClockHandle) -> Self {
+    pub(crate) fn new(pool: &PgPool, clock: &ClockHandle) -> Self {
         Self {
-            repo: JournalRepo::new(pool, publisher),
+            repo: JournalRepo::new(pool),
             clock: clock.clone(),
         }
     }
@@ -80,19 +78,5 @@ impl Journals {
     #[instrument(level = "debug", name = "cala_ledger.journal.find_by_code", skip(self))]
     pub async fn find_by_code(&self, code: String) -> Result<Journal, JournalError> {
         Ok(self.repo.find_by_code(Some(code)).await?)
-    }
-}
-
-impl From<&JournalEvent> for OutboxEventPayload {
-    fn from(event: &JournalEvent) -> Self {
-        match event {
-            JournalEvent::Initialized { values } => OutboxEventPayload::JournalCreated {
-                journal: values.clone(),
-            },
-            JournalEvent::Updated { values, fields } => OutboxEventPayload::JournalUpdated {
-                journal: values.clone(),
-                fields: fields.clone(),
-            },
-        }
     }
 }

--- a/cala-ledger/src/journal/repo.rs
+++ b/cala-ledger/src/journal/repo.rs
@@ -1,8 +1,6 @@
 use es_entity::*;
 use sqlx::PgPool;
 
-use crate::outbox::OutboxPublisher;
-
 use super::entity::*;
 
 #[derive(EsRepo, Debug, Clone)]
@@ -13,31 +11,14 @@ use super::entity::*;
         code(ty = "Option<String>", update(accessor = "values().code")),
     ),
     tbl_prefix = "cala",
-    post_persist_hook = "publish",
     persist_event_context = false
 )]
 pub(super) struct JournalRepo {
     pool: PgPool,
-    publisher: OutboxPublisher,
 }
 
 impl JournalRepo {
-    pub fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
-        Self {
-            pool: pool.clone(),
-            publisher: publisher.clone(),
-        }
-    }
-
-    async fn publish(
-        &self,
-        op: &mut impl es_entity::AtomicOperation,
-        entity: &Journal,
-        new_events: es_entity::LastPersisted<'_, JournalEvent>,
-    ) -> Result<(), sqlx::Error> {
-        self.publisher
-            .publish_entity_events(op, entity, new_events)
-            .await?;
-        Ok(())
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
     }
 }

--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -65,8 +65,8 @@ impl CalaLedger {
         let clock = config.clock;
         let publisher = OutboxPublisher::init(&pool, &clock).await?;
         let accounts = Accounts::new(&pool, &publisher, &clock);
-        let journals = Journals::new(&pool, &publisher, &clock);
-        let tx_templates = TxTemplates::new(&pool, &publisher, &clock);
+        let journals = Journals::new(&pool, &clock);
+        let tx_templates = TxTemplates::new(&pool, &clock);
         let transactions = Transactions::new(&pool, &publisher);
         let entries = Entries::new(&pool, &publisher);
         let balances = Balances::new(&pool, &publisher, &journals);

--- a/cala-ledger/src/outbox/publisher.rs
+++ b/cala-ledger/src/outbox/publisher.rs
@@ -30,9 +30,10 @@ impl OutboxPublisher {
         Event: es_entity::EsEvent,
         for<'a> &'a Event: Into<OutboxEventPayload>,
     {
-        self.inner
-            .publish_all_persisted(op, new_events.map(|e| &e.event))
-            .await
+        let events = new_events
+            .map(|e| (&e.event).into())
+            .filter(|e| !matches!(e, OutboxEventPayload::Empty));
+        self.inner.publish_all_persisted(op, events).await
     }
 
     pub async fn publish_all(

--- a/cala-ledger/src/tx_template/mod.rs
+++ b/cala-ledger/src/tx_template/mod.rs
@@ -12,7 +12,7 @@ use tracing::instrument;
 use uuid::Uuid;
 
 pub use crate::param::*;
-use crate::{entry::NewEntry, outbox::*, primitives::*, transaction::NewTransaction};
+use crate::{entry::NewEntry, primitives::*, transaction::NewTransaction};
 
 pub use entity::*;
 use error::*;
@@ -31,9 +31,9 @@ pub struct TxTemplates {
 }
 
 impl TxTemplates {
-    pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher, clock: &ClockHandle) -> Self {
+    pub(crate) fn new(pool: &PgPool, clock: &ClockHandle) -> Self {
         Self {
-            repo: TxTemplateRepo::new(pool, publisher),
+            repo: TxTemplateRepo::new(pool),
             clock: clock.clone(),
         }
     }
@@ -213,17 +213,5 @@ impl TxTemplates {
         }
 
         Ok(new_entries)
-    }
-}
-
-impl From<&TxTemplateEvent> for OutboxEventPayload {
-    fn from(event: &TxTemplateEvent) -> Self {
-        match event {
-            TxTemplateEvent::Initialized {
-                values: tx_template,
-            } => OutboxEventPayload::TxTemplateCreated {
-                tx_template: tx_template.clone(),
-            },
-        }
     }
 }

--- a/cala-ledger/src/tx_template/repo.rs
+++ b/cala-ledger/src/tx_template/repo.rs
@@ -6,8 +6,6 @@ use tracing::instrument;
 
 use std::sync::Arc;
 
-use crate::outbox::OutboxPublisher;
-
 use super::{entity::*, error::TxTemplateError};
 
 #[derive(EsRepo, Clone)]
@@ -19,32 +17,15 @@ use super::{entity::*, error::TxTemplateError};
         list_by
     ),),
     tbl_prefix = "cala",
-    post_persist_hook = "publish",
     persist_event_context = false
 )]
 pub(super) struct TxTemplateRepo {
     pool: PgPool,
-    publisher: OutboxPublisher,
 }
 
 impl TxTemplateRepo {
-    pub fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
-        Self {
-            pool: pool.clone(),
-            publisher: publisher.clone(),
-        }
-    }
-
-    async fn publish(
-        &self,
-        op: &mut impl es_entity::AtomicOperation,
-        entity: &TxTemplate,
-        new_events: es_entity::LastPersisted<'_, TxTemplateEvent>,
-    ) -> Result<(), sqlx::Error> {
-        self.publisher
-            .publish_entity_events(op, entity, new_events)
-            .await?;
-        Ok(())
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
     }
 
     #[instrument(


### PR DESCRIPTION
## Why

These `OutboxEventPayload` variants are persisted to `cala_persistent_outbox_events` but **consumed by nobody**:

- `AccountUpdated`
- `AccountSetCreated` / `AccountSetUpdated`
- `JournalCreated` / `JournalUpdated`
- `TxTemplateCreated`

lana's only cala outbox consumer (`DwCalaRelayHandler` → data warehouse → dbt) subscribes to `AccountCreated`, `AccountSetMemberCreated/Removed`, `TransactionCreated/Updated`, `EntryCreated` and `EffectiveBalanceCreated/Updated` only, and no `stg_*` dbt model exists for the removed types. On staging-main they account for ~55% of all persisted cala outbox rows (`account_set_created` alone is 2,013 of 7,427).

## What

- Drop the six variants from `OutboxEventPayload`
- Remove the `publish` post-persist hooks from the journal, tx-template and account-set repos (`AccountSetMemberCreated/Removed` events, published explicitly via `publish_all`, are unaffected)
- `AccountEvent::Updated` now maps to `OutboxEventPayload::Empty`, which the publisher filters out — `AccountCreated` still flows

Stacks independently of #793 (same enum, disjoint hunks).