### PR TITLE
feat(ledger): journal entry listing filtered by created-at + effective date (Option A for lana #7796)

### DIFF
--- a/cala-ledger/.sqlx/query-3d6e1d30a0040d09c2a5e1fcd84bb17aa3dcba84905d9fcc0b2749efabbaa0d9.json
+++ b/cala-ledger/.sqlx/query-3d6e1d30a0040d09c2a5e1fcd84bb17aa3dcba84905d9fcc0b2749efabbaa0d9.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (\n                    SELECT created_at, id\n                    FROM cala_entries\n                    WHERE journal_id = $4\n                      AND ($5::timestamptz IS NULL OR created_at >= $5::timestamptz)\n                      AND ($6::timestamptz IS NULL OR created_at <= $6::timestamptz)\n                      AND (\n                        ($7::date IS NULL AND $8::date IS NULL)\n                        OR transaction_id IN (\n                          SELECT id FROM cala_transactions\n                          WHERE ($7::date IS NULL OR effective >= $7::date)\n                            AND ($8::date IS NULL OR effective <= $8::date)\n                        )\n                      )\n                      AND (COALESCE((created_at, id) < ($3, $2), $2 IS NULL))\n                    ORDER BY created_at DESC, id DESC\n                    LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $9 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Uuid",
+        "Timestamptz",
+        "Timestamptz",
+        "Date",
+        "Date",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "3d6e1d30a0040d09c2a5e1fcd84bb17aa3dcba84905d9fcc0b2749efabbaa0d9"
+}

--- a/cala-ledger/.sqlx/query-4431f1178a7bc014b9e8aae8ae2bf2fb4497fae9209235c239d2cdf25feb4844.json
+++ b/cala-ledger/.sqlx/query-4431f1178a7bc014b9e8aae8ae2bf2fb4497fae9209235c239d2cdf25feb4844.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (\n                    SELECT created_at, id\n                    FROM cala_entries\n                    WHERE journal_id = $4\n                      AND ($5::timestamptz IS NULL OR created_at >= $5::timestamptz)\n                      AND ($6::timestamptz IS NULL OR created_at <= $6::timestamptz)\n                      AND (\n                        ($7::date IS NULL AND $8::date IS NULL)\n                        OR transaction_id IN (\n                          SELECT id FROM cala_transactions\n                          WHERE ($7::date IS NULL OR effective >= $7::date)\n                            AND ($8::date IS NULL OR effective <= $8::date)\n                        )\n                      )\n                      AND (COALESCE((created_at, id) > ($3, $2), $2 IS NULL))\n                    ORDER BY created_at ASC, id ASC\n                    LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $9 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN cala_entry_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Uuid",
+        "Timestamptz",
+        "Timestamptz",
+        "Date",
+        "Date",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "4431f1178a7bc014b9e8aae8ae2bf2fb4497fae9209235c239d2cdf25feb4844"
+}

--- a/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
+++ b/cala-ledger/migrations/20231208110808_cala_ledger_setup.sql
@@ -123,6 +123,7 @@ CREATE TABLE cala_transactions (
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE INDEX idx_cala_transactions_correlation_id ON cala_transactions (correlation_id);
+CREATE INDEX idx_cala_transactions_effective ON cala_transactions (effective);
 
 CREATE TABLE cala_transaction_events (
   id UUID NOT NULL REFERENCES cala_transactions(id),
@@ -145,6 +146,7 @@ CREATE TABLE cala_entries (
 );
 CREATE INDEX idx_cala_entries_transaction_id ON cala_entries (transaction_id);
 CREATE INDEX idx_cala_entries_account_id ON cala_entries (account_id, created_at DESC, id DESC);
+CREATE INDEX idx_cala_entries_journal_id_created_at ON cala_entries (journal_id, created_at DESC, id DESC);
 
 CREATE TABLE cala_entry_events (
   id UUID NOT NULL REFERENCES cala_entries(id),

--- a/cala-ledger/src/entry/entity.rs
+++ b/cala-ledger/src/entry/entity.rs
@@ -5,6 +5,20 @@ use serde::{Deserialize, Serialize};
 use crate::primitives::*;
 pub use cala_types::{entry::*, primitives::EntryId};
 
+/// Filter for listing a journal's entries. All bounds are inclusive and combined
+/// with AND semantics; an unset bound is ignored.
+#[derive(Debug, Clone, Default)]
+pub struct EntriesFilter {
+    /// Inclusive lower bound on the entry's creation time.
+    pub created_at_from: Option<chrono::DateTime<chrono::Utc>>,
+    /// Inclusive upper bound on the entry's creation time.
+    pub created_at_to: Option<chrono::DateTime<chrono::Utc>>,
+    /// Inclusive lower bound on the posting transaction's effective date.
+    pub effective_from: Option<chrono::NaiveDate>,
+    /// Inclusive upper bound on the posting transaction's effective date.
+    pub effective_to: Option<chrono::NaiveDate>,
+}
+
 #[derive(EsEvent, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/cala-ledger/src/entry/mod.rs
+++ b/cala-ledger/src/entry/mod.rs
@@ -86,6 +86,28 @@ impl Entries {
             .await?)
     }
 
+    /// List a journal's entries with optional inclusive filters on the entry
+    /// creation time and on the posting transaction's effective date, paginated
+    /// on `(created_at, id)`. Unlike [`Self::list_for_journal_id`] this supports
+    /// date ranges and the cross-entity effective-date filter, which the generated
+    /// `list_for_*` methods cannot express.
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.entries.list_for_journal_id_filtered",
+        skip_all
+    )]
+    pub async fn list_for_journal_id_filtered(
+        &self,
+        journal_id: JournalId,
+        filter: EntriesFilter,
+        query: es_entity::PaginatedQueryArgs<EntryByCreatedAtCursor>,
+        direction: es_entity::ListDirection,
+    ) -> Result<es_entity::PaginatedQueryRet<Entry, EntryByCreatedAtCursor>, EntryError> {
+        self.repo
+            .list_for_journal_id_filtered_by_created_at(journal_id, filter, query, direction)
+            .await
+    }
+
     #[instrument(
         level = "debug",
         name = "cala_ledger.entries.list_for_transaction_id",

--- a/cala-ledger/src/entry/repo.rs
+++ b/cala-ledger/src/entry/repo.rs
@@ -112,6 +112,118 @@ impl EntryRepo {
         })
     }
 
+    #[instrument(
+        level = "debug",
+        name = "entry.list_for_journal_id_filtered_by_created_at",
+        skip_all,
+        err(level = "warn")
+    )]
+    pub(super) async fn list_for_journal_id_filtered_by_created_at(
+        &self,
+        journal_id: JournalId,
+        filter: EntriesFilter,
+        query: es_entity::PaginatedQueryArgs<entry_cursor::EntryByCreatedAtCursor>,
+        direction: es_entity::ListDirection,
+    ) -> Result<es_entity::PaginatedQueryRet<Entry, entry_cursor::EntryByCreatedAtCursor>, EntryError>
+    {
+        let es_entity::PaginatedQueryArgs { first, after } = query;
+        let (id, created_at) = if let Some(after) = after {
+            (Some(after.id), Some(after.created_at))
+        } else {
+            (None, None)
+        };
+        let EntriesFilter {
+            created_at_from,
+            created_at_to,
+            effective_from,
+            effective_to,
+        } = filter;
+
+        let executor = &self.pool;
+
+        // The outer query stays single-table on `cala_entries` (so `created_at` /
+        // `id` are unambiguous and the cursor pagination matches the other
+        // `list_for_*` methods); the effective-date range is applied as a
+        // semi-join against `cala_transactions`. When neither effective bound is
+        // set the disjunct short-circuits to the plain journal listing.
+        let (entities, has_next_page) = match direction {
+            es_entity::ListDirection::Ascending => {
+                es_entity::es_query!(
+                    entity = Entry,
+                    r#"
+                    SELECT created_at, id
+                    FROM cala_entries
+                    WHERE journal_id = $4
+                      AND ($5::timestamptz IS NULL OR created_at >= $5::timestamptz)
+                      AND ($6::timestamptz IS NULL OR created_at <= $6::timestamptz)
+                      AND (
+                        ($7::date IS NULL AND $8::date IS NULL)
+                        OR transaction_id IN (
+                          SELECT id FROM cala_transactions
+                          WHERE ($7::date IS NULL OR effective >= $7::date)
+                            AND ($8::date IS NULL OR effective <= $8::date)
+                        )
+                      )
+                      AND (COALESCE((created_at, id) > ($3, $2), $2 IS NULL))
+                    ORDER BY created_at ASC, id ASC
+                    LIMIT $1"#,
+                    (first + 1) as i64,
+                    id as Option<EntryId>,
+                    created_at as Option<chrono::DateTime<chrono::Utc>>,
+                    journal_id as JournalId,
+                    created_at_from as Option<chrono::DateTime<chrono::Utc>>,
+                    created_at_to as Option<chrono::DateTime<chrono::Utc>>,
+                    effective_from as Option<chrono::NaiveDate>,
+                    effective_to as Option<chrono::NaiveDate>,
+                )
+                .fetch_n(executor, first)
+                .await?
+            }
+            es_entity::ListDirection::Descending => {
+                es_entity::es_query!(
+                    entity = Entry,
+                    r#"
+                    SELECT created_at, id
+                    FROM cala_entries
+                    WHERE journal_id = $4
+                      AND ($5::timestamptz IS NULL OR created_at >= $5::timestamptz)
+                      AND ($6::timestamptz IS NULL OR created_at <= $6::timestamptz)
+                      AND (
+                        ($7::date IS NULL AND $8::date IS NULL)
+                        OR transaction_id IN (
+                          SELECT id FROM cala_transactions
+                          WHERE ($7::date IS NULL OR effective >= $7::date)
+                            AND ($8::date IS NULL OR effective <= $8::date)
+                        )
+                      )
+                      AND (COALESCE((created_at, id) < ($3, $2), $2 IS NULL))
+                    ORDER BY created_at DESC, id DESC
+                    LIMIT $1"#,
+                    (first + 1) as i64,
+                    id as Option<EntryId>,
+                    created_at as Option<chrono::DateTime<chrono::Utc>>,
+                    journal_id as JournalId,
+                    created_at_from as Option<chrono::DateTime<chrono::Utc>>,
+                    created_at_to as Option<chrono::DateTime<chrono::Utc>>,
+                    effective_from as Option<chrono::NaiveDate>,
+                    effective_to as Option<chrono::NaiveDate>,
+                )
+                .fetch_n(executor, first)
+                .await?
+            }
+        };
+
+        let end_cursor = entities
+            .last()
+            .map(entry_cursor::EntryByCreatedAtCursor::from);
+
+        Ok(es_entity::PaginatedQueryRet {
+            entities,
+            has_next_page,
+            end_cursor,
+        })
+    }
+
     async fn publish(
         &self,
         op: &mut impl es_entity::AtomicOperation,

--- a/cala-ledger/tests/entries_filter.rs
+++ b/cala-ledger/tests/entries_filter.rs
@@ -34,12 +34,31 @@ async fn page(
     first: usize,
     after: Option<EntryByCreatedAtCursor>,
 ) -> es_entity::PaginatedQueryRet<Entry, EntryByCreatedAtCursor> {
+    page_dir(
+        cala,
+        journal_id,
+        filter,
+        first,
+        after,
+        es_entity::ListDirection::Descending,
+    )
+    .await
+}
+
+async fn page_dir(
+    cala: &CalaLedger,
+    journal_id: JournalId,
+    filter: EntriesFilter,
+    first: usize,
+    after: Option<EntryByCreatedAtCursor>,
+    direction: es_entity::ListDirection,
+) -> es_entity::PaginatedQueryRet<Entry, EntryByCreatedAtCursor> {
     cala.entries()
         .list_for_journal_id_filtered(
             journal_id,
             filter,
             es_entity::PaginatedQueryArgs { first, after },
-            es_entity::ListDirection::Descending,
+            direction,
         )
         .await
         .unwrap()
@@ -186,6 +205,63 @@ async fn list_for_journal_id_filtered() -> anyhow::Result<()> {
     let second_page = page(&cala, journal.id(), jun_filter(), 4, first_page.end_cursor).await;
     assert_eq!(second_page.entities.len(), 2);
     assert!(!second_page.has_next_page);
+
+    // Ascending direction: oldest first, ordered on (created_at, id) -- entries
+    // posted in the same transaction can share a created_at, so the id
+    // tie-break matters.
+    let asc_first = page_dir(
+        &cala,
+        journal.id(),
+        EntriesFilter::default(),
+        5,
+        None,
+        es_entity::ListDirection::Ascending,
+    )
+    .await;
+    assert_eq!(asc_first.entities.len(), 5);
+    assert!(asc_first.has_next_page);
+    assert!(asc_first
+        .entities
+        .windows(2)
+        .all(|w| (w[0].created_at(), w[0].id) <= (w[1].created_at(), w[1].id)));
+
+    // Cursor continuation covers the rest with no gaps or overlap.
+    let asc_rest = page_dir(
+        &cala,
+        journal.id(),
+        EntriesFilter::default(),
+        100,
+        asc_first.end_cursor,
+        es_entity::ListDirection::Ascending,
+    )
+    .await;
+    assert_eq!(asc_rest.entities.len(), 7);
+    assert!(!asc_rest.has_next_page);
+    let mut ids: std::collections::HashSet<_> = asc_first.entities.iter().map(|e| e.id).collect();
+    for entry in &asc_rest.entities {
+        assert!(ids.insert(entry.id));
+    }
+    assert_eq!(ids.len(), 12);
+
+    // Ascending composes with a filter: June's entries, oldest first.
+    let jun_asc = page_dir(
+        &cala,
+        journal.id(),
+        jun_filter(),
+        100,
+        None,
+        es_entity::ListDirection::Ascending,
+    )
+    .await;
+    assert_eq!(jun_asc.entities.len(), 6);
+    assert!(jun_asc
+        .entities
+        .iter()
+        .all(|e| e.values().transaction_id == tx_jun));
+    assert!(jun_asc
+        .entities
+        .windows(2)
+        .all(|w| (w[0].created_at(), w[0].id) <= (w[1].created_at(), w[1].id)));
 
     Ok(())
 }

--- a/cala-ledger/tests/entries_filter.rs
+++ b/cala-ledger/tests/entries_filter.rs
@@ -1,0 +1,191 @@
+mod helpers;
+
+use chrono::{Duration, NaiveDate};
+use rand::distr::{Alphanumeric, SampleString};
+
+use cala_ledger::{
+    entry::{EntriesFilter, Entry, EntryByCreatedAtCursor},
+    tx_template::*,
+    *,
+};
+
+async fn post_tx(
+    cala: &CalaLedger,
+    code: &str,
+    journal_id: JournalId,
+    sender: AccountId,
+    recipient: AccountId,
+    effective: NaiveDate,
+) -> TransactionId {
+    let mut params = Params::new();
+    params.insert("journal_id", journal_id);
+    params.insert("sender", sender);
+    params.insert("recipient", recipient);
+    params.insert("effective", effective);
+    let id = TransactionId::new();
+    cala.post_transaction(id, code, params).await.unwrap();
+    id
+}
+
+async fn page(
+    cala: &CalaLedger,
+    journal_id: JournalId,
+    filter: EntriesFilter,
+    first: usize,
+    after: Option<EntryByCreatedAtCursor>,
+) -> es_entity::PaginatedQueryRet<Entry, EntryByCreatedAtCursor> {
+    cala.entries()
+        .list_for_journal_id_filtered(
+            journal_id,
+            filter,
+            es_entity::PaginatedQueryArgs { first, after },
+            es_entity::ListDirection::Descending,
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn list_for_journal_id_filtered() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let (sender, recipient) = helpers::test_accounts();
+    let sender = cala.accounts().create(sender).await?;
+    let recipient = cala.accounts().create(recipient).await?;
+
+    let code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    cala.tx_templates()
+        .create(helpers::currency_conversion_template(&code))
+        .await?;
+
+    // Each posting of the currency-conversion template writes 6 entries.
+    let jan = NaiveDate::from_ymd_opt(2020, 1, 15).unwrap();
+    let jun = NaiveDate::from_ymd_opt(2020, 6, 20).unwrap();
+    let tx_jan = post_tx(&cala, &code, journal.id(), sender.id(), recipient.id(), jan).await;
+    let tx_jun = post_tx(&cala, &code, journal.id(), sender.id(), recipient.id(), jun).await;
+
+    // No filter -> every entry in the journal, across both transactions.
+    let all = page(&cala, journal.id(), EntriesFilter::default(), 100, None).await;
+    assert_eq!(all.entities.len(), 12);
+    assert!(!all.has_next_page);
+
+    // effective == jan -> only the January transaction's entries.
+    let only_jan = page(
+        &cala,
+        journal.id(),
+        EntriesFilter {
+            effective_from: Some(jan),
+            effective_to: Some(jan),
+            ..Default::default()
+        },
+        100,
+        None,
+    )
+    .await;
+    assert_eq!(only_jan.entities.len(), 6);
+    assert!(only_jan
+        .entities
+        .iter()
+        .all(|e| e.values().transaction_id == tx_jan));
+
+    // effective range covering only June.
+    let only_jun = page(
+        &cala,
+        journal.id(),
+        EntriesFilter {
+            effective_from: Some(NaiveDate::from_ymd_opt(2020, 6, 1).unwrap()),
+            effective_to: Some(NaiveDate::from_ymd_opt(2020, 12, 31).unwrap()),
+            ..Default::default()
+        },
+        100,
+        None,
+    )
+    .await;
+    assert_eq!(only_jun.entities.len(), 6);
+    assert!(only_jun
+        .entities
+        .iter()
+        .all(|e| e.values().transaction_id == tx_jun));
+
+    // effective range that matches nothing.
+    let empty = page(
+        &cala,
+        journal.id(),
+        EntriesFilter {
+            effective_from: Some(NaiveDate::from_ymd_opt(2019, 1, 1).unwrap()),
+            effective_to: Some(NaiveDate::from_ymd_opt(2019, 12, 31).unwrap()),
+            ..Default::default()
+        },
+        100,
+        None,
+    )
+    .await;
+    assert!(empty.entities.is_empty());
+    assert!(empty.end_cursor.is_none());
+
+    // created_at bounds derived from the entries themselves (avoids clock skew).
+    let max_created = all.entities.iter().map(|e| e.created_at()).max().unwrap();
+    let up_to_max = page(
+        &cala,
+        journal.id(),
+        EntriesFilter {
+            created_at_to: Some(max_created),
+            ..Default::default()
+        },
+        100,
+        None,
+    )
+    .await;
+    assert_eq!(up_to_max.entities.len(), 12);
+
+    let after_all = page(
+        &cala,
+        journal.id(),
+        EntriesFilter {
+            created_at_from: Some(max_created + Duration::seconds(1)),
+            ..Default::default()
+        },
+        100,
+        None,
+    )
+    .await;
+    assert!(after_all.entities.is_empty());
+
+    // created + effective filters compose with AND.
+    let combined = page(
+        &cala,
+        journal.id(),
+        EntriesFilter {
+            created_at_to: Some(max_created),
+            effective_from: Some(jan),
+            effective_to: Some(jan),
+            ..Default::default()
+        },
+        100,
+        None,
+    )
+    .await;
+    assert_eq!(combined.entities.len(), 6);
+
+    // Cursor pagination composes with a filter: 4 + 2 over the 6 June entries.
+    let jun_filter = || EntriesFilter {
+        effective_from: Some(jun),
+        effective_to: Some(jun),
+        ..Default::default()
+    };
+    let first_page = page(&cala, journal.id(), jun_filter(), 4, None).await;
+    assert_eq!(first_page.entities.len(), 4);
+    assert!(first_page.has_next_page);
+
+    let second_page = page(&cala, journal.id(), jun_filter(), 4, first_page.end_cursor).await;
+    assert_eq!(second_page.entities.len(), 2);
+    assert!(!second_page.has_next_page);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds a typed cala query method for **journal-scoped entry listing filtered by
created-at range and by the posting transaction's effective date**, cursor-paginated
on `(created_at, id)` in either direction.

This is the exact shape es-entity's generated `list_for_*` methods can't express:
they do equality on a single column + created-at cursor only, so a **created-at
range window** and the **cross-entity effective-date filter** (`effective` lives on
`cala_transactions`, not `cala_entries`) require a hand-written query.

```rust
pub struct EntriesFilter {
    pub created_at_from: Option<DateTime<Utc>>,
    pub created_at_to: Option<DateTime<Utc>>,
    pub effective_from: Option<NaiveDate>,
    pub effective_to: Option<NaiveDate>,
}

// on Entries
pub async fn list_for_journal_id_filtered(
    &self,
    journal_id: JournalId,
    filter: EntriesFilter,
    query: PaginatedQueryArgs<EntryByCreatedAtCursor>,
    direction: ListDirection,
) -> Result<PaginatedQueryRet<Entry, EntryByCreatedAtCursor>, EntryError>
```

## What's in the change

- **`Entries::list_for_journal_id_filtered`** + `EntriesFilter` (`cala-ledger/src/entry/`).
  Implemented as a hand-written `es_query!` mirroring the existing
  `list_for_account_set_id_by_created_at` precedent — all bounds inclusive, AND
  semantics, unset bounds ignored.
- **Two indexes added to the `cala_ledger_setup` migration in place** (a breaking
  migration edit — acceptable pre-production; recreate dev stacks):
  - `idx_cala_entries_journal_id_created_at (journal_id, created_at DESC, id DESC)` —
    this backs the **existing** `Entries::list_for_journal_id` too, which was
    previously **unindexed** (scan + sort). Standalone perf win independent of the
    filter.
  - `idx_cala_transactions_effective (effective)` — backs the effective-date range.
- **Regenerated `.sqlx` offline cache** (2 new query files).
- **Integration test** `tests/entries_filter.rs` covering effective range, created-at
  range, no-filter, AND composition, empty result, and cursor pagination composed
  with a filter.

## Design notes

The outer query stays **single-table on `cala_entries`** (so `created_at`/`id` are
unambiguous and pagination matches the other `list_for_*` methods); the effective-date
range is applied as a **semi-join** against `cala_transactions`
(`transaction_id IN (SELECT id FROM cala_transactions WHERE effective …)`). When
neither effective bound is set the disjunct short-circuits to the plain journal
listing, so the unfiltered path keeps its fast plan.

No new events, no change to the outbox surface, no dependency changes.

## Why — relationship to lana-bank

lana-bank [#7796](https://github.com/GaloyMoney/lana-bank/pull/7796) ("journal
date-range filtering POC") implements this capability by querying cala's tables
directly — a `CREATE VIEW` over `cala_entries ⋈ cala_entry_events (JSONB) ⋈
cala_transactions ⋈ cala_accounts` plus two indexes on cala's tables, all from
**lana's** migration, then raw `sqlx` run on cala's pool. That couples lana to cala's
physical schema, event-sourcing JSONB layout, enum serde casing, and an internal
`sequence = 1` invariant.

This PR is **Option A** from the cross-DB boundary analysis (drua `cala-dev`
space, `analysis-lana-pr7796-cross-db-query.md`): expose the capability as a typed
cala API so lana can drop the cross-schema coupling.

**Migration path for #7796 once this lands:** `Journal::filtered_entries` collapses to
`self.cala.entries().list_for_journal_id_filtered(journal_id, filter.into(), cursor, Descending)`
mapping `Entry -> LedgerEntry` via the existing `TryFrom`; lana deletes its
`core_journal_entries` view, the two `CREATE INDEX`es on cala tables, the raw
`QueryBuilder` SQL, and the enum re-parsing. The GraphQL + admin-panel layers are
unchanged.

## Validation

- `nix flake check` — green (fmt, clippy `--all-features --deny warnings`, audit, deny).
- `cargo sqlx prepare` against a migrated DB — new queries type-check; cache committed.
- `cargo nextest run --test entries_filter` — passes.

## Status

Draft / POC — opening for design feedback on the API shape (filter struct fields,
method naming, whether to fold the follow-up filters — entry_type, layer, account-code
scoping, sort — into `EntriesFilter` now vs. incrementally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ledger read paths and alters the base migration (index additions); query correctness and pagination semantics matter for downstream consumers like lana-bank, but behavior is covered by integration tests and does not change posting or event surfaces.
> 
> **Overview**
> Adds **`EntriesFilter`** and **`Entries::list_for_journal_id_filtered`**, a typed API to list journal entries with optional inclusive bounds on entry `created_at` and on the parent transaction’s **effective** date, with cursor pagination on `(created_at, id)` in ascending or descending order. Generated `list_for_*` helpers cannot express created-at ranges or filters on `cala_transactions.effective`, so this uses a hand-written `es_query!` that keeps the outer query on `cala_entries` and applies effective-date constraints via a semi-join on `cala_transactions`.
> 
> The setup migration gains **`idx_cala_entries_journal_id_created_at`** (also benefits existing `list_for_journal_id`) and **`idx_cala_transactions_effective`**. Offline **`.sqlx`** cache is updated; integration test **`entries_filter`** covers filters, composition, empty results, and pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d09d23901dc7cbc264977203c4b9084cddb642. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->