### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+Only the latest release and `main` receive security fixes.
+
+Please report security vulnerabilities by email to **security@galoy.io** —
+do not report them through public GitHub issues, discussions, or pull requests.


### PR DESCRIPTION
Adds a minimal `SECURITY.md` so GitHub surfaces a security policy for this
repo, pointing reporters at **security@galoy.io**.

Part of an effort to add a consistent security policy across Galoy's open
source repositories (obix, job, es-entity, cala, bria, drua).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no changes to auth, data handling, or executable code.
> 
> **Overview**
> Introduces **`SECURITY.md`** for GitHub’s security policy UI. It states that only the latest release and `main` get security fixes, and asks reporters to email **security@galoy.io** rather than opening public GitHub issues, discussions, or pull requests.
> 
> No application code, dependencies, or runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cc2a6593abfd25993d007178d918335c62c4a2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->