### PR TITLE
feat(ledger): range-partition cala_persistent_outbox_events (obix 0.6.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,6 +711,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +748,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,6 +780,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1611,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7918bab03582f8ccb1f1a932d28b2220cab559339c6e48c731a1d92920bc830a"
+checksum = "d5f6e0714ebcfdd1ab4ab249ca5915971dd6f252a001918c86041fbcdf696cdf"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1634,14 +1668,14 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d22945a31b5451e80efefcc19c5e995457f833a0771d76bd05bd5af1a0ad38"
+checksum = "3a61e88f9b2411876a1bc2513d40c32534dddd060319e95de007cf98c82a8307"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cala-ledger = { path = "cala-ledger", version = "0.20.3-dev" }
 cel = "0.14.1"
 es-entity = "0.11.11"
 job = { version = "0.6.36", features = ["es-entity"] }
-obix = { version = "0.5.0", default-features = false }
+obix = { version = "0.6.0", default-features = false }
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }

--- a/cala-ledger/migrations/20260804211500_cala_partition_persistent_outbox_events.sql
+++ b/cala-ledger/migrations/20260804211500_cala_partition_persistent_outbox_events.sql
@@ -1,0 +1,56 @@
+-- Convert cala_persistent_outbox_events to the RANGE-partitioned layout
+-- introduced in obix 0.6.0 (Stage 1 partitioning): primary key on `sequence`,
+-- explicit partitions of width 2M tiling onto _p0, plus an always-present
+-- DEFAULT backstop so inserts can never fail to route. The obix partition
+-- maintainer (registered by the consuming application) keeps partitions
+-- pre-created ahead of the head from here on.
+--
+-- The table is rewritten in place: all rows and the sequence position are
+-- preserved, so consumers' sequence cursors stay valid. The unused seen_at
+-- column is dropped (removed in obix 0.6.0). The copy holds ACCESS EXCLUSIVE,
+-- so outbox writes BLOCK (they do not fail) for the duration of this
+-- migration.
+
+ALTER TABLE cala_persistent_outbox_events RENAME TO cala_persistent_outbox_events_old;
+
+CREATE TABLE cala_persistent_outbox_events (
+  id UUID NOT NULL DEFAULT gen_random_uuid(),
+  sequence BIGINT NOT NULL DEFAULT nextval('cala_persistent_outbox_events_sequence_seq'),
+  payload JSONB,
+  tracing_context JSONB,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (sequence)
+) PARTITION BY RANGE (sequence);
+
+ALTER SEQUENCE cala_persistent_outbox_events_sequence_seq
+  OWNED BY cala_persistent_outbox_events.sequence;
+
+-- Cover the existing sequence range with explicit partitions (2M width, same
+-- storage params the obix maintainer applies) so no copied row lands in
+-- DEFAULT.
+DO $$
+DECLARE
+  max_k BIGINT;
+  k BIGINT;
+BEGIN
+  SELECT COALESCE(MAX(sequence), 0) / 2000000 INTO max_k
+  FROM cala_persistent_outbox_events_old;
+  FOR k IN 0..max_k LOOP
+    EXECUTE format(
+      'CREATE TABLE cala_persistent_outbox_events_p%s PARTITION OF cala_persistent_outbox_events '
+      'FOR VALUES FROM (%s) TO (%s) WITH (autovacuum_vacuum_insert_scale_factor = 0.0, '
+      'autovacuum_vacuum_insert_threshold = 50000, autovacuum_freeze_min_age = 0, fillfactor = 100)',
+      k, k * 2000000, (k + 1) * 2000000);
+  END LOOP;
+END $$;
+
+CREATE TABLE cala_persistent_outbox_events_default
+  PARTITION OF cala_persistent_outbox_events DEFAULT;
+
+-- Explicit column list: sequence is copied (no nextval), preserving every
+-- row's position; seen_at is dropped.
+INSERT INTO cala_persistent_outbox_events (id, sequence, payload, tracing_context, recorded_at)
+  SELECT id, sequence, payload, tracing_context, recorded_at
+  FROM cala_persistent_outbox_events_old;
+
+DROP TABLE cala_persistent_outbox_events_old;


### PR DESCRIPTION
## What

Bumps **obix 0.5.0 → 0.6.0** ([release](https://github.com/GaloyMoney/obix/releases/tag/0.6.0), upstream [GaloyMoney/obix#106](https://github.com/GaloyMoney/obix/pull/106)) and adopts its Stage 1 partitioning for `cala_persistent_outbox_events` via a **new** migration — the existing `20251204130226_cala_obix_setup.sql` is left untouched so applied-migration checksums stay valid.

## Migration behaviour

`20260804211500_cala_partition_persistent_outbox_events.sql` rewrites the table in place:

- all rows are copied across **with their `sequence` preserved**, and the sequence object is re-owned by the new table — consumer sequence cursors (relay jobs) stay valid;
- explicit 2M-wide partitions are pre-created to cover the existing sequence range (tiling onto `_p0`, matching obix's `DEFAULT_PARTITION_WIDTH` and storage params), so **no copied row lands in DEFAULT**;
- the always-present `DEFAULT` backstop partition is created, so inserts can never fail to route even if the maintainer is absent;
- the unused `seen_at` column is dropped (removed in obix 0.6.0); `id` is demoted to a plain column and `sequence` becomes the PK (required: partition key).

⚠️ The copy holds `ACCESS EXCLUSIVE` for its duration — outbox writes **block** (do not fail) while the migration runs. Duration scales with table size.

Verified locally against PG 17.8 on both the fresh-install and upgrade-with-data paths (rows preserved and correctly routed, DEFAULT empty, sequence continuity).

## Consumer follow-up

The partition maintainer is registered by the consuming application (lana PR follows): `outbox.register_partition_maintainer(...)`. Without it everything stays correct — rows just accumulate in DEFAULT and forfeit the per-partition vacuum/locality wins.