### PR TITLE
feat(balance): entry-sourced EC balance verify/repair tool (PR 5)

### DIFF
--- a/cala-ledger/.sqlx/query-186980c34d237000a9f94f822fd68ee79e6b891843678dd7a93d1aab87f00b42.json
+++ b/cala-ledger/.sqlx/query-186980c34d237000a9f94f822fd68ee79e6b891843678dd7a93d1aab87f00b42.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT execution_state_json\n        FROM job_executions\n        WHERE job_type = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "execution_state_json",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "186980c34d237000a9f94f822fd68ee79e6b891843678dd7a93d1aab87f00b42"
+}

--- a/cala-ledger/.sqlx/query-20f3a51b4e92e80fe18b5e82fb1892b8f7520c87de4f2fdfa1613c00994b9e70.json
+++ b/cala-ledger/.sqlx/query-20f3a51b4e92e80fe18b5e82fb1892b8f7520c87de4f2fdfa1613c00994b9e70.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH RECURSIVE subtree AS (\n            SELECT v.target_id AS target_id, v.target_id AS set_id\n            FROM UNNEST($1::uuid[]) AS v(target_id)\n            UNION\n            SELECT s.target_id, e.member_account_set_id\n            FROM subtree s\n            JOIN cala_account_set_member_account_sets e\n                ON e.account_set_id = s.set_id\n        )\n        SELECT\n            s.target_id AS \"target_id!: AccountId\",\n            m.member_account_id AS \"leaf_id!: AccountId\"\n        FROM subtree s\n        JOIN cala_account_set_member_accounts m\n            ON m.account_set_id = s.set_id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "target_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "leaf_id!: AccountId",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null,
+      false
+    ]
+  },
+  "hash": "20f3a51b4e92e80fe18b5e82fb1892b8f7520c87de4f2fdfa1613c00994b9e70"
+}

--- a/cala-ledger/.sqlx/query-36fc66194303c79751bbc0b24f30ae4f05c7a7870be69b7c1d800ec54690b316.json
+++ b/cala-ledger/.sqlx/query-36fc66194303c79751bbc0b24f30ae4f05c7a7870be69b7c1d800ec54690b316.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            c.account_id AS \"account_id!: AccountId\",\n            c.currency,\n            c.latest_values\n        FROM cala_current_balances c\n        WHERE c.journal_id = $1\n          AND c.account_id = ANY($2)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "latest_values",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "36fc66194303c79751bbc0b24f30ae4f05c7a7870be69b7c1d800ec54690b316"
+}

--- a/cala-ledger/.sqlx/query-4a0128d8f973225f1df2fa7cd478e4da10bf4287242c026e49088810ff6cb9af.json
+++ b/cala-ledger/.sqlx/query-4a0128d8f973225f1df2fa7cd478e4da10bf4287242c026e49088810ff6cb9af.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            h.account_id AS \"account_id!: AccountId\",\n            h.currency,\n            MAX(h.version) AS \"max_version!\"\n        FROM cala_balance_history h\n        WHERE h.journal_id = $1\n          AND h.account_id = ANY($2)\n        GROUP BY h.account_id, h.currency\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "max_version!",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "4a0128d8f973225f1df2fa7cd478e4da10bf4287242c026e49088810ff6cb9af"
+}

--- a/cala-ledger/.sqlx/query-806e41dbc67fe7eaf8067adaa91a73d62dbb7fe649570ddf65ae812a6eb92cb7.json
+++ b/cala-ledger/.sqlx/query-806e41dbc67fe7eaf8067adaa91a73d62dbb7fe649570ddf65ae812a6eb92cb7.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT ON (b.account_id, b.currency)\n            b.account_id AS \"account_id!: AccountId\",\n            b.currency,\n            b.values\n        FROM cala_cumulative_effective_balances b\n        WHERE b.journal_id = $1\n          AND b.account_id = ANY($2)\n        ORDER BY b.account_id, b.currency, b.all_time_version DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "account_id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "currency",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "values",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "806e41dbc67fe7eaf8067adaa91a73d62dbb7fe649570ddf65ae812a6eb92cb7"
+}

--- a/cala-ledger/.sqlx/query-98a1935a3f66f57d4b0b7bf7a40cbcfcb3ce0077ff45536db7ad533a4e8fa9a0.json
+++ b/cala-ledger/.sqlx/query-98a1935a3f66f57d4b0b7bf7a40cbcfcb3ce0077ff45536db7ad533a4e8fa9a0.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            o.sequence AS \"tx_seq!\",\n            (ev.event->'values') AS \"entry_values!\",\n            ((ev.event#>>'{values,sequence}')::int4) AS \"entry_seq!\",\n            t.created_at AS \"tx_created_at!\",\n            t.effective AS \"effective!\"\n        FROM cala_persistent_outbox_events o\n        JOIN cala_entries e\n            ON e.transaction_id = ((o.payload->'transaction'->>'id')::uuid)\n        JOIN cala_entry_events ev\n            ON ev.id = e.id AND ev.event_type = 'initialized'\n        JOIN cala_transactions t\n            ON t.id = e.transaction_id\n        WHERE o.payload->>'type' = 'transaction_created'\n          AND o.sequence <= $1\n          AND e.journal_id = $2\n          AND e.account_id = ANY($3)\n          AND ($4::bigint IS NULL\n               OR (o.sequence, (ev.event#>>'{values,sequence}')::int4)\n                  > ($4::bigint, $5::int4))\n        ORDER BY o.sequence, (ev.event#>>'{values,sequence}')::int4\n        LIMIT $6\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "tx_seq!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "entry_values!",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "entry_seq!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "tx_created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "effective!",
+        "type_info": "Date"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "UuidArray",
+        "Int8",
+        "Int4",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      null,
+      false,
+      false
+    ]
+  },
+  "hash": "98a1935a3f66f57d4b0b7bf7a40cbcfcb3ce0077ff45536db7ad533a4e8fa9a0"
+}

--- a/cala-ledger/.sqlx/query-cd9589dedcee5829f715bbaa417b5c16730cebb5e48ab0008821f56ee7b184d6.json
+++ b/cala-ledger/.sqlx/query-cd9589dedcee5829f715bbaa417b5c16730cebb5e48ab0008821f56ee7b184d6.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT pg_advisory_xact_lock($1::int4, hashtext(v.account_id::text))\n        FROM UNNEST($2::uuid[]) AS v(account_id)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pg_advisory_xact_lock",
+        "type_info": "Void"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "cd9589dedcee5829f715bbaa417b5c16730cebb5e48ab0008821f56ee7b184d6"
+}

--- a/cala-ledger/.sqlx/query-d71990b7148c62a323e8a6c07df6771488f0ecda0c8ea3de16ca7142ed70d390.json
+++ b/cala-ledger/.sqlx/query-d71990b7148c62a323e8a6c07df6771488f0ecda0c8ea3de16ca7142ed70d390.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM cala_cumulative_effective_balances\n            WHERE journal_id = $1\n              AND (account_id, currency) IN (\n                SELECT account_id, currency\n                FROM UNNEST($2::uuid[], $3::text[]) AS v(account_id, currency)\n              )\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "UuidArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d71990b7148c62a323e8a6c07df6771488f0ecda0c8ea3de16ca7142ed70d390"
+}

--- a/cala-ledger/.sqlx/query-d8677b857e8de4dbdf7b3e6c50250307313d1bff574a5cf9f5dea5a8921fc9f6.json
+++ b/cala-ledger/.sqlx/query-d8677b857e8de4dbdf7b3e6c50250307313d1bff574a5cf9f5dea5a8921fc9f6.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            a.id AS \"id!: AccountId\",\n            a.eventually_consistent,\n            a.is_account_set\n        FROM cala_accounts a\n        WHERE a.id = ANY($1)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: AccountId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "eventually_consistent",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "is_account_set",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d8677b857e8de4dbdf7b3e6c50250307313d1bff574a5cf9f5dea5a8921fc9f6"
+}

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -6,7 +6,7 @@ use sqlx::PgPool;
 use std::collections::{HashMap, HashSet};
 use tracing::instrument;
 
-use cala_types::{entry::EntryValues, primitives::*};
+use cala_types::{balance::EffectiveBalanceSnapshot, entry::EntryValues, primitives::*};
 
 use crate::{outbox::OutboxPublisher, primitives::JournalId};
 
@@ -275,6 +275,36 @@ impl EffectiveBalances {
             .insert_new_snapshots(op, journal_id, new_balances)
             .await?;
 
+        Ok(())
+    }
+
+    /// Repair path used by the EC reconciler (`Balances::repair_ec`):
+    /// drop every cumulative-effective row of the drifted
+    /// `(account, currency)` pairs and reinsert the rebuilt series. The
+    /// cumulative table is a projection (the inline back-dating path
+    /// already deletes future-dated rows), so a wholesale rebuild is
+    /// legitimate; reinserted rows publish through the normal
+    /// `insert_new_snapshots` outbox path.
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balance.effective.rebuild_ec_series_in_op",
+        skip_all,
+        fields(pairs = pairs.len(), snapshots = snapshots.len()),
+        err(level = "warn")
+    )]
+    pub(crate) async fn rebuild_ec_series_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        journal_id: JournalId,
+        pairs: &[(AccountId, Currency)],
+        snapshots: Vec<EffectiveBalanceSnapshot>,
+    ) -> Result<(), BalanceError> {
+        self.repo.delete_for_pairs(op, journal_id, pairs).await?;
+        if !snapshots.is_empty() {
+            self.repo
+                .insert_new_snapshots(op, journal_id, snapshots)
+                .await?;
+        }
         Ok(())
     }
 }

--- a/cala-ledger/src/balance/effective/repo.rs
+++ b/cala-ledger/src/balance/effective/repo.rs
@@ -1034,6 +1034,46 @@ impl EffectiveBalanceRepo {
         Ok(ret)
     }
 
+    /// Delete every cumulative-effective row of the given
+    /// `(account, currency)` pairs — the destructive half of the EC
+    /// reconciler's series rebuild. Callers hold the exclusive EC-class
+    /// advisory locks on the accounts, so no applier write can interleave.
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.balances.effective.delete_for_pairs",
+        skip(self, op, pairs),
+        fields(pairs = pairs.len())
+    )]
+    pub(super) async fn delete_for_pairs(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        journal_id: JournalId,
+        pairs: &[(AccountId, Currency)],
+    ) -> Result<(), BalanceError> {
+        let mut account_ids = Vec::with_capacity(pairs.len());
+        let mut currencies = Vec::with_capacity(pairs.len());
+        for (account_id, currency) in pairs {
+            account_ids.push(*account_id);
+            currencies.push(currency.code());
+        }
+        sqlx::query!(
+            r#"
+            DELETE FROM cala_cumulative_effective_balances
+            WHERE journal_id = $1
+              AND (account_id, currency) IN (
+                SELECT account_id, currency
+                FROM UNNEST($2::uuid[], $3::text[]) AS v(account_id, currency)
+              )
+            "#,
+            journal_id as JournalId,
+            &account_ids as &[AccountId],
+            &currencies as &[&str],
+        )
+        .execute(op.as_executor())
+        .await?;
+        Ok(())
+    }
+
     #[instrument(
         level = "debug",
         name = "cala_ledger.balances.effective.insert_new_snapshots",

--- a/cala-ledger/src/balance/error.rs
+++ b/cala-ledger/src/balance/error.rs
@@ -14,4 +14,8 @@ pub enum BalanceError {
     JournalLocked(JournalId),
     #[error("BalanceError - AccountLocked: Cannot update balances. The account {0} is locked")]
     AccountLocked(AccountId),
+    #[error(
+        "BalanceError - NotEventuallyConsistent: account {0} is not an eventually-consistent account"
+    )]
+    NotEventuallyConsistent(AccountId),
 }

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -33,6 +33,7 @@ mod account_balance;
 mod cursor;
 mod effective;
 pub mod error;
+mod reconcile;
 mod repo;
 mod snapshot;
 
@@ -53,6 +54,7 @@ pub use account_balance::*;
 pub use cursor::*;
 use effective::*;
 use error::BalanceError;
+pub use reconcile::{EcDriftReport, LayerDrift};
 use repo::*;
 pub(crate) use snapshot::*;
 
@@ -70,7 +72,7 @@ pub struct Balances {
     repo: BalanceRepo,
     journals: Journals,
     effective: EffectiveBalances,
-    _pool: PgPool,
+    pool: PgPool,
 }
 
 impl Balances {
@@ -79,7 +81,7 @@ impl Balances {
             repo: BalanceRepo::new(pool),
             effective: EffectiveBalances::new(pool, publisher),
             journals: journals.clone(),
-            _pool: pool.clone(),
+            pool: pool.clone(),
         }
     }
 

--- a/cala-ledger/src/balance/reconcile/mod.rs
+++ b/cala-ledger/src/balance/reconcile/mod.rs
@@ -1,0 +1,580 @@
+//! # Entry-sourced verify/repair for eventually-consistent balances
+//!
+//! The streaming rollup ([`crate::ec_rollup`]) is delta-based and not
+//! idempotent: it folds each committed transaction's deltas exactly once,
+//! advancing its checkpoint atomically with every write. If an EC balance
+//! ever drifts (applier bug, operator error, partial restore), nothing in
+//! the steady-state machinery can recompute it. This module provides the
+//! deterministic, bounded reconciliation path: [`Balances::verify_ec`]
+//! computes the *expected* EC balances from the ledger's entries and
+//! reports drift; [`Balances::repair_ec`] additionally appends corrective
+//! snapshots (history stays append-only) and rebuilds the
+//! cumulative-effective series for drifted pairs.
+//!
+//! ## The consistency anchor
+//!
+//! A naive "Σ entries as of now" rebuild double-counts: entries the
+//! applier has not yet folded would be included in the rebuilt balance
+//! *and* folded again later. And outbox sequence order is not commit
+//! order, so "all committed entries right now" corresponds to no stream
+//! position. The one clean consistency point is the rollup job's
+//! committed cursor `C`: obix delivery is gapless, so every transaction
+//! event with `seq ≤ C` is committed *and* already folded, and everything
+//! above `C` will be folded later, exactly once. The expected state is
+//! therefore the fold of entries belonging to transactions whose
+//! `TransactionCreated` outbox event has `seq ≤ C` — computed while `C`
+//! cannot move for the targets.
+//!
+//! Freezing `C` per target is free: the applier's flush takes SHARED
+//! EC-class advisory locks on every account it writes
+//! (`find_ec_balances_for_update`) in the same transaction that advances
+//! the checkpoint. The reconciler takes the EXCLUSIVE counterpart on its
+//! targets, so an in-flight applier batch touching them blocks *before*
+//! writing or advancing `C`; its batch covers `(C, C']`, disjoint from the
+//! reconciler's `≤ C` fold, and applies on top of the corrected state
+//! after the reconciler commits.
+//!
+//! ## Why current membership is historical routing
+//!
+//! The fold routes each leaf entry to its EC ancestor sets using the
+//! *current* membership graph (the downward inverse of the applier's
+//! upward walk). That is sound because the membership guard
+//! (`member_has_balance_history_in_op`) freezes every node on an applied
+//! entry's ancestor path: the leaf has entries, and every ancestor set —
+//! synchronous (inline history) or EC (history materialized at apply
+//! time) — has balance history, so no edge on the path can be attached or
+//! cut. The only members that can still move are those with zero applied
+//! activity, which contribute nothing to the fold either way.
+//!
+//! ## Ground truth and retention
+//!
+//! Ground truth is `cala_entries` + each entry's `initialized` event —
+//! never member balance history. The `tx event seq ≤ C` mapping is read
+//! from the persistent outbox, which obix range-partitions but never
+//! prunes; if outbox pruning/archival ever lands, this scan needs an
+//! alternative "entries as of `C`" source.
+
+mod repo;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use tracing::instrument;
+
+use std::collections::{BTreeMap, HashMap};
+
+use cala_types::{
+    balance::{BalanceAmount, BalanceSnapshot, EffectiveBalanceSnapshot},
+    entry::EntryValues,
+    primitives::{AccountId, Currency, EntryId, JournalId},
+};
+
+use crate::{ec_rollup::EC_BALANCE_ROLLUP_JOB_NAME, journal::Journal};
+
+use super::{
+    error::BalanceError,
+    snapshot::{Snapshots, UNASSIGNED_ENTRY_ID},
+    Balances,
+};
+
+/// Targets reconciled per atomic operation: bounds the advisory locks
+/// held, the fold's working set and the size of any repair commit.
+const TARGETS_PER_RECONCILE_OP: usize = 100;
+
+/// Rows per keyset-paginated contributing-entry scan — bounds the
+/// reconciler's memory per round trip (the running fold itself holds one
+/// snapshot per involved `(account, currency)` pair, never a history).
+const ENTRY_SCAN_CHUNK: i64 = 10_000;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReconcileMode {
+    Verify,
+    Repair,
+}
+
+/// Drift of one balance layer/direction pair: `expected − found`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LayerDrift {
+    pub dr_delta: Decimal,
+    pub cr_delta: Decimal,
+}
+
+impl LayerDrift {
+    fn between(expected: Option<&BalanceAmount>, found: Option<&BalanceAmount>) -> Self {
+        let zero = Decimal::ZERO;
+        Self {
+            dr_delta: expected.map(|a| a.dr_balance).unwrap_or(zero)
+                - found.map(|a| a.dr_balance).unwrap_or(zero),
+            cr_delta: expected.map(|a| a.cr_balance).unwrap_or(zero)
+                - found.map(|a| a.cr_balance).unwrap_or(zero),
+        }
+    }
+
+    pub fn is_zero(&self) -> bool {
+        self.dr_delta == Decimal::ZERO && self.cr_delta == Decimal::ZERO
+    }
+}
+
+/// Verification result for one `(account, currency)` pair. Any nonzero
+/// drift is evidence of an applier bug (or external interference) — the
+/// report is the evidence; keep it.
+#[derive(Debug, Clone)]
+pub struct EcDriftReport {
+    pub journal_id: JournalId,
+    pub account_id: AccountId,
+    pub currency: Currency,
+    /// `expected − found` per layer.
+    pub settled: LayerDrift,
+    pub pending: LayerDrift,
+    pub encumbrance: LayerDrift,
+    /// Version the fold reproduces (one bump per folded entry) — what a
+    /// single correct applier run would have left behind. Evidence, not a
+    /// drift trigger: a previously repaired pair legitimately carries a
+    /// higher found version (the appended corrective snapshot).
+    pub expected_version: u32,
+    /// The current snapshot's version; `None` when no row exists.
+    pub found_version: Option<u32>,
+    /// The latest cumulative-effective snapshot's totals disagree with
+    /// the expected fold (only checked when the journal maintains
+    /// effective balances).
+    pub effective_drift: bool,
+    /// Set by [`Balances::repair_ec`] when a corrective write was issued
+    /// for this pair.
+    pub repaired: bool,
+}
+
+impl EcDriftReport {
+    /// Drift in the balance values themselves (any layer/direction).
+    /// Versions are deliberately not compared: they are chain
+    /// bookkeeping, and a corrective append leaves the found version
+    /// above the fold's count by design.
+    pub fn balance_drift(&self) -> bool {
+        !self.settled.is_zero() || !self.pending.is_zero() || !self.encumbrance.is_zero()
+    }
+
+    pub fn is_drifted(&self) -> bool {
+        self.balance_drift() || self.effective_drift
+    }
+}
+
+impl Balances {
+    /// Verify the eventually-consistent balances of `account_ids`
+    /// (EC set-backing accounts and/or EC plain accounts) against the
+    /// expected fold of their contributing entries as of the streaming
+    /// rollup's committed cursor. Read-only; returns one report per
+    /// involved `(account, currency)` pair.
+    ///
+    /// Takes the same exclusive locks as [`repair_ec`](Self::repair_ec)
+    /// so the report is race-free against the applier — cheap, and this
+    /// is a rare operational tool.
+    #[instrument(
+        name = "cala_ledger.balance.verify_ec",
+        skip(self, account_ids),
+        fields(journal_id = %journal_id, targets = account_ids.len()),
+        err(level = "warn")
+    )]
+    pub async fn verify_ec(
+        &self,
+        journal_id: JournalId,
+        account_ids: &[AccountId],
+    ) -> Result<Vec<EcDriftReport>, BalanceError> {
+        self.reconcile_ec(journal_id, account_ids, ReconcileMode::Verify)
+            .await
+    }
+
+    /// [`verify_ec`](Self::verify_ec) plus repair: for every drifted
+    /// pair, append a corrective `BalanceSnapshot` (history stays
+    /// append-only — no rows are rewritten or deleted) and, when the
+    /// journal maintains effective balances, delete-and-reinsert the
+    /// cumulative-effective series (a projection, not the audit log).
+    ///
+    /// Idempotent at the state level: once repaired, a second run finds
+    /// zero drift and writes nothing. Each chunk of targets commits
+    /// independently, so a run that fails midway leaves earlier chunks
+    /// repaired and is safe to re-run.
+    #[instrument(
+        name = "cala_ledger.balance.repair_ec",
+        skip(self, account_ids),
+        fields(journal_id = %journal_id, targets = account_ids.len()),
+        err(level = "warn")
+    )]
+    pub async fn repair_ec(
+        &self,
+        journal_id: JournalId,
+        account_ids: &[AccountId],
+    ) -> Result<Vec<EcDriftReport>, BalanceError> {
+        self.reconcile_ec(journal_id, account_ids, ReconcileMode::Repair)
+            .await
+    }
+
+    async fn reconcile_ec(
+        &self,
+        journal_id: JournalId,
+        account_ids: &[AccountId],
+        mode: ReconcileMode,
+    ) -> Result<Vec<EcDriftReport>, BalanceError> {
+        let journal = self.journals.find(journal_id).await?;
+        if mode == ReconcileMode::Repair && journal.is_locked() {
+            return Err(BalanceError::JournalLocked(journal.id));
+        }
+
+        let mut targets: Vec<AccountId> = account_ids.to_vec();
+        targets.sort();
+        targets.dedup();
+
+        let mut reports = Vec::new();
+        for chunk in targets.chunks(TARGETS_PER_RECONCILE_OP) {
+            reports.extend(self.reconcile_chunk(&journal, chunk, mode).await?);
+        }
+        Ok(reports)
+    }
+
+    /// Reconcile one bounded chunk of targets in its own atomic
+    /// operation: lock → read cursor → fold → compare → (repair) →
+    /// commit.
+    async fn reconcile_chunk(
+        &self,
+        journal: &Journal,
+        targets: &[AccountId],
+        mode: ReconcileMode,
+    ) -> Result<Vec<EcDriftReport>, BalanceError> {
+        let journal_id = journal.id;
+        let mut op = es_entity::DbOp::init(&self.pool).await?;
+
+        // 1. Exclusive locks on the (sorted, deduped) targets — the
+        //    serialization point against the streaming applier.
+        repo::lock_targets_exclusive(&mut op, targets).await?;
+
+        // 2. Only *after* the locks: the cursor is now frozen for any
+        //    applier batch touching the targets.
+        let set_targets = repo::load_set_backed_targets(&mut op, targets).await?;
+        let cursor = repo::ec_rollup_cursor(&mut op, EC_BALANCE_ROLLUP_JOB_NAME).await?;
+
+        // 3. Routing map: leaf account → the targets its entries fold
+        //    into. Set-backed targets expand downward through the
+        //    membership graph; EC plain-account targets route to
+        //    themselves.
+        let mut routing: HashMap<AccountId, Vec<AccountId>> = HashMap::new();
+        for (target, leaf) in repo::expand_set_targets(&mut op, &set_targets).await? {
+            let routes = routing.entry(leaf).or_default();
+            if !routes.contains(&target) {
+                routes.push(target);
+            }
+        }
+        for target in targets {
+            if !set_targets.contains(target) {
+                let routes = routing.entry(*target).or_default();
+                if !routes.contains(target) {
+                    routes.push(*target);
+                }
+            }
+        }
+        let leaf_ids: Vec<AccountId> = routing.keys().copied().collect();
+
+        // 4. Streaming fold of the contributing entries ≤ cursor, in
+        //    applier order (tx event seq, then entry sequence), chunk by
+        //    chunk — the running state is one snapshot per involved
+        //    pair, never a materialized history.
+        let mut expected: HashMap<(AccountId, Currency), BalanceSnapshot> = HashMap::new();
+        let mut effective_series = (mode == ReconcileMode::Repair
+            && journal.insert_effective_balances())
+        .then(EffectiveSeriesBuilder::default);
+
+        if cursor > 0 && !leaf_ids.is_empty() {
+            let mut after: Option<(i64, i32)> = None;
+            loop {
+                let batch = repo::contributing_entries_chunk(
+                    &mut op,
+                    journal_id,
+                    cursor,
+                    &leaf_ids,
+                    after,
+                    ENTRY_SCAN_CHUNK,
+                )
+                .await?;
+                let n = batch.len();
+                for row in batch {
+                    let entry: EntryValues = serde_json::from_value(row.entry_values)
+                        .expect("Failed to deserialize entry values");
+                    after = Some((row.tx_seq, row.entry_seq));
+                    let Some(routes) = routing.get(&entry.account_id) else {
+                        continue;
+                    };
+                    for target in routes {
+                        let key = (*target, entry.currency);
+                        let next = match expected.remove(&key) {
+                            Some(prev) => {
+                                Snapshots::update_snapshot(row.tx_created_at, prev, &entry)
+                            }
+                            None => Snapshots::new_snapshot(row.tx_created_at, *target, &entry),
+                        };
+                        expected.insert(key, next);
+                        if let Some(series) = effective_series.as_mut() {
+                            series.apply(*target, row.effective, row.tx_created_at, &entry);
+                        }
+                    }
+                }
+                if n < ENTRY_SCAN_CHUNK as usize {
+                    break;
+                }
+            }
+        }
+
+        // 5. Found state (still under the locks).
+        let current = repo::current_balances(&mut op, journal_id, targets).await?;
+        let history_max = repo::max_history_versions(&mut op, journal_id, targets).await?;
+        let effective_current = if journal.insert_effective_balances() {
+            repo::latest_effective_balances(&mut op, journal_id, targets).await?
+        } else {
+            HashMap::new()
+        };
+
+        // 6. Compare per pair; collect repairs.
+        let mut pairs: Vec<(AccountId, Currency)> = expected
+            .keys()
+            .chain(current.keys())
+            .chain(effective_current.keys())
+            .copied()
+            .collect();
+        pairs.sort_by(|a, b| (a.0, a.1.code()).cmp(&(b.0, b.1.code())));
+        pairs.dedup();
+
+        let mut reports = Vec::with_capacity(pairs.len());
+        let mut correctives: Vec<BalanceSnapshot> = Vec::new();
+        let mut effective_rebuild: Vec<(AccountId, Currency)> = Vec::new();
+
+        for pair in pairs {
+            let exp = expected.get(&pair);
+            let cur = current.get(&pair);
+            let effective_drift = journal.insert_effective_balances()
+                && match (exp, effective_current.get(&pair)) {
+                    (None, None) => false,
+                    (Some(e), Some(c)) => !amounts_equal(e, c),
+                    (Some(_), None) | (None, Some(_)) => true,
+                };
+
+            let mut report = EcDriftReport {
+                journal_id,
+                account_id: pair.0,
+                currency: pair.1,
+                settled: LayerDrift::between(exp.map(|s| &s.settled), cur.map(|s| &s.settled)),
+                pending: LayerDrift::between(exp.map(|s| &s.pending), cur.map(|s| &s.pending)),
+                encumbrance: LayerDrift::between(
+                    exp.map(|s| &s.encumbrance),
+                    cur.map(|s| &s.encumbrance),
+                ),
+                expected_version: exp.map(|s| s.version).unwrap_or(0),
+                found_version: cur.map(|s| s.version),
+                effective_drift,
+                repaired: false,
+            };
+
+            if mode == ReconcileMode::Repair {
+                if report.balance_drift() {
+                    correctives.push(corrective_snapshot(
+                        journal_id,
+                        pair,
+                        exp,
+                        report.found_version,
+                        history_max.get(&pair).copied().unwrap_or(0),
+                    ));
+                    report.repaired = true;
+                }
+                if report.effective_drift {
+                    effective_rebuild.push(pair);
+                    report.repaired = true;
+                }
+            }
+            if report.is_drifted() {
+                tracing::warn!(
+                    report = ?report,
+                    "eventually-consistent balance drift detected"
+                );
+            }
+            reports.push(report);
+        }
+
+        // 7. Repair writes: corrective snapshots append through the
+        //    normal insert path; the effective series is rebuilt
+        //    wholesale for drifted pairs (one row per effective date).
+        if !correctives.is_empty() {
+            self.repo
+                .insert_new_snapshots(&mut op, journal_id, correctives)
+                .await?;
+        }
+        if !effective_rebuild.is_empty() {
+            let series = effective_series
+                .as_ref()
+                .expect("effective series is built in repair mode");
+            let mut snapshots = Vec::new();
+            for pair in &effective_rebuild {
+                snapshots.extend(series.series_for(*pair, journal_id));
+            }
+            self.effective
+                .rebuild_ec_series_in_op(&mut op, journal_id, &effective_rebuild, snapshots)
+                .await?;
+        }
+
+        op.commit().await?;
+        Ok(reports)
+    }
+}
+
+fn amounts_equal(a: &BalanceSnapshot, b: &BalanceSnapshot) -> bool {
+    a.settled.dr_balance == b.settled.dr_balance
+        && a.settled.cr_balance == b.settled.cr_balance
+        && a.pending.dr_balance == b.pending.dr_balance
+        && a.pending.cr_balance == b.pending.cr_balance
+        && a.encumbrance.dr_balance == b.encumbrance.dr_balance
+        && a.encumbrance.cr_balance == b.encumbrance.cr_balance
+}
+
+/// The snapshot appended to correct a drifted pair.
+///
+/// Values are the expected fold's; the version clears both the found
+/// `latest_version` and the highest history row (the history version
+/// column is unique per balance). A pair whose chain is entirely absent
+/// keeps the fold's own version — the single appended row carries the
+/// applier-identical end state (intermediate versions are not
+/// re-materialized). A phantom pair (no expected entries but a balance
+/// row exists) is zeroed out one version above everything found.
+fn corrective_snapshot(
+    journal_id: JournalId,
+    (account_id, currency): (AccountId, Currency),
+    expected: Option<&BalanceSnapshot>,
+    found_version: Option<u32>,
+    max_history_version: u32,
+) -> BalanceSnapshot {
+    let floor = found_version.unwrap_or(0).max(max_history_version);
+    match expected {
+        Some(snapshot) => {
+            let mut corrective = snapshot.clone();
+            if floor > 0 {
+                corrective.version = floor.max(corrective.version) + 1;
+            }
+            corrective
+        }
+        None => {
+            let mut corrective = zero_snapshot(journal_id, account_id, currency, Utc::now());
+            corrective.version = floor + 1;
+            corrective
+        }
+    }
+}
+
+fn zero_snapshot(
+    journal_id: JournalId,
+    account_id: AccountId,
+    currency: Currency,
+    time: DateTime<Utc>,
+) -> BalanceSnapshot {
+    let entry_id = EntryId::from(UNASSIGNED_ENTRY_ID);
+    let zero_amount = BalanceAmount {
+        dr_balance: Decimal::ZERO,
+        cr_balance: Decimal::ZERO,
+        entry_id,
+        modified_at: time,
+    };
+    BalanceSnapshot {
+        journal_id,
+        account_id,
+        currency,
+        entry_id,
+        settled: zero_amount.clone(),
+        pending: zero_amount.clone(),
+        encumbrance: zero_amount,
+        version: 0,
+        modified_at: time,
+        created_at: time,
+    }
+}
+
+/// Accumulates per-day *delta* folds during the entry scan and produces
+/// the rebuilt cumulative-effective series: one row per effective date,
+/// `version` = entries folded that day, `all_time_version` = entries
+/// folded up to and including that day. Memory is bounded by
+/// `pairs × distinct effective dates` — never per-entry.
+///
+/// Intra-day per-entry rows are deliberately not reproduced: the
+/// applier's incremental history depends on arrival-order interleaving
+/// (back-dated rewrites bump `all_time_version` per rewritten row),
+/// which is not reconstructible from the ledger. The rebuilt series
+/// preserves every read-path semantic (`effective ≤ date` lookups and
+/// `all_time_version` diffs as entry counts in range).
+#[derive(Default)]
+struct EffectiveSeriesBuilder {
+    days: HashMap<(AccountId, Currency), BTreeMap<NaiveDate, BalanceSnapshot>>,
+}
+
+impl EffectiveSeriesBuilder {
+    fn apply(
+        &mut self,
+        target: AccountId,
+        effective: NaiveDate,
+        time: DateTime<Utc>,
+        entry: &EntryValues,
+    ) {
+        let days = self.days.entry((target, entry.currency)).or_default();
+        let next = match days.remove(&effective) {
+            Some(prev) => Snapshots::update_snapshot(time, prev, entry),
+            None => Snapshots::new_snapshot(time, target, entry),
+        };
+        days.insert(effective, next);
+    }
+
+    fn series_for(
+        &self,
+        pair: (AccountId, Currency),
+        journal_id: JournalId,
+    ) -> Vec<EffectiveBalanceSnapshot> {
+        let Some(days) = self.days.get(&pair) else {
+            return Vec::new();
+        };
+        let mut out = Vec::with_capacity(days.len());
+        let mut cumulative: Option<BalanceSnapshot> = None;
+        let mut all_time_version = 0u32;
+        for (date, delta) in days {
+            let snapshot = match &cumulative {
+                None => delta.clone(),
+                Some(prev) => merge_day(prev, delta),
+            };
+            all_time_version += delta.version;
+            out.push(EffectiveBalanceSnapshot {
+                journal_id,
+                account_id: pair.0,
+                currency: pair.1,
+                effective: *date,
+                version: delta.version,
+                all_time_version,
+                created_at: snapshot.created_at,
+                modified_at: snapshot.modified_at,
+                entry_id: snapshot.entry_id,
+                settled: snapshot.settled.clone(),
+                pending: snapshot.pending.clone(),
+                encumbrance: snapshot.encumbrance.clone(),
+            });
+            cumulative = Some(snapshot);
+        }
+        out
+    }
+}
+
+/// Merge one day's delta fold onto the previous cumulative snapshot:
+/// touched layers add their deltas (keeping the day's last entry id);
+/// untouched layers carry the previous cumulative amount forward.
+fn merge_day(prev: &BalanceSnapshot, delta: &BalanceSnapshot) -> BalanceSnapshot {
+    let mut snapshot = delta.clone();
+    snapshot.created_at = prev.created_at;
+    merge_amount(&mut snapshot.settled, &prev.settled);
+    merge_amount(&mut snapshot.pending, &prev.pending);
+    merge_amount(&mut snapshot.encumbrance, &prev.encumbrance);
+    snapshot
+}
+
+fn merge_amount(day: &mut BalanceAmount, prev: &BalanceAmount) {
+    if day.entry_id == EntryId::from(UNASSIGNED_ENTRY_ID) {
+        *day = prev.clone();
+    } else {
+        day.dr_balance += prev.dr_balance;
+        day.cr_balance += prev.cr_balance;
+    }
+}

--- a/cala-ledger/src/balance/reconcile/repo.rs
+++ b/cala-ledger/src/balance/reconcile/repo.rs
@@ -1,0 +1,361 @@
+//! SQL for the entry-sourced EC verify/repair tool.
+//!
+//! Kept in its own module (not `balance::repo`) so the reconcile surface
+//! stays additive and conflict-free next to ongoing poster-lock work; the
+//! only shared item is the `EC_SET_LOCK_CLASS` advisory-lock class.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, NaiveDate, Utc};
+
+use cala_types::{
+    balance::BalanceSnapshot,
+    primitives::{AccountId, Currency, JournalId},
+};
+
+use super::super::{error::BalanceError, repo::EC_SET_LOCK_CLASS};
+
+/// One leaf entry that a correct streaming applier folded (or would have
+/// folded) at or before the anchoring cursor, in applier order.
+pub(super) struct ContributingEntry {
+    /// Outbox sequence of the transaction's `TransactionCreated` event —
+    /// the applier's ordering and the cursor-anchoring key.
+    pub tx_seq: i64,
+    /// The entry's per-transaction sequence (applier sort key within a
+    /// transaction).
+    pub entry_seq: i32,
+    /// The raw `EntryValues` JSON from the entry's `initialized` event.
+    pub entry_values: serde_json::Value,
+    /// The posting transaction's `created_at` — the `time` the applier
+    /// stamps into every snapshot it folds for this transaction.
+    pub tx_created_at: DateTime<Utc>,
+    /// The posting transaction's effective date (cumulative-effective
+    /// series bucket).
+    pub effective: NaiveDate,
+}
+
+/// Take **exclusive** advisory locks (EC-set lock class) on `account_ids`.
+///
+/// This is the reconciler's serialization point against the streaming
+/// applier, whose flush takes the SHARED counterpart on every EC account it
+/// writes (`find_ec_balances_for_update`) *in the same transaction that
+/// advances its checkpoint*. Any in-flight applier batch touching a target
+/// therefore blocks here before writing balances *or* advancing the cursor.
+///
+/// `account_ids` MUST be pre-sorted ascending (and deduped) by the caller:
+/// the statement is join-free, so the bare UNNEST scan emits rows in array
+/// order and array order IS the lock acquisition order — the same canonical
+/// ordering discipline as every other EC-set-class locker.
+pub(super) async fn lock_targets_exclusive(
+    op: &mut impl es_entity::AtomicOperation,
+    account_ids: &[AccountId],
+) -> Result<(), BalanceError> {
+    sqlx::query!(
+        r#"
+        SELECT pg_advisory_xact_lock($1::int4, hashtext(v.account_id::text))
+        FROM UNNEST($2::uuid[]) AS v(account_id)
+        "#,
+        EC_SET_LOCK_CLASS,
+        account_ids as &[AccountId],
+    )
+    .execute(op.as_executor())
+    .await?;
+    Ok(())
+}
+
+/// Load the target accounts and validate every one is eventually
+/// consistent. Returns the subset of `account_ids` that back an account
+/// set (the ones needing downward membership expansion).
+pub(super) async fn load_set_backed_targets(
+    op: &mut impl es_entity::AtomicOperation,
+    account_ids: &[AccountId],
+) -> Result<Vec<AccountId>, BalanceError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            a.id AS "id!: AccountId",
+            a.eventually_consistent,
+            a.is_account_set
+        FROM cala_accounts a
+        WHERE a.id = ANY($1)
+        "#,
+        account_ids as &[AccountId],
+    )
+    .fetch_all(op.as_executor())
+    .await?;
+
+    let mut found: HashMap<AccountId, (bool, bool)> = HashMap::new();
+    for row in rows {
+        found.insert(row.id, (row.eventually_consistent, row.is_account_set));
+    }
+    let mut set_targets = Vec::new();
+    for id in account_ids {
+        match found.get(id) {
+            Some((true, is_set)) => {
+                if *is_set {
+                    set_targets.push(*id);
+                }
+            }
+            _ => return Err(BalanceError::NotEventuallyConsistent(*id)),
+        }
+    }
+    Ok(set_targets)
+}
+
+/// Read the streaming rollup job's committed cursor from its persisted
+/// execution state (`spawn_unique` ⇒ at most one row per job type).
+///
+/// Returns `0` when the job has never run (no row / no checkpoint yet) —
+/// in that state *nothing* has been folded, so the expected EC balances
+/// are empty regardless of how many entries exist.
+///
+/// MUST be called *after* [`lock_targets_exclusive`]: the applier commits
+/// its writes and its checkpoint atomically under the SHARED counterpart
+/// of our locks, so post-lock the cursor cannot advance for any batch that
+/// touches the targets.
+pub(super) async fn ec_rollup_cursor(
+    op: &mut impl es_entity::AtomicOperation,
+    job_type: &str,
+) -> Result<i64, BalanceError> {
+    let row = sqlx::query!(
+        r#"
+        SELECT execution_state_json
+        FROM job_executions
+        WHERE job_type = $1
+        "#,
+        job_type,
+    )
+    .fetch_optional(op.as_executor())
+    .await?;
+
+    Ok(row
+        .and_then(|r| r.execution_state_json)
+        .and_then(|state| state.get("sequence").and_then(|s| s.as_i64()))
+        .unwrap_or(0))
+}
+
+/// Downward membership expansion: for each set-backed target, every
+/// account reachable through the set→set edge graph — the inverse of the
+/// applier's upward walk (`fetch_ec_set_mappings`). Returns
+/// `(target, leaf)` pairs.
+///
+/// Sound as historical routing because the membership guard
+/// (`member_has_balance_history_in_op`) freezes every node on an applied
+/// entry's ancestor path: the leaf has entries, and every ancestor —
+/// synchronous (inline history) or EC (history at apply time) — has
+/// balance history, so no edge on the path can be cut or re-attached.
+/// Members that could still move are exactly those with zero applied
+/// activity, which contribute nothing to the fold either way.
+pub(super) async fn expand_set_targets(
+    op: &mut impl es_entity::AtomicOperation,
+    set_target_ids: &[AccountId],
+) -> Result<Vec<(AccountId, AccountId)>, BalanceError> {
+    let rows = sqlx::query!(
+        r#"
+        WITH RECURSIVE subtree AS (
+            SELECT v.target_id AS target_id, v.target_id AS set_id
+            FROM UNNEST($1::uuid[]) AS v(target_id)
+            UNION
+            SELECT s.target_id, e.member_account_set_id
+            FROM subtree s
+            JOIN cala_account_set_member_account_sets e
+                ON e.account_set_id = s.set_id
+        )
+        SELECT
+            s.target_id AS "target_id!: AccountId",
+            m.member_account_id AS "leaf_id!: AccountId"
+        FROM subtree s
+        JOIN cala_account_set_member_accounts m
+            ON m.account_set_id = s.set_id
+        "#,
+        set_target_ids as &[AccountId],
+    )
+    .fetch_all(op.as_executor())
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.target_id, row.leaf_id))
+        .collect())
+}
+
+/// One keyset-paginated chunk of the contributing-entry scan.
+///
+/// Anchors and orders on the **transaction event's** outbox sequence
+/// (`≤ cursor`): the applier applies a transaction when its
+/// `TransactionCreated` event is processed (entries are stream-collected
+/// or DB-loaded), so the transaction event position — never the entry
+/// events' — decides whether an entry is folded as of a checkpoint.
+/// Entry values are hydrated from the entry's `initialized` event; the
+/// entry *set* comes from `cala_entries`, so a transaction whose event
+/// group straddled the checkpoint landing is still counted in full.
+///
+/// The outbox scan is seq-range partition-pruned (#809); the entries side
+/// is driven by `idx_cala_entries_account_id`. `after` is the previous
+/// chunk's last `(tx_seq, entry_seq)` key.
+///
+/// NOTE: this depends on persistent-outbox retention covering full
+/// history. obix range-partitions but never prunes the persistent outbox
+/// today; if pruning/archival ever lands, the reconciler needs an
+/// alternative "entries ≤ cursor" mapping.
+pub(super) async fn contributing_entries_chunk(
+    op: &mut impl es_entity::AtomicOperation,
+    journal_id: JournalId,
+    cursor: i64,
+    leaf_account_ids: &[AccountId],
+    after: Option<(i64, i32)>,
+    limit: i64,
+) -> Result<Vec<ContributingEntry>, BalanceError> {
+    let (after_tx_seq, after_entry_seq) = match after {
+        Some((tx_seq, entry_seq)) => (Some(tx_seq), Some(entry_seq)),
+        None => (None, None),
+    };
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            o.sequence AS "tx_seq!",
+            (ev.event->'values') AS "entry_values!",
+            ((ev.event#>>'{values,sequence}')::int4) AS "entry_seq!",
+            t.created_at AS "tx_created_at!",
+            t.effective AS "effective!"
+        FROM cala_persistent_outbox_events o
+        JOIN cala_entries e
+            ON e.transaction_id = ((o.payload->'transaction'->>'id')::uuid)
+        JOIN cala_entry_events ev
+            ON ev.id = e.id AND ev.event_type = 'initialized'
+        JOIN cala_transactions t
+            ON t.id = e.transaction_id
+        WHERE o.payload->>'type' = 'transaction_created'
+          AND o.sequence <= $1
+          AND e.journal_id = $2
+          AND e.account_id = ANY($3)
+          AND ($4::bigint IS NULL
+               OR (o.sequence, (ev.event#>>'{values,sequence}')::int4)
+                  > ($4::bigint, $5::int4))
+        ORDER BY o.sequence, (ev.event#>>'{values,sequence}')::int4
+        LIMIT $6
+        "#,
+        cursor,
+        journal_id as JournalId,
+        leaf_account_ids as &[AccountId],
+        after_tx_seq,
+        after_entry_seq,
+        limit,
+    )
+    .fetch_all(op.as_executor())
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ContributingEntry {
+            tx_seq: row.tx_seq,
+            entry_seq: row.entry_seq,
+            entry_values: row.entry_values,
+            tx_created_at: row.tx_created_at,
+            effective: row.effective,
+        })
+        .collect())
+}
+
+/// The targets' current balance snapshots (`latest_values`), keyed by
+/// `(account, currency)`.
+pub(super) async fn current_balances(
+    op: &mut impl es_entity::AtomicOperation,
+    journal_id: JournalId,
+    account_ids: &[AccountId],
+) -> Result<HashMap<(AccountId, Currency), BalanceSnapshot>, BalanceError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            c.account_id AS "account_id!: AccountId",
+            c.currency,
+            c.latest_values
+        FROM cala_current_balances c
+        WHERE c.journal_id = $1
+          AND c.account_id = ANY($2)
+        "#,
+        journal_id as JournalId,
+        account_ids as &[AccountId],
+    )
+    .fetch_all(op.as_executor())
+    .await?;
+
+    let mut ret = HashMap::new();
+    for row in rows {
+        let snapshot: BalanceSnapshot = serde_json::from_value(row.latest_values)
+            .expect("Failed to deserialize balance snapshot");
+        let currency: Currency = row.currency.parse().expect("Could not parse currency");
+        ret.insert((row.account_id, currency), snapshot);
+    }
+    Ok(ret)
+}
+
+/// Highest `cala_balance_history` version per `(account, currency)` for
+/// the targets — the floor a corrective snapshot's version must clear even
+/// when `cala_current_balances` was corrupted below it (the history
+/// version column is unique per balance).
+pub(super) async fn max_history_versions(
+    op: &mut impl es_entity::AtomicOperation,
+    journal_id: JournalId,
+    account_ids: &[AccountId],
+) -> Result<HashMap<(AccountId, Currency), u32>, BalanceError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            h.account_id AS "account_id!: AccountId",
+            h.currency,
+            MAX(h.version) AS "max_version!"
+        FROM cala_balance_history h
+        WHERE h.journal_id = $1
+          AND h.account_id = ANY($2)
+        GROUP BY h.account_id, h.currency
+        "#,
+        journal_id as JournalId,
+        account_ids as &[AccountId],
+    )
+    .fetch_all(op.as_executor())
+    .await?;
+
+    let mut ret = HashMap::new();
+    for row in rows {
+        let currency: Currency = row.currency.parse().expect("Could not parse currency");
+        ret.insert((row.account_id, currency), row.max_version as u32);
+    }
+    Ok(ret)
+}
+
+/// The latest cumulative-effective snapshot (highest `all_time_version`)
+/// per `(account, currency)` for the targets. Its per-layer totals must
+/// equal the expected fold's — the cumulative series ends at the same
+/// all-time totals the settled balance carries.
+pub(super) async fn latest_effective_balances(
+    op: &mut impl es_entity::AtomicOperation,
+    journal_id: JournalId,
+    account_ids: &[AccountId],
+) -> Result<HashMap<(AccountId, Currency), BalanceSnapshot>, BalanceError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT DISTINCT ON (b.account_id, b.currency)
+            b.account_id AS "account_id!: AccountId",
+            b.currency,
+            b.values
+        FROM cala_cumulative_effective_balances b
+        WHERE b.journal_id = $1
+          AND b.account_id = ANY($2)
+        ORDER BY b.account_id, b.currency, b.all_time_version DESC
+        "#,
+        journal_id as JournalId,
+        account_ids as &[AccountId],
+    )
+    .fetch_all(op.as_executor())
+    .await?;
+
+    let mut ret = HashMap::new();
+    for row in rows {
+        let snapshot: BalanceSnapshot =
+            serde_json::from_value(row.values).expect("Failed to deserialize balance snapshot");
+        let currency: Currency = row.currency.parse().expect("Could not parse currency");
+        ret.insert((row.account_id, currency), snapshot);
+    }
+    Ok(ret)
+}

--- a/cala-ledger/src/balance/repo.rs
+++ b/cala-ledger/src/balance/repo.rs
@@ -16,7 +16,7 @@ use super::{
     error::BalanceError,
 };
 
-const EC_SET_LOCK_CLASS: i32 = 1;
+pub(super) const EC_SET_LOCK_CLASS: i32 = 1;
 
 /// Maximum balance snapshots written per `INSERT` in
 /// [`BalanceRepo::insert_new_snapshots`]. A single streaming-rollup batch

--- a/cala-ledger/src/ec_rollup.rs
+++ b/cala-ledger/src/ec_rollup.rs
@@ -62,7 +62,12 @@ use crate::{
     primitives::{EntryId, JournalId, TransactionId},
 };
 
-const EC_BALANCE_ROLLUP_JOB: JobType = JobType::new("cala.ec_balance_rollup");
+/// Job-type name of the streaming rollup's unique instance. Shared with
+/// the reconciler ([`crate::balance`]'s `verify_ec`/`repair_ec`), which
+/// reads the job's persisted checkpoint as its consistency anchor.
+pub(crate) const EC_BALANCE_ROLLUP_JOB_NAME: &str = "cala.ec_balance_rollup";
+
+const EC_BALANCE_ROLLUP_JOB: JobType = JobType::new(EC_BALANCE_ROLLUP_JOB_NAME);
 
 /// Maximum number of collected events (transactions + their entries)
 /// folded into a single commit. Bounds per-transaction memory/WAL/lock

--- a/cala-ledger/tests/ec_reconcile.rs
+++ b/cala-ledger/tests/ec_reconcile.rs
@@ -1,0 +1,723 @@
+//! End-to-end tests for the entry-sourced EC verify/repair tool
+//! (`Balances::verify_ec` / `Balances::repair_ec`).
+//!
+//! The reconciler anchors on the streaming rollup job's committed cursor,
+//! so — like the rollup tests — every test runs on its own isolated
+//! database (`helpers::init_isolated_pool`). Convergence via
+//! `wait_for_settled` doubles as a checkpoint barrier: the applier commits
+//! its balance writes and its cursor atomically, so once the balance is
+//! visible the cursor covers the folded events.
+
+mod helpers;
+
+use rand::distr::{Alphanumeric, SampleString};
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use cala_ledger::{
+    account::{Account, NewAccount},
+    account_set::{AccountSet, AccountSetId, NewAccountSet},
+    balance::error::BalanceError,
+    job::Jobs,
+    journal::NewJournal,
+    primitives::BalanceRollup,
+    tx_template::Params,
+    AccountId, CalaLedger, CalaLedgerConfig, Currency, JournalId, TransactionId,
+};
+
+const POST_AMOUNT: Decimal = dec!(7);
+
+struct Fixture {
+    cala: CalaLedger,
+    journal_id: JournalId,
+    sender: Account,
+    members: Vec<Account>,
+    tx_code: String,
+}
+
+async fn setup(pool: sqlx::PgPool, journal: NewJournal) -> anyhow::Result<(Fixture, Jobs)> {
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(journal).await?;
+
+    let sender_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    let sender = NewAccount::builder()
+        .id(uuid::Uuid::now_v7())
+        .name(format!("Reconcile sender {sender_code}"))
+        .code(sender_code)
+        .build()?;
+    let sender = cala.accounts().create(sender).await?;
+
+    let mut members = Vec::with_capacity(2);
+    for i in 0..2 {
+        let code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+        let acc = NewAccount::builder()
+            .id(uuid::Uuid::now_v7())
+            .name(format!("Reconcile member {i} {code}"))
+            .code(code)
+            .build()?;
+        members.push(cala.accounts().create(acc).await?);
+    }
+
+    // amount + effective params, USD settled defaults — supports both
+    // dated and undated posts.
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    cala.tx_templates()
+        .create(helpers::velocity_template(&tx_code))
+        .await?;
+
+    let journal_id = journal.id();
+    Ok((
+        Fixture {
+            cala,
+            journal_id,
+            sender,
+            members,
+            tx_code,
+        },
+        jobs,
+    ))
+}
+
+async fn create_ec_set(
+    cala: &CalaLedger,
+    journal_id: JournalId,
+    name: &str,
+) -> anyhow::Result<AccountSet> {
+    let set = NewAccountSet::builder()
+        .id(AccountSetId::new())
+        .name(name)
+        .journal_id(journal_id)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
+        .build()?;
+    Ok(cala.account_sets().create(set).await?)
+}
+
+async fn create_ec_plain_account(cala: &CalaLedger, name: &str) -> anyhow::Result<Account> {
+    let code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    let account = NewAccount::builder()
+        .id(uuid::Uuid::now_v7())
+        .name(format!("{name} {code}"))
+        .code(code)
+        .balance_rollup(BalanceRollup::EventuallyConsistent)
+        .build()?;
+    Ok(cala.accounts().create(account).await?)
+}
+
+async fn post(
+    fixture: &Fixture,
+    recipient: AccountId,
+    effective: Option<chrono::NaiveDate>,
+) -> anyhow::Result<()> {
+    let mut params = Params::new();
+    params.insert("journal_id", fixture.journal_id.to_string());
+    params.insert("sender", fixture.sender.id());
+    params.insert("recipient", recipient);
+    params.insert("amount", POST_AMOUNT);
+    if let Some(date) = effective {
+        params.insert("effective", date);
+    }
+    fixture
+        .cala
+        .post_transaction(TransactionId::new(), &fixture.tx_code, params)
+        .await?;
+    Ok(())
+}
+
+async fn post_round_robin(fixture: &Fixture, n_posts: usize) -> anyhow::Result<()> {
+    for i in 0..n_posts {
+        post(
+            fixture,
+            fixture.members[i % fixture.members.len()].id(),
+            None,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Clean state: verification reports zero drift and repair writes nothing.
+#[tokio::test]
+async fn verify_reports_no_drift_when_clean() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool, helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "clean EC set").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+    let ec_leaf = create_ec_plain_account(&fixture.cala, "clean EC leaf").await?;
+
+    let n_posts = 6;
+    post_round_robin(&fixture, n_posts).await?;
+    post(&fixture, ec_leaf.id(), None).await?;
+    let set_expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    jobs.start_poll().await?;
+    helpers::wait_for_settled(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        set_expected,
+    )
+    .await?;
+    helpers::wait_for_settled(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_leaf.id(),
+        usd,
+        POST_AMOUNT,
+    )
+    .await?;
+
+    let targets = [AccountId::from(ec_set.id()), ec_leaf.id()];
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert_eq!(reports.len(), 2);
+    assert!(reports.iter().all(|r| !r.is_drifted()));
+    assert!(reports
+        .iter()
+        .any(|r| r.account_id == AccountId::from(ec_set.id())
+            && r.expected_version == n_posts as u32));
+
+    let reports = fixture
+        .cala
+        .balances()
+        .repair_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports.iter().all(|r| !r.repaired));
+
+    // Repair-noop must not have changed the balances.
+    let bal = fixture
+        .cala
+        .balances()
+        .find(fixture.journal_id, ec_set.id(), usd)
+        .await?;
+    assert_eq!(bal.settled(), set_expected);
+    Ok(())
+}
+
+/// A non-EC account is rejected — synchronous balances are maintained
+/// inline and out of scope for the reconciler.
+#[tokio::test]
+async fn rejects_non_ec_targets() -> anyhow::Result<()> {
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, _jobs) = setup(pool, helpers::test_journal()).await?;
+
+    let result = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &[fixture.sender.id()])
+        .await;
+    assert!(matches!(
+        result,
+        Err(BalanceError::NotEventuallyConsistent(id)) if id == fixture.sender.id()
+    ));
+    Ok(())
+}
+
+/// Corrupt `cala_current_balances.latest_values` → verify reports the
+/// exact drift → repair restores the expected value with an appended
+/// (version + 1) corrective snapshot → a second verify is clean.
+#[tokio::test]
+async fn detects_and_repairs_corrupted_current_balance() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool.clone(), helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "corrupted EC set").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_posts = 8;
+    post_round_robin(&fixture, n_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    jobs.start_poll().await?;
+    helpers::wait_for_settled(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        expected,
+    )
+    .await?;
+
+    // Corrupt the settled credit balance (Decimal serializes as a JSON
+    // string in the snapshot).
+    let bogus = dec!(999999);
+    sqlx::query(
+        r#"
+        UPDATE cala_current_balances
+        SET latest_values =
+            jsonb_set(latest_values, '{settled,cr_balance}', to_jsonb($3::text))
+        WHERE journal_id = $1 AND account_id = $2
+        "#,
+    )
+    .bind(uuid::Uuid::from(fixture.journal_id))
+    .bind(uuid::Uuid::from(AccountId::from(ec_set.id())))
+    .bind(bogus.to_string())
+    .execute(&pool)
+    .await?;
+
+    let targets = [AccountId::from(ec_set.id())];
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert_eq!(reports.len(), 1);
+    let report = &reports[0];
+    assert!(report.is_drifted());
+    assert_eq!(report.settled.cr_delta, expected - bogus);
+    assert_eq!(report.settled.dr_delta, Decimal::ZERO);
+    assert_eq!(report.expected_version, n_posts as u32);
+    assert_eq!(report.found_version, Some(n_posts as u32));
+
+    let reports = fixture
+        .cala
+        .balances()
+        .repair_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports[0].repaired);
+
+    let bal = fixture
+        .cala
+        .balances()
+        .find(fixture.journal_id, ec_set.id(), usd)
+        .await?;
+    assert_eq!(bal.settled(), expected);
+    // Corrective snapshot appended on top of the existing chain.
+    assert_eq!(bal.details.version, n_posts as u32 + 1);
+
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports.iter().all(|r| !r.is_drifted()));
+    Ok(())
+}
+
+/// Balance row and history wiped entirely → repair recreates the balance
+/// from entries with the applier-identical end state.
+#[tokio::test]
+async fn repairs_deleted_balance_rows() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool.clone(), helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "wiped EC set").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_posts = 6;
+    post_round_robin(&fixture, n_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    jobs.start_poll().await?;
+    helpers::wait_for_settled(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        expected,
+    )
+    .await?;
+
+    let journal_uuid = uuid::Uuid::from(fixture.journal_id);
+    let set_uuid = uuid::Uuid::from(AccountId::from(ec_set.id()));
+    // History references current — wipe it first.
+    sqlx::query("DELETE FROM cala_balance_history WHERE journal_id = $1 AND account_id = $2")
+        .bind(journal_uuid)
+        .bind(set_uuid)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM cala_current_balances WHERE journal_id = $1 AND account_id = $2")
+        .bind(journal_uuid)
+        .bind(set_uuid)
+        .execute(&pool)
+        .await?;
+
+    let targets = [AccountId::from(ec_set.id())];
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert_eq!(reports.len(), 1);
+    assert!(reports[0].is_drifted());
+    assert_eq!(reports[0].found_version, None);
+    assert_eq!(reports[0].settled.cr_delta, expected);
+
+    fixture
+        .cala
+        .balances()
+        .repair_ec(fixture.journal_id, &targets)
+        .await?;
+
+    let bal = fixture
+        .cala
+        .balances()
+        .find(fixture.journal_id, ec_set.id(), usd)
+        .await?;
+    assert_eq!(bal.settled(), expected);
+    // Fresh chain: the single corrective row carries the applier-identical
+    // end version (one bump per folded entry).
+    assert_eq!(bal.details.version, n_posts as u32);
+
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports.iter().all(|r| !r.is_drifted()));
+    Ok(())
+}
+
+/// The double-count guard: with the rollup job never run (cursor = 0),
+/// posted-but-unapplied entries must contribute *nothing* to the expected
+/// state — a naive Σ-entries rebuild would report (and "repair" in) a
+/// balance the applier would then add again.
+#[tokio::test]
+async fn cursor_zero_expects_empty_state() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool, helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "cursor-zero EC set").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_posts = 6;
+    post_round_robin(&fixture, n_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    // Job not polling: entries exist, nothing is applied, cursor is 0.
+    let targets = [AccountId::from(ec_set.id())];
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(
+        reports.is_empty(),
+        "no expected state and no found state ⇒ no involved pairs, got {reports:?}"
+    );
+
+    // Repair is likewise a no-op — and must not fabricate a balance the
+    // applier would double-count later.
+    let reports = fixture
+        .cala
+        .balances()
+        .repair_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports.is_empty());
+
+    // Now let the stream catch up: the full backlog folds exactly once on
+    // top of the untouched state.
+    jobs.start_poll().await?;
+    helpers::wait_for_settled(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        expected,
+    )
+    .await?;
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert_eq!(reports.len(), 1);
+    assert!(!reports[0].is_drifted());
+    Ok(())
+}
+
+/// The reconciler's exclusive advisory locks must block the streaming
+/// applier *before* it writes or advances its cursor: hold the lock in a
+/// raw transaction, observe the applier queued behind it (`pg_locks`),
+/// release, and assert the backlog then folds exactly once.
+#[tokio::test]
+async fn exclusive_lock_blocks_applier_until_release() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool.clone(), helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "lock-race EC set").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_posts = 6;
+    post_round_robin(&fixture, n_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    // Take the reconciler's exclusive lock on the EC set (same class-1
+    // key the tool uses) in a dedicated transaction.
+    let mut lock_tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock(1, hashtext($1::uuid::text))")
+        .bind(uuid::Uuid::from(AccountId::from(ec_set.id())))
+        .execute(&mut *lock_tx)
+        .await?;
+
+    jobs.start_poll().await?;
+
+    // The applier must queue behind the exclusive lock: an ungranted
+    // advisory waiter appears and the EC set stays without a balance.
+    let mut saw_waiter = false;
+    for _ in 0..300 {
+        let waiters: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND NOT granted",
+        )
+        .fetch_one(&pool)
+        .await?;
+        if waiters > 0 {
+            saw_waiter = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    assert!(saw_waiter, "applier never queued behind the exclusive lock");
+    assert!(
+        fixture
+            .cala
+            .balances()
+            .find(fixture.journal_id, ec_set.id(), usd)
+            .await
+            .is_err(),
+        "EC set must not gain a balance while the exclusive lock is held",
+    );
+
+    // Release: the blocked batch applies on top, exactly once.
+    lock_tx.rollback().await?;
+    helpers::wait_for_settled(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        expected,
+    )
+    .await?;
+
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &[AccountId::from(ec_set.id())])
+        .await?;
+    assert!(reports.iter().all(|r| !r.is_drifted()));
+    Ok(())
+}
+
+/// Effective-series repair for a back-dated history: corrupt the series
+/// (drop an interior date, corrupt the latest) → verify flags effective
+/// drift with the settled state clean → repair rebuilds the whole
+/// per-date cumulative series.
+#[tokio::test]
+async fn repairs_backdated_effective_series() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(
+        pool.clone(),
+        helpers::test_journal_with_effective_balances(),
+    )
+    .await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "effective EC set").await?;
+    let member = fixture.members[0].id();
+    fixture
+        .cala
+        .account_sets()
+        .add_member(ec_set.id(), member)
+        .await?;
+
+    let today = chrono::Utc::now().date_naive();
+    let d1 = today - chrono::Days::new(2);
+    let d2 = today - chrono::Days::new(1);
+
+    // Post d2 first, then back-date d1 — exercising the applier's
+    // rewrite path before any corruption.
+    post(&fixture, member, Some(d2)).await?;
+    post(&fixture, member, Some(d1)).await?;
+
+    jobs.start_poll().await?;
+    helpers::wait_for_effective(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        d1,
+        POST_AMOUNT,
+    )
+    .await?;
+    helpers::wait_for_effective(
+        &fixture.cala,
+        fixture.journal_id,
+        ec_set.id(),
+        usd,
+        d2,
+        POST_AMOUNT * dec!(2),
+    )
+    .await?;
+
+    let journal_uuid = uuid::Uuid::from(fixture.journal_id);
+    let set_uuid = uuid::Uuid::from(AccountId::from(ec_set.id()));
+    // Drop the interior date and corrupt the latest cumulative row.
+    sqlx::query(
+        "DELETE FROM cala_cumulative_effective_balances
+         WHERE journal_id = $1 AND account_id = $2 AND effective = $3",
+    )
+    .bind(journal_uuid)
+    .bind(set_uuid)
+    .bind(d1)
+    .execute(&pool)
+    .await?;
+    sqlx::query(
+        r#"
+        UPDATE cala_cumulative_effective_balances
+        SET values = jsonb_set(values, '{settled,cr_balance}', to_jsonb($3::text))
+        WHERE journal_id = $1 AND account_id = $2 AND effective = $4
+        "#,
+    )
+    .bind(journal_uuid)
+    .bind(set_uuid)
+    .bind(dec!(424242).to_string())
+    .bind(d2)
+    .execute(&pool)
+    .await?;
+
+    let targets = [AccountId::from(ec_set.id())];
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert_eq!(reports.len(), 1);
+    assert!(reports[0].effective_drift);
+    assert!(!reports[0].balance_drift());
+
+    fixture
+        .cala
+        .balances()
+        .repair_ec(fixture.journal_id, &targets)
+        .await?;
+
+    // Whole series restored — including the dropped interior date.
+    let bal = fixture
+        .cala
+        .balances()
+        .effective()
+        .find_cumulative(fixture.journal_id, ec_set.id(), usd, d1)
+        .await?;
+    assert_eq!(bal.settled(), POST_AMOUNT);
+    let bal = fixture
+        .cala
+        .balances()
+        .effective()
+        .find_cumulative(fixture.journal_id, ec_set.id(), usd, d2)
+        .await?;
+    assert_eq!(bal.settled(), POST_AMOUNT * dec!(2));
+
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports.iter().all(|r| !r.is_drifted()));
+    Ok(())
+}
+
+/// After a repair the stream keeps flowing: later postings fold on top of
+/// the corrected state exactly once.
+#[tokio::test]
+async fn streaming_continues_after_repair() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool.clone(), helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "repair-then-stream").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_initial = 6;
+    post_round_robin(&fixture, n_initial).await?;
+    let initial = POST_AMOUNT * Decimal::from(n_initial);
+
+    jobs.start_poll().await?;
+    helpers::wait_for_settled(&fixture.cala, fixture.journal_id, ec_set.id(), usd, initial).await?;
+
+    sqlx::query(
+        r#"
+        UPDATE cala_current_balances
+        SET latest_values =
+            jsonb_set(latest_values, '{settled,cr_balance}', to_jsonb($3::text))
+        WHERE journal_id = $1 AND account_id = $2
+        "#,
+    )
+    .bind(uuid::Uuid::from(fixture.journal_id))
+    .bind(uuid::Uuid::from(AccountId::from(ec_set.id())))
+    .bind(dec!(1).to_string())
+    .execute(&pool)
+    .await?;
+
+    let targets = [AccountId::from(ec_set.id())];
+    let reports = fixture
+        .cala
+        .balances()
+        .repair_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports[0].repaired);
+
+    // New activity lands on the corrected state, exactly once.
+    let n_more = 4;
+    post_round_robin(&fixture, n_more).await?;
+    let total = initial + POST_AMOUNT * Decimal::from(n_more);
+    helpers::wait_for_settled(&fixture.cala, fixture.journal_id, ec_set.id(), usd, total).await?;
+
+    let reports = fixture
+        .cala
+        .balances()
+        .verify_ec(fixture.journal_id, &targets)
+        .await?;
+    assert!(reports.iter().all(|r| !r.is_drifted()));
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Since the streaming EC rollup replaced `recalculate_balances_*` (#811), a drifted eventually-consistent balance had **no repair path**: nothing could recompute it. This adds the deterministic, bounded reconciliation tool from the perf-review roadmap (§6, PR 5):

- **`Balances::verify_ec(journal_id, &[AccountId])`** — read-only: recompute expected EC balances (set-backing accounts *and* EC plain leaves) from contributing entries and report per-layer/direction drift (`EcDriftReport`).
- **`Balances::repair_ec(...)`** — verify + append **corrective snapshots** (history stays append-only; nothing is rewritten or deleted) and rebuild the cumulative-effective series for effective-drifted pairs.

Implements the impl spec in drua library `cala-dev/impl-pr-ec-rebuild-tool.md`; master context is the holistic lock/perf review (`cala-dev/analysis-locks-holistic-perf-review.md`, memory `019fd1f5`).

## Correctness core

- **Consistency anchor.** The applier is delta-based and not idempotent, and outbox seq order ≠ commit order — so the *only* clean fold boundary is the rollup job's committed cursor `C` (obix delivery is gapless: everything ≤ C is committed **and** folded; everything > C folds later exactly once). Expected state = fold of entries whose transaction's `TransactionCreated` event has `seq ≤ C`.
- **Freezing `C`.** The reconciler takes **EXCLUSIVE** class-1 advisory locks on its targets (join-free UNNEST, Rust-sorted — canonical ordering) and reads `C` only *after*. The applier's flush takes the SHARED counterpart on every EC account it writes (`find_ec_balances_for_update`) in the same tx that advances the checkpoint — this PR is what that "defensive serialization point" was defending for. A target-touching batch blocks before writing *or* advancing `C`; its `(C, C']` window is disjoint from the `≤ C` fold; it applies on top of the corrected state after commit. No marker column, no job-pause API.
- **Routing = current membership walk** (downward inverse of #814's upward walk). Sound because the #813 membership guard freezes every node on an applied entry's ancestor path (leaf has entries; every ancestor — sync or EC — has history), so no edge on the path can be attached or cut.
- **Ordering/replay.** Entries fold via the existing `Snapshots::new_snapshot`/`update_snapshot` with `time = tx.created_at`, in `(tx event seq, entry sequence)` order — field-exact replay of applier semantics (values, versions, entry ids, timestamps). Entry *sets* come from `cala_entries` + `initialized` events (a checkpoint-straddling event group still counts in full); scans are keyset-chunked and memory-bounded (one running snapshot per pair — the #740 lesson).

## Deliberate calls (flagging per review)

- **Cursor accessor**: read-only `SELECT execution_state_json FROM job_executions WHERE job_type = 'cala.ec_balance_rollup'` (spec §6 open question — chose raw scoped SQL; can move to a job-crate API later).
- **Corrective outbox events**: settled snapshots have **no outbox event type at all** (only `EffectiveBalance*` exist), so there is nothing to publish for settled corrections. Effective reinserts publish through the normal `insert_new_snapshots` path — note the first reinserted row re-emits `EffectiveBalanceCreated` at `all_time_version = 1`.
- **Effective series rebuilt as one row per effective date** (`version` = entries that day, `all_time_version` = entries ≤ day). Intra-day per-entry rows and rewrite-inflated `all_time_version` counts are not reconstructible from the ledger (they depend on arrival-order interleaving); all read-path semantics (`effective ≤ date` lookups, `all_time_version` diffs as entry counts) are preserved.
- **Version drift is evidence, not a trigger**: `EcDriftReport` carries `expected_version`/`found_version`, but drift = value deltas — a corrective append legitimately leaves found = expected + 1.
- **Fresh-chain repair** (row + history wiped): a single corrective row carries the applier-identical end state; intermediate versions are not re-materialized.
- **RETENTION DEPENDENCY**: the fold requires the persistent outbox to cover full history. obix range-partitions (#809) but never prunes today. If outbox pruning/archival ever lands, this needs an alternative "entries ≤ C" mapping — documented in the module docs.

## Coordination with PR 6 (attach fence — sibling, in flight)

- All reconcile SQL lives in a **new** `balance/reconcile/` module. The only `balance/repo.rs` contact is a one-line `EC_SET_LOCK_CLASS` visibility change; `find_for_update`, `find_ec_balances_for_update`, the B3 member guards and the class-1 doctrine comment are untouched (PR 6 owns that surface).
- PR 6 must keep the applier's SHARED lock in `find_ec_balances_for_update` — it is this tool's serialization partner (both specs carry the note; whoever lands second re-checks the doctrine comment).
- Until PR 6 lands, posters also hold SHARED on EC ancestors, so a repair chunk briefly blocks posting into the target subtree; after PR 6 only the applier serializes against repair.

## Tests (`tests/ec_reconcile.rs`, isolated DB per test)

- clean verify → zero drift; repair is a no-op
- corrupted `latest_values` → **exact** drift deltas reported → repair → second verify clean; corrective at `version + 1`
- current + history wiped → rebuilt from entries (fresh chain, applier-identical version)
- **cursor = 0 double-count guard**: posted-but-unapplied entries contribute nothing (a naive Σ-entries "repair" would be double-counted by the applier later); stream then catches up exactly once
- exclusive lock blocks the applier before write/checkpoint (observed via `pg_locks`), then exactly-once catch-up after release
- back-dated effective series: interior date dropped + latest corrupted → effective drift flagged with settled clean → whole series rebuilt
- streaming continues on top of the corrected state after repair

`nix flake check` green (fmt / clippy `-D warnings` / deny / audit), full live-PG suite 128/128, `.sqlx` regenerated.

## Semver

Additive (**minor**): new public methods + `EcDriftReport`/`LayerDrift` + `BalanceError::NotEventuallyConsistent`. No schema changes, no migrations.

## Downstream

- **lana**: should expose this as an admin runbook / mutation (`verify_ec` sweep + gated `repair_ec`) — flagged only, not touched here.
- **obix**: no changes; retention dependency flagged above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)