### PR TITLE
docs: document advisory-lock ordering invariants

### DIFF
--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -45,6 +45,16 @@ use super::{entity::*, error::*};
 /// lock. An operation must never wait on the coarse lock while holding
 /// a per-member lock — under PostgreSQL's FIFO lock queueing that can
 /// form a wait cycle with a queued exclusive (structure) waiter.
+///
+/// Namespace note: this is a 1-arg `pg_advisory_xact_lock`, so it
+/// shares a key space with the balance locks
+/// (`hashtext(journal_id, account_id, currency)`), the
+/// velocity-balance locks, and any other 1-arg advisory lock in the
+/// database. A `hashtext` collision with this id would only cause
+/// false serialization between unrelated operations — never
+/// incorrectness. The 2-arg locks (`EC_SET_LOCK_CLASS`,
+/// `MEMBER_LOCK_CLASS`) live in a disjoint namespace keyed by
+/// `classid`.
 const ADDVISORY_LOCK_ID: i64 = 123456;
 
 /// `classid` namespace for the per-member advisory locks (2-arg form),

--- a/cala-ledger/src/balance/repo.rs
+++ b/cala-ledger/src/balance/repo.rs
@@ -358,12 +358,27 @@ impl BalanceRepo {
     ///
     /// The 2-arg and 1-arg `pg_advisory_xact_lock` namespaces are
     /// disjoint in PostgreSQL, so the two locks cannot collide with
-    /// each other. Lock acquisition order across transactions is
-    /// canonical because the caller pre-sorts the input via a BTreeSet
-    /// in `Balances::update_balances_in_op` and the planner picks a
-    /// nested-loop join with `v` as the outer side for the tiny inputs
-    /// this query receives, preserving UNNEST scan order through to
-    /// the function calls in the SELECT list.
+    /// each other.
+    ///
+    /// Lock acquisition order across transactions is canonical
+    /// **only** because the caller pre-sorts the input via a BTreeSet
+    /// in `Balances::update_balances_in_op`: the planner is free to
+    /// evaluate the per-row projection (the lock function calls)
+    /// before any SQL-level sort node, so the `ORDER BY` below is
+    /// *not* what orders the lock acquisitions — it merely keeps the
+    /// (already sorted) scan on the simple path. Do not change the
+    /// caller to an unordered container (e.g. HashMap iteration), and
+    /// do not "optimize" this query in ways that would let the
+    /// planner evaluate the locks in a different order than the
+    /// UNNEST input; both would reopen the deadlock window this
+    /// protocol exists to close.
+    ///
+    /// All lock keys are 32-bit `hashtext` values, and this 1-arg
+    /// namespace is shared with the velocity-balance locks and the
+    /// membership coarse lock (`ADDVISORY_LOCK_ID`). Hash collisions
+    /// only cause false serialization between unrelated accounts —
+    /// never a correctness issue — at the price of occasional extra
+    /// contention.
     #[instrument(level = "debug", name = "cala_ledger.balances.find_for_update", skip(self, op, account_ids, currencies), fields(balances_count = account_ids.len()))]
     pub(super) async fn find_for_update(
         &self,

--- a/cala-ledger/src/velocity/balance/repo.rs
+++ b/cala-ledger/src/velocity/balance/repo.rs
@@ -28,6 +28,24 @@ impl VelocityBalanceRepo {
             _pool: pool.clone(),
         }
     }
+    /// Takes one advisory lock per velocity-balance key and loads the
+    /// current snapshots.
+    ///
+    /// Lock ordering notes (same protocol as
+    /// `BalanceRepo::find_for_update`):
+    ///
+    /// - The canonical acquisition order is guaranteed by the
+    ///   Rust-side `sorted_keys` sort below, *not* by the query's
+    ///   `ORDER BY`: the planner may evaluate the lock projection
+    ///   before any sort node. Keep the input sort and the UNNEST
+    ///   parameter order in sync if this function is ever changed.
+    /// - The lock key deliberately excludes `window`: keys that differ
+    ///   only in their partition window share one lock. That is safe
+    ///   over-serialization (a posting updates all of a key's windows
+    ///   in one go anyway) and keeps the lock space small.
+    /// - Keys are 32-bit `hashtext` values in the shared 1-arg
+    ///   advisory-lock namespace; collisions with unrelated locks only
+    ///   cause false serialization, never incorrectness.
     #[instrument(
         level = "debug",
         name = "velocity_balance.find_for_update",


### PR DESCRIPTION
Documentation-only PR capturing the conclusions of the locking review (finding 7), so the invariants survive future edits. **No behavior change.**

## What the review found

The advisory-lock protocol itself held up: canonical ordering is consistent across posters, EC recalcs, and both member-check paths; the 2-arg EC-set namespace and the membership coarse/per-member locks don't produce a deadlock cycle I could construct. But two fragile points were only implicitly protected:

1. **`find_for_update` (balance and velocity) relies on caller-side input sorting, not the query's `ORDER BY`.** The code already notes elsewhere (`lock_accounts_exclusive_in_op`) that PostgreSQL's planner is free to evaluate projection expressions (the `pg_advisory_xact_lock` calls) *before* any sort node. The canonical acquisition order is safe today only because callers pre-sort the UNNEST input (BTreeSet / `sorted_keys`) and that order coincides with the `ORDER BY`. The doc comments now say this explicitly and warn against reordering either side.
2. **All 1-arg advisory locks share one namespace** (balance locks, velocity locks, `ADDVISORY_LOCK_ID = 123456`), and all keys are 32-bit `hashtext` values. Collisions cause false serialization only — documented at `ADDVISORY_LOCK_ID` and both `find_for_update` sites. Also documented that the velocity lock key deliberately excludes `window` (safe over-serialization).