### PR TITLE
fix(ledger): reject entries targeting eventually-consistent accounts

### DIFF
--- a/cala-ledger/src/ledger/error.rs
+++ b/cala-ledger/src/ledger/error.rs
@@ -34,6 +34,11 @@ pub enum LedgerError {
     BalanceError(#[from] BalanceError),
     #[error("LedgerError - VelocityError: {0}")]
     VelocityError(#[from] VelocityError),
+    #[error(
+        "LedgerError - EntriesTargetEventuallyConsistentAccount: entries cannot target \
+         eventually-consistent account '{0}' directly; post to its member accounts instead"
+    )]
+    EntriesTargetEventuallyConsistentAccount(crate::primitives::AccountId),
 }
 
 impl From<sqlx::Error> for LedgerError {

--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -190,6 +190,27 @@ impl CalaLedger {
             .iter()
             .map(|entry| entry.account_id)
             .collect::<Vec<_>>();
+
+        // Entries must not target eventually-consistent (EC) accounts
+        // directly: the posting path deliberately skips EC accounts when
+        // updating balances (EC sets are maintained by recalculation
+        // from member history), so such an entry would be persisted and
+        // published yet never reflected in any balance - not even by
+        // recalc, which only folds in *member* history.
+        {
+            let accounts = self
+                .accounts
+                .find_all_in_op::<crate::account::Account>(&mut db, &account_ids)
+                .await?;
+            for account in accounts.values() {
+                if account.values().config.eventually_consistent {
+                    return Err(LedgerError::EntriesTargetEventuallyConsistentAccount(
+                        account.id(),
+                    ));
+                }
+            }
+        }
+
         let mappings = self
             .account_sets
             .fetch_mappings_in_op(&mut db, transaction.values().journal_id, &account_ids)

--- a/cala-ledger/tests/transaction_post.rs
+++ b/cala-ledger/tests/transaction_post.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use rand::distr::{Alphanumeric, SampleString};
 use rust_decimal::Decimal;
 
-use cala_ledger::{tx_template::*, *};
+use cala_ledger::{account_set::*, error::LedgerError, primitives::BalanceRollup, tx_template::*, *};
 
 #[tokio::test]
 async fn transaction_post() -> anyhow::Result<()> {
@@ -78,6 +78,128 @@ async fn transaction_post() -> anyhow::Result<()> {
         .get(&(journal.id(), sender_account.id(), "BTC".parse().unwrap()))
         .unwrap();
     assert_eq!(sender_balance.settled(), Decimal::from(-1290 * 2));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn errors_when_entry_targets_eventually_consistent_account() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config).await?;
+
+    let journal = cala
+        .journals()
+        .create(helpers::test_journal())
+        .await
+        .unwrap();
+    let (sender, recipient) = helpers::test_accounts();
+    let sender_account = cala.accounts().create(sender).await.unwrap();
+    let recipient_account = cala.accounts().create(recipient).await.unwrap();
+
+    let ec_set = NewAccountSet::builder()
+        .id(AccountSetId::new())
+        .name("EC SET")
+        .journal_id(journal.id())
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
+        .build()
+        .unwrap();
+    let ec_set = cala.account_sets().create(ec_set).await.unwrap();
+
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    let params_def = vec![
+        NewParamDefinition::builder()
+            .name("recipient")
+            .r#type(ParamDataType::Uuid)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("sender")
+            .r#type(ParamDataType::Uuid)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("journal_id")
+            .r#type(ParamDataType::Uuid)
+            .build()
+            .unwrap(),
+        NewParamDefinition::builder()
+            .name("effective")
+            .r#type(ParamDataType::Date)
+            .default_expr("date()")
+            .build()
+            .unwrap(),
+    ];
+    let entries = vec![
+        NewTxTemplateEntry::builder()
+            .entry_type("'DR'")
+            .account_id("params.sender")
+            .layer("SETTLED")
+            .direction("DEBIT")
+            .units("decimal('100')")
+            .currency("'USD'")
+            .build()
+            .unwrap(),
+        NewTxTemplateEntry::builder()
+            .entry_type("'CR'")
+            .account_id("params.recipient")
+            .layer("SETTLED")
+            .direction("CREDIT")
+            .units("decimal('100')")
+            .currency("'USD'")
+            .build()
+            .unwrap(),
+    ];
+    let new_template = NewTxTemplate::builder()
+        .id(uuid::Uuid::now_v7())
+        .code(&tx_code)
+        .params(params_def)
+        .transaction(
+            NewTxTemplateTransaction::builder()
+                .effective("params.effective")
+                .journal_id("params.journal_id")
+                .build()
+                .unwrap(),
+        )
+        .entries(entries)
+        .build()
+        .unwrap();
+    cala.tx_templates().create(new_template).await.unwrap();
+
+    let make_params = |recipient: AccountId| {
+        let mut params = Params::new();
+        params.insert("journal_id", journal.id());
+        params.insert("sender", sender_account.id());
+        params.insert("recipient", recipient);
+        params
+    };
+
+    // Posting directly to an EC account set's underlying account would
+    // persist the entry without ever reflecting it in any balance
+    let res = cala
+        .post_transaction(
+            TransactionId::new(),
+            &tx_code,
+            make_params(AccountId::from(ec_set.id())),
+        )
+        .await;
+    assert!(matches!(
+        res,
+        Err(LedgerError::EntriesTargetEventuallyConsistentAccount(_))
+    ));
+
+    // Posting to regular accounts works
+    let res = cala
+        .post_transaction(
+            TransactionId::new(),
+            &tx_code,
+            make_params(recipient_account.id()),
+        )
+        .await;
+    assert!(res.is_ok());
 
     Ok(())
 }


### PR DESCRIPTION
## Problem

The posting path deliberately skips eventually-consistent (EC) accounts when updating balances — `BalanceRepo::find_for_update` filters them out of both the lock query and the data fetch, and EC account sets are maintained by recalculation from *member* history. But nothing stopped a template from posting an entry **directly to an EC set's underlying account**:

- the entry was persisted to `cala_entries` and published to the outbox,
- no balance-history row was ever written for it (`new_snapshots` hits `current = None → continue`),
- and no recalc would ever see it (recalc only folds in *member* history).

The value simply disappeared from all balances while remaining in the entry log — a silent ledger/balance divergence.

## Fix

Reject such postings in `post_transaction_in_op` with a new `LedgerError::EntriesTargetEventuallyConsistentAccount`, checked right after entries are prepared (before velocity and balance updates) so the whole operation rolls back.

## Tests

- New integration test `errors_when_entry_targets_eventually_consistent_account`: posting to an EC set's account errors; posting the same template to regular accounts succeeds.
- Full workspace suite passes (108 tests)