### PR TITLE
chore: pin nix dev postgres to 18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
         cargo-deny
         samply
         bacon
-        postgresql
+        postgresql_18
         process-compose
         bc
         jq
@@ -108,7 +108,7 @@
       pg-start = pkgs.writeShellApplication {
         name = "pg-start";
         runtimeInputs =
-          [pkgs.postgresql pkgs.coreutils]
+          [pkgs.postgresql_18 pkgs.coreutils]
           ++ pkgs.lib.optionals pkgs.stdenv.isLinux [pkgs.util-linux];
         text = ''
           NAME="$1" PORT="$2" PGUSER="$3" DB="$4"
@@ -211,7 +211,7 @@
           exec.command = "${
             pkgs.writeShellApplication {
               name = "ready-${name}";
-              runtimeInputs = [pkgs.postgresql];
+              runtimeInputs = [pkgs.postgresql_18];
               text = ''
                 exec psql -p "''${PGPORT:-${toString port}}" -U ${user} -h 127.0.0.1 -d ${db} -c 'SELECT 1' -t -q
               '';
@@ -305,7 +305,7 @@
           pkgs.gnused
           pkgs.gnugrep
           pkgs.findutils
-          pkgs.postgresql
+          pkgs.postgresql_18
           rustToolchain
           pkgs.stdenv.cc
         ]}:$PATH"
@@ -327,7 +327,7 @@
         ${depsUp}
 
         echo "Running perf DB setup..."
-        ${pkgs.postgresql}/bin/psql "$DATABASE_URL" -f ./cala-perf/pg-tools/setup.sql
+        ${pkgs.postgresql_18}/bin/psql "$DATABASE_URL" -f ./cala-perf/pg-tools/setup.sql
 
         echo "Running benchmarks..."
         cargo bench -p cala-perf


### PR DESCRIPTION
## Why

`pkgs.postgresql` follows the nixpkgs default version (currently 17). lana-bank runs PostgreSQL **18** in every environment (local nix, staging 18.3, QA 18.4), and downstream work (e.g. obix adopting the PG18 built-in `uuidv7()` for outbox IDs) assumes PG18 as the floor.

## What

Pin `postgresql` → `postgresql_18` in `flake.nix`:
- dev shell `buildInputs`
- `pg-start` runtime inputs
- readiness-probe runtime inputs
- perf DB setup (`psql` invocation + inputs)

## Verification

- `nix eval .#devShells.<system>.default.drvPath` — evaluates
- `nix develop -c psql --version` → 18.x (verified on the identical obix change)