### PR TITLE
chore(deps): fix cargo audit failures

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,11 @@
 [advisories]
-ignore = ["RUSTSEC-2023-0071"]
+ignore = [
+  "RUSTSEC-2023-0071",
+  # rkyv 0.7.46 appears in Cargo.lock only as an *optional* dependency of
+  # rust_decimal whose "rkyv" feature is never enabled in this workspace
+  # (verified with `cargo tree` / `cargo metadata`: rust_decimal resolves with
+  # features default, maths, serde, std only). The crate is never compiled or
+  # shipped, so the OOB-read advisory is not exploitable here. Remove this
+  # ignore if rust_decimal/rkyv is ever enabled.
+  "RUSTSEC-2026-0235",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -652,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Fixes the failing `security_audit` job (e.g. [this run](https://github.com/GaloyMoney/cala/actions/runs/30934105285)):

- **Ignore RUSTSEC-2026-0235 (`rkyv 0.7.46`)**: `rkyv` is only an *optional* dependency of `rust_decimal` whose `rkyv` feature is never enabled anywhere in this workspace (verified via `cargo tree`/`cargo metadata` — `rust_decimal` resolves with only `default, maths, serde, std`). The crate is never compiled or shipped; it appears in `Cargo.lock` because modern Cargo records optional dependencies of lockfile packages. No upgrade path exists (`rust_decimal 1.42.x` still requires `rkyv ^0.7`). The ignore is documented in `.cargo/audit.toml` with instructions to revisit if the feature is ever enabled.
- **Bump `crossbeam-epoch` 0.9.18 → 0.9.20**: fixes RUSTSEC-2026-0204. Only present via `criterion` (dev-dependency). This advisory wasn't in the advisory DB at the time of the failing CI run, but would fail CI as soon as the DB updates.

## Verification

- `cargo audit` exits clean (only pre-existing allowed informational warnings)
- `cargo check -p cala-cel-interpreter --benches` passes (benches are what pull in `criterion` → `crossbeam-epoch`)