### PR TITLE
fix(account-set): prevent membership cycles in add_member_set

### DIFF
--- a/cala-ledger/.sqlx/query-9da8d49f29ffcf5219c28ad9e0031d1b238677f782d5fffc2dcc1bb78e1c32bd.json
+++ b/cala-ledger/.sqlx/query-9da8d49f29ffcf5219c28ad9e0031d1b238677f782d5fffc2dcc1bb78e1c32bd.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          WITH RECURSIVE parents AS (\n            SELECT m.member_account_set_id, m.account_set_id\n            FROM cala_account_set_member_account_sets m\n            WHERE m.member_account_set_id = $1\n\n            UNION ALL\n            SELECT p.member_account_set_id, m.account_set_id\n            FROM parents p\n            JOIN cala_account_set_member_account_sets m\n                ON p.account_set_id = m.member_account_set_id\n          )\n          SELECT EXISTS(\n            SELECT 1 FROM parents WHERE account_set_id = $2\n          ) AS \"exists!\"\n          ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9da8d49f29ffcf5219c28ad9e0031d1b238677f782d5fffc2dcc1bb78e1c32bd"
+}

--- a/cala-ledger/src/account_set/error.rs
+++ b/cala-ledger/src/account_set/error.rs
@@ -48,6 +48,15 @@ pub enum AccountSetError {
          only eventually-consistent sets support recalculation"
     )]
     CannotRecalculateNonEcSet { account_set_id: AccountSetId },
+    #[error(
+        "AccountSetError - Cannot add account set '{member_account_set_id}' as a member of \
+         account set '{account_set_id}': the member is already an ancestor of the set, \
+         so the membership would create a cycle"
+    )]
+    MembershipCycleDetected {
+        account_set_id: AccountSetId,
+        member_account_set_id: AccountSetId,
+    },
 }
 
 impl From<AccountSetFindError> for AccountSetError {

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -630,9 +630,52 @@ impl AccountSetRepo {
         member_account_set_id: AccountSetId,
     ) -> Result<(), AccountSetError> {
         // Structure mutation: EXCLUSIVE coarse lock (see ADDVISORY_LOCK_ID).
+        // Held across the cycle check and the insert below, so the graph
+        // the check validated cannot change before the new edge commits.
         sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
             .execute(db.as_executor())
             .await?;
+
+        // Reject edges that would close a cycle: the ancestor walks in
+        // this repo are `UNION ALL` recursive CTEs without cycle
+        // detection, so a cycle would make subsequent membership
+        // mutations non-terminating (while holding the coarse lock) and
+        // would cross-contaminate the transitive member closure.
+        if account_set_id == member_account_set_id {
+            return Err(AccountSetError::MembershipCycleDetected {
+                account_set_id,
+                member_account_set_id,
+            });
+        }
+        let cycle = sqlx::query!(
+            r#"
+          WITH RECURSIVE parents AS (
+            SELECT m.member_account_set_id, m.account_set_id
+            FROM cala_account_set_member_account_sets m
+            WHERE m.member_account_set_id = $1
+
+            UNION ALL
+            SELECT p.member_account_set_id, m.account_set_id
+            FROM parents p
+            JOIN cala_account_set_member_account_sets m
+                ON p.account_set_id = m.member_account_set_id
+          )
+          SELECT EXISTS(
+            SELECT 1 FROM parents WHERE account_set_id = $2
+          ) AS "exists!"
+          "#,
+            account_set_id as AccountSetId,
+            member_account_set_id as AccountSetId,
+        )
+        .fetch_one(db.as_executor())
+        .await?;
+        if cycle.exists {
+            return Err(AccountSetError::MembershipCycleDetected {
+                account_set_id,
+                member_account_set_id,
+            });
+        }
+
         sqlx::query!(r#"
           WITH RECURSIVE parents AS (
             SELECT m.member_account_set_id, m.account_set_id

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -88,6 +88,65 @@ async fn errors_on_collision() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn errors_on_membership_cycle() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let journal = cala
+        .journals()
+        .create(helpers::test_journal())
+        .await
+        .unwrap();
+
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name.to_string())
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let set_a = cala.account_sets().create(new_set("SET A")).await.unwrap();
+    let set_b = cala.account_sets().create(new_set("SET B")).await.unwrap();
+    let set_c = cala.account_sets().create(new_set("SET C")).await.unwrap();
+
+    // B becomes a member of A, C a member of B
+    let res = cala.account_sets().add_member(set_a.id(), set_b.id()).await;
+    assert!(res.is_ok());
+    let res = cala.account_sets().add_member(set_b.id(), set_c.id()).await;
+    assert!(res.is_ok());
+
+    // A is an ancestor of B: adding A to B would close a cycle
+    let res = cala.account_sets().add_member(set_b.id(), set_a.id()).await;
+    assert!(matches!(
+        res,
+        Err(AccountSetError::MembershipCycleDetected { .. })
+    ));
+
+    // A is a (transitive) ancestor of C: adding A to C would close a cycle
+    let res = cala.account_sets().add_member(set_c.id(), set_a.id()).await;
+    assert!(matches!(
+        res,
+        Err(AccountSetError::MembershipCycleDetected { .. })
+    ));
+
+    // A set can never be its own member
+    let res = cala.account_sets().add_member(set_a.id(), set_a.id()).await;
+    assert!(res.is_err());
+
+    // Non-cyclic additions still work
+    let res = cala.account_sets().add_member(set_a.id(), set_c.id()).await;
+    assert!(res.is_ok());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn add_members_batch() -> anyhow::Result<()> {
     let btc: Currency = "BTC".parse().unwrap();
 


### PR DESCRIPTION
## Problem

`add_member_set` inserted set→set edges with no cycle check. Creating A→B and then B→A has two severe consequences:

1. **DoS**: every membership mutation walks ancestors via `WITH RECURSIVE parents ... UNION ALL` with no cycle detection. Once a cycle exists, any subsequent add/remove touching it never terminates — while holding the coarse `ADDVISORY_LOCK_ID` **exclusive** advisory lock, blocking *all* membership mutations ledger-wide.
2. **Closure corruption**: the transitive member closure cross-contaminates both sets (each set's members folded into the other), so balance rollups silently include each other's members.

## Fix

Reject the edge up front with `AccountSetError::MembershipCycleDetected` when the candidate member is the target itself or is found in the target's ancestor walk. The check runs under the same `EXCLUSIVE` coarse advisory lock that guards the insert, so the validated graph cannot change before commit.

Note: the direct self-edge (`add_member(S, S)`) is already rejected earlier with `CouldNotFindById` by the entity resolution in `add_member_in_op`; the repo-level self-check added here makes the guard explicit regardless of call path. (See also #799, which gives the self case a dedicated error.)

## Tests

- New integration test `errors_on_membership_cycle`: direct cycle (A↔B), transitive cycle (A→B→C then C→A), self-edge, and a non-cyclic control case.
- New query added to `.sqlx` via `cargo sqlx prepare` (only the new query file; the 35 unrelated deletions a local `prepare` produces on clean `main` were reverted — that's a pre-existing environment discrepancy).
- Full workspace suite passes (108 tests)