### PR TITLE
fix(account-set): reject self-membership that double-counts balances

### DIFF
--- a/cala-ledger/src/account_set/error.rs
+++ b/cala-ledger/src/account_set/error.rs
@@ -48,6 +48,12 @@ pub enum AccountSetError {
          only eventually-consistent sets support recalculation"
     )]
     CannotRecalculateNonEcSet { account_set_id: AccountSetId },
+    #[error(
+        "AccountSetError - Cannot add account set '{account_set_id}' as a member of itself: \
+         self-membership would make every entry to the underlying account count twice \
+         in the set's balance"
+    )]
+    CannotAddSelfAsMember { account_set_id: AccountSetId },
 }
 
 impl From<AccountSetFindError> for AccountSetError {

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -178,6 +178,16 @@ impl AccountSets {
     ) -> Result<AccountSet, AccountSetError> {
         let member = member.into();
 
+        // Self-membership is never meaningful and actively corrupts
+        // balances: the posting path resolves an entry's account to its
+        // member sets *and* the account itself, so a set containing its
+        // own underlying account would apply every entry twice.
+        if let AccountSetMemberId::AccountSet(id) = member {
+            if id == account_set_id {
+                return Err(AccountSetError::CannotAddSelfAsMember { account_set_id });
+            }
+        }
+
         // Resolve the target set (and, for set-member, verify the journal
         // matches) without writing the membership row, so we can run the
         // no-history check first.
@@ -211,6 +221,10 @@ impl AccountSets {
                 (target, AccountId::from(id))
             }
         };
+
+        if member_id == AccountId::from(account_set.id()) {
+            return Err(AccountSetError::CannotAddSelfAsMember { account_set_id });
+        }
 
         self.assert_member_history_empty_in_op(
             op,
@@ -281,6 +295,12 @@ impl AccountSets {
             let set = sets
                 .get(account_set_id)
                 .ok_or(AccountSetError::CouldNotFindById(*account_set_id))?;
+            // See add_member_in_op: self-membership would double-apply entries.
+            if *member_id == AccountId::from(set.id()) {
+                return Err(AccountSetError::CannotAddSelfAsMember {
+                    account_set_id: *account_set_id,
+                });
+            }
             check_pairs.push((
                 set.values().journal_id,
                 AccountId::from(set.id()),

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -438,6 +438,10 @@ impl EffectiveBalances {
                 .unwrap_or(&empty)
                 .iter()
                 .map(AccountId::from)
+                // Skip self-mappings (rejected at the API level): the
+                // entry's own account is appended by the chain below,
+                // and pushing the entry twice would double-apply it.
+                .filter(|account_id| *account_id != entry.account_id)
                 .chain(std::iter::once(entry.account_id))
             {
                 if let Some(data) = all_data.get_mut(&(account_id, entry.currency)) {

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -524,6 +524,11 @@ impl Balances {
                 .unwrap_or(&empty)
                 .iter()
                 .map(AccountId::from)
+                // Self-mappings are rejected at the API level, but skip
+                // them here too: the entry's own account is appended by
+                // the chain below, and visiting it twice would apply
+                // the entry twice.
+                .filter(|account_id| *account_id != entry.account_id)
                 .chain(std::iter::once(entry.account_id))
             {
                 let latest =
@@ -780,6 +785,37 @@ mod tests {
             let result = Balances::new_snapshots(Utc::now(), current_balances, &entries, &mappings);
 
             assert_eq!(result.len(), 2);
+        }
+
+        #[test]
+        fn new_snapshots_applies_entry_once_for_self_mapping() {
+            // A set that (incorrectly) contains its own underlying
+            // account must not have entries applied twice: the entry's
+            // account is already visited via the chain's final `once`.
+            let account_set_id = AccountSetId::new();
+            let account_id = AccountId::from(&account_set_id);
+            let currency: Currency = "USD".parse().unwrap();
+
+            let mut current_balances = HashMap::new();
+            current_balances.insert((account_id, currency), None);
+
+            let mut mappings = HashMap::new();
+            mappings.insert(account_id, vec![account_set_id]);
+
+            let entry = create_test_entry(
+                Decimal::from(100),
+                DebitOrCredit::Debit,
+                Layer::Settled,
+                "USD",
+                account_id,
+            );
+            let entries = vec![entry];
+
+            let result = Balances::new_snapshots(Utc::now(), current_balances, &entries, &mappings);
+
+            assert_eq!(result.len(), 1);
+            assert_eq!(result[0].version, 1);
+            assert_eq!(result[0].settled.dr_balance, Decimal::from(100));
         }
     }
 

--- a/cala-ledger/src/velocity/balance/mod.rs
+++ b/cala-ledger/src/velocity/balance/mod.rs
@@ -94,6 +94,10 @@ impl VelocityBalances {
                 .unwrap_or(&empty)
                 .iter()
                 .map(AccountId::from)
+                // Skip self-mappings (rejected at the API level): the
+                // entry's own account is appended by the chain below,
+                // and checking it twice would double-count the entry.
+                .filter(|account_id| *account_id != entry.account_id)
                 .chain(std::iter::once(entry.account_id))
             {
                 let Some((_, controls)) = controls.get(&account_id) else {

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -88,6 +88,60 @@ async fn errors_on_collision() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn errors_on_self_membership() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let journal = cala
+        .journals()
+        .create(helpers::test_journal())
+        .await
+        .unwrap();
+
+    let set = NewAccountSet::builder()
+        .id(AccountSetId::new())
+        .name("SELF SET")
+        .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::Synchronous)
+        .build()
+        .unwrap();
+    let set = cala.account_sets().create(set).await.unwrap();
+
+    // Cannot add the set's own underlying account as a member
+    let res = cala
+        .account_sets()
+        .add_member(set.id(), AccountId::from(set.id()))
+        .await;
+    assert!(matches!(
+        res,
+        Err(AccountSetError::CannotAddSelfAsMember { .. })
+    ));
+
+    // Cannot add the set itself as a member
+    let res = cala.account_sets().add_member(set.id(), set.id()).await;
+    assert!(matches!(
+        res,
+        Err(AccountSetError::CannotAddSelfAsMember { .. })
+    ));
+
+    // Batch path rejects self-membership too
+    let res = cala
+        .account_sets()
+        .add_members(&[(set.id(), AccountId::from(set.id()))])
+        .await;
+    assert!(matches!(
+        res,
+        Err(AccountSetError::CannotAddSelfAsMember { .. })
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn add_members_batch() -> anyhow::Result<()> {
     let btc: Currency = "BTC".parse().unwrap();
 


### PR DESCRIPTION
## Problem

`AccountSets::add_member(_in_op)` / `add_members_in_op` accepted adding an account set's **own underlying account** as a member (account sets *are* accounts, and `AccountId::from(AccountSetId)` is public). The posting path resolves an entry's account to its member sets **and** the account itself:

```rust
mappings.get(&entry.account_id)      // -> [S]  (== entry.account_id!)
    .chain(std::iter::once(entry.account_id))  // -> [S, S]
```

so every entry was applied **twice** to the same balance — in `Balances::new_snapshots`, in the effective-balance path, and in velocity `balances_to_check` — silently inflating amounts with no error raised.

## Fix

- Reject self-membership (both the `Account` and `AccountSet` member forms, single and batch paths) with a new `AccountSetError::CannotAddSelfAsMember`.
- Defense in depth: filter self-mappings out of the account-resolution chains in `Balances::new_snapshots`, `EffectiveBalances::update_cumulative_balances_in_op` and `VelocityBalances::balances_to_check`, so even a pre-existing/crafted self-mapping can no longer double-apply an entry.

## Tests

- New unit test: `new_snapshots_applies_entry_once_for_self_mapping`
- New integration test: `errors_on_self_membership` (single account form, set form, and batch path)
- Full workspace suite passes (109 tests)