### PR TITLE
fix(tx-template): reject non-positive entry units

### DIFF
--- a/cala-ledger/src/tx_template/error.rs
+++ b/cala-ledger/src/tx_template/error.rs
@@ -33,6 +33,10 @@ pub enum TxTemplateError {
     SerdeJson(#[from] serde_json::Error),
     #[error("TxTemplateError - UnbalancedTransaction: currency {0}, layer {1:?}, amount {2}")]
     UnbalancedTransaction(Currency, Layer, Decimal),
+    #[error(
+        "TxTemplateError - NonPositiveUnits: entry type '{0}' evaluated to non-positive units {1}"
+    )]
+    NonPositiveUnits(String, Decimal),
     #[error("TxTemplateError - NotFound: code '{0}' not found")]
     CouldNotFindByCode(String),
     #[error("{0}")]

--- a/cala-ledger/src/tx_template/mod.rs
+++ b/cala-ledger/src/tx_template/mod.rs
@@ -175,12 +175,22 @@ impl TxTemplates {
             builder.account_id(account_id);
 
             let entry_type: String = entry.entry_type.try_evaluate(ctx)?;
-            builder.entry_type(entry_type);
+            builder.entry_type(entry_type.clone());
 
             let layer: Layer = entry.layer.try_evaluate(ctx)?;
             builder.layer(layer);
 
             let units: Decimal = entry.units.try_evaluate(ctx)?;
+            // Negative or zero units invert the entry's accounting
+            // meaning (a DEBIT of -X is a CREDIT of X) while still
+            // passing the zero-sum check below, and let postings drive
+            // balance legs negative and slip past velocity enforcement.
+            if units <= Decimal::ZERO {
+                return Err(TxTemplateError::NonPositiveUnits(
+                    entry_type.clone(),
+                    units,
+                ));
+            }
             let currency: Currency = entry.currency.try_evaluate(ctx)?;
             let direction: DebitOrCredit = entry.direction.try_evaluate(ctx)?;
 

--- a/cala-ledger/tests/tx_template.rs
+++ b/cala-ledger/tests/tx_template.rs
@@ -1,6 +1,9 @@
 mod helpers;
 
-use cala_ledger::{tx_template::error::TxTemplateError, *};
+use rand::distr::{Alphanumeric, SampleString};
+use rust_decimal::Decimal;
+
+use cala_ledger::{error::LedgerError, tx_template::error::TxTemplateError, tx_template::*, *};
 
 #[tokio::test]
 async fn duplicate_code() -> anyhow::Result<()> {
@@ -17,6 +20,132 @@ async fn duplicate_code() -> anyhow::Result<()> {
     let new_template = helpers::currency_conversion_template("tx_template_code");
     let res = cala.tx_templates().create(new_template).await;
     assert!(matches!(res, Err(TxTemplateError::DuplicateCode(_))));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn errors_on_non_positive_units() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let journal = cala
+        .journals()
+        .create(helpers::test_journal())
+        .await
+        .unwrap();
+    let (sender, recipient) = helpers::test_accounts();
+    let sender_account = cala.accounts().create(sender).await.unwrap();
+    let recipient_account = cala.accounts().create(recipient).await.unwrap();
+
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    let params_def = vec![
+        NewParamDefinition::builder()
+            .name("recipient")
+            .r#type(ParamDataType::Uuid)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("sender")
+            .r#type(ParamDataType::Uuid)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("journal_id")
+            .r#type(ParamDataType::Uuid)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("amount")
+            .r#type(ParamDataType::Decimal)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("effective")
+            .r#type(ParamDataType::Date)
+            .default_expr("date()")
+            .build()
+            .unwrap(),
+    ];
+    let entries = vec![
+        NewTxTemplateEntry::builder()
+            .entry_type("'DR'")
+            .account_id("params.sender")
+            .layer("SETTLED")
+            .direction("DEBIT")
+            .units("params.amount")
+            .currency("'USD'")
+            .build()
+            .unwrap(),
+        NewTxTemplateEntry::builder()
+            .entry_type("'CR'")
+            .account_id("params.recipient")
+            .layer("SETTLED")
+            .direction("CREDIT")
+            .units("params.amount")
+            .currency("'USD'")
+            .build()
+            .unwrap(),
+    ];
+    let new_template = NewTxTemplate::builder()
+        .id(uuid::Uuid::now_v7())
+        .code(&tx_code)
+        .params(params_def)
+        .transaction(
+            NewTxTemplateTransaction::builder()
+                .effective("params.effective")
+                .journal_id("params.journal_id")
+                .build()
+                .unwrap(),
+        )
+        .entries(entries)
+        .build()
+        .unwrap();
+    cala.tx_templates().create(new_template).await.unwrap();
+
+    let make_params = |amount: Decimal| {
+        let mut params = Params::new();
+        params.insert("journal_id", journal.id());
+        params.insert("sender", sender_account.id());
+        params.insert("recipient", recipient_account.id());
+        params.insert("amount", amount);
+        params
+    };
+
+    // Negative units would invert the entry's accounting meaning and
+    // must be rejected
+    let res = cala
+        .post_transaction(
+            TransactionId::new(),
+            &tx_code,
+            make_params(Decimal::from(-100)),
+        )
+        .await;
+    assert!(matches!(res, Err(LedgerError::TxTemplateError(
+        TxTemplateError::NonPositiveUnits(_, _)
+    ))));
+
+    // Zero units are rejected too
+    let res = cala
+        .post_transaction(TransactionId::new(), &tx_code, make_params(Decimal::ZERO))
+        .await;
+    assert!(matches!(res, Err(LedgerError::TxTemplateError(
+        TxTemplateError::NonPositiveUnits(_, _)
+    ))));
+
+    // Positive units still post
+    let res = cala
+        .post_transaction(
+            TransactionId::new(),
+            &tx_code,
+            make_params(Decimal::from(100)),
+        )
+        .await;
+    assert!(res.is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

Nothing validated that a template's `units` expression evaluates to a positive amount. A `DEBIT -X` is accounting-equivalent to `CREDIT +X`, but everything downstream treats the entry by its direction label:

- The zero-sum double-entry check in `prep_entries` still passes (it nets signed values).
- `Snapshots::update_snapshot` adds the negative units to the dr/cr legs, driving individual legs negative.
- Velocity `enforce()` checks net dr−cr against the limit, so negative net amounts always pass — a transfer executed entirely with negative-unit entries inverts each side's direction and never trips debit/credit velocity windows.

Any template using e.g. `units: params.amount` was one negative param away from bypassing velocity controls.

## Fix

Reject `units <= 0` in `prep_entries` with a new `TxTemplateError::NonPositiveUnits` that names the offending entry type and the evaluated amount.

## Tests

- New integration test `errors_on_non_positive_units`: negative and zero amounts are rejected, positive amount posts fine.
- Full workspace suite passes (108 tests)