### PR TITLE
feat(ledger): EC rollup caught-up barrier — ec_rollup_status + await_ec_caught_up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,9 +1440,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "job"
-version = "0.7.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618e339b07bb230aa2283472c3f893e3823fe44088053ca0221275c668d1882c"
+checksum = "787e0bada3ca33fb727b9d3a631c351c48d6eec9da8139f90ae8946145199ada"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1646,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0d91a35f0c6791681bcfab75c3a5eb4ded6465ee15fb7b6d73d885ce5962c7"
+checksum = "c90cf0f8d7276927ccf51535e4bbbdb13f65ef73f30bd55f63e147a68d45f41b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4220bc2166d1425ca0191d91e98e75d0fde4b11309d5103da051fabbde397735"
+checksum = "cb03ce8b8dbd3c542ac11a511444574b61c032282d2c512e8bf1d9ce8815a247"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ cala-ledger = { path = "cala-ledger", version = "0.23.1-dev" }
 
 cel = "0.14.1"
 es-entity = "0.12.7"
-job = { version = "0.7.3", features = ["es-entity"] }
-obix = { version = "0.7.2", default-features = false }
+job = { version = "0.9.1", features = ["es-entity"] }
+obix = { version = "0.8.0", default-features = false }
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }

--- a/cala-ledger/.sqlx/query-019135648f4d3371f724322403863b87a60ad88a44541651afaf9f7ef6288435.json
+++ b/cala-ledger/.sqlx/query-019135648f4d3371f724322403863b87a60ad88a44541651afaf9f7ef6288435.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          INSERT INTO job_executions (id, job_type, queue_id, execute_at, alive_at, created_at)\n          VALUES ($1, $2, $3, $4, COALESCE($5, NOW()), COALESCE($5, NOW()))\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "019135648f4d3371f724322403863b87a60ad88a44541651afaf9f7ef6288435"
+}

--- a/cala-ledger/.sqlx/query-0ef759ca363dd6215cacf388c8f2d3a31ee655b14d9f992fd7dcd7ea4559fb49.json
+++ b/cala-ledger/.sqlx/query-0ef759ca363dd6215cacf388c8f2d3a31ee655b14d9f992fd7dcd7ea4559fb49.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE job_executions\n        SET state = 'pending',\n            execute_at = $1,\n            poller_instance_id = NULL\n        WHERE poller_instance_id = $2 AND state = 'running'\n        RETURNING id as \"id!: JobId\", attempt_index\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "attempt_index",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "0ef759ca363dd6215cacf388c8f2d3a31ee655b14d9f992fd7dcd7ea4559fb49"
+}

--- a/cala-ledger/.sqlx/query-0f686e82dacdea670330c9d2e02ab99bc884bcfbab54e1a5fa9b7bcc9a5523eb.json
+++ b/cala-ledger/.sqlx/query-0f686e82dacdea670330c9d2e02ab99bc884bcfbab54e1a5fa9b7bcc9a5523eb.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM job_executions WHERE id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0f686e82dacdea670330c9d2e02ab99bc884bcfbab54e1a5fa9b7bcc9a5523eb"
+}

--- a/cala-ledger/.sqlx/query-232c7eb7d5e1782f64962a4ef4b40fba51d328fbf1ad14b2c566741b90aa00f9.json
+++ b/cala-ledger/.sqlx/query-232c7eb7d5e1782f64962a4ef4b40fba51d328fbf1ad14b2c566741b90aa00f9.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT state AS \"state: JobExecutionState\", execute_at, attempt_index, alive_at, execution_state_json\n            FROM job_executions WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "state: JobExecutionState",
+        "type_info": {
+          "Custom": {
+            "name": "jobexecutionstate",
+            "kind": {
+              "Enum": [
+                "pending",
+                "running"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "execute_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempt_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "alive_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "execution_state_json",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "232c7eb7d5e1782f64962a4ef4b40fba51d328fbf1ad14b2c566741b90aa00f9"
+}

--- a/cala-ledger/.sqlx/query-2d190a08529ceff844964b3a388bfbdc3e609f48a66290905074826f502e1c3a.json
+++ b/cala-ledger/.sqlx/query-2d190a08529ceff844964b3a388bfbdc3e609f48a66290905074826f502e1c3a.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          DELETE FROM job_executions\n          WHERE id = $1 AND poller_instance_id = $2\n          RETURNING queue_id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "queue_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "2d190a08529ceff844964b3a388bfbdc3e609f48a66290905074826f502e1c3a"
+}

--- a/cala-ledger/.sqlx/query-305467f4cafa5cb37a533cfcf7da7addd45ce99d3285d9b2a655bf7a02c68398.json
+++ b/cala-ledger/.sqlx/query-305467f4cafa5cb37a533cfcf7da7addd45ce99d3285d9b2a655bf7a02c68398.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                DELETE FROM job_executions\n                WHERE id = ANY($1) AND poller_instance_id = $2\n                RETURNING id AS \"id!: JobId\", queue_id\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "queue_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "305467f4cafa5cb37a533cfcf7da7addd45ce99d3285d9b2a655bf7a02c68398"
+}

--- a/cala-ledger/.sqlx/query-3a3d9fb77d32aa926867bb4e5dba893073129637d3d56412aea27d239a2fcd1f.json
+++ b/cala-ledger/.sqlx/query-3a3d9fb77d32aa926867bb4e5dba893073129637d3d56412aea27d239a2fcd1f.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM job_executions\n            WHERE id = ANY($1) AND poller_instance_id = $2\n            RETURNING id AS \"id!: JobId\", queue_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "queue_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "3a3d9fb77d32aa926867bb4e5dba893073129637d3d56412aea27d239a2fcd1f"
+}

--- a/cala-ledger/.sqlx/query-3bb124b6dd4f6b2f523569c67c96bfc94179e9e857d559e3fb224f17ab6ebdb9.json
+++ b/cala-ledger/.sqlx/query-3bb124b6dd4f6b2f523569c67c96bfc94179e9e857d559e3fb224f17ab6ebdb9.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE job_type = $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "3bb124b6dd4f6b2f523569c67c96bfc94179e9e857d559e3fb224f17ab6ebdb9"
+}

--- a/cala-ledger/.sqlx/query-3c13c67fd358a8b6dc4f6c96b538134ca4022be52e3869b766068420b0e21023.json
+++ b/cala-ledger/.sqlx/query-3c13c67fd358a8b6dc4f6c96b538134ca4022be52e3869b766068420b0e21023.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT id FROM jobs WHERE (id < $2) AND ($2 IS NOT NULL) ORDER BY id DESC LIMIT $1) UNION ALL (SELECT id FROM jobs WHERE ($2 IS NULL) ORDER BY id DESC LIMIT $1) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "3c13c67fd358a8b6dc4f6c96b538134ca4022be52e3869b766068420b0e21023"
+}

--- a/cala-ledger/.sqlx/query-4235e9bab5ce20f53879defbd7ab1b415609ea007ebdd76fa65e68c0a8509531.json
+++ b/cala-ledger/.sqlx/query-4235e9bab5ce20f53879defbd7ab1b415609ea007ebdd76fa65e68c0a8509531.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT id FROM jobs WHERE (id > $2) AND ($2 IS NOT NULL) ORDER BY id ASC LIMIT $1) UNION ALL (SELECT id FROM jobs WHERE ($2 IS NULL) ORDER BY id ASC LIMIT $1) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "4235e9bab5ce20f53879defbd7ab1b415609ea007ebdd76fa65e68c0a8509531"
+}

--- a/cala-ledger/.sqlx/query-452f79837dff78243fdd7fd2ea45371d1e3ff04da632c907c5779f186e0faf90.json
+++ b/cala-ledger/.sqlx/query-452f79837dff78243fdd7fd2ea45371d1e3ff04da632c907c5779f186e0faf90.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT execution_state_json FROM job_executions WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "execution_state_json",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "452f79837dff78243fdd7fd2ea45371d1e3ff04da632c907c5779f186e0faf90"
+}

--- a/cala-ledger/.sqlx/query-5a11b2ffbf16adc233e32ac0b17f16e1a83d1e6f3cac7729383ae3b52292ae89.json
+++ b/cala-ledger/.sqlx/query-5a11b2ffbf16adc233e32ac0b17f16e1a83d1e6f3cac7729383ae3b52292ae89.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE queue_id IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "5a11b2ffbf16adc233e32ac0b17f16e1a83d1e6f3cac7729383ae3b52292ae89"
+}

--- a/cala-ledger/.sqlx/query-5a71ac3f9107bd2bbd5cd5cd54b06b2b35d28d97bb7ac3c3cf022a697f6111a2.json
+++ b/cala-ledger/.sqlx/query-5a71ac3f9107bd2bbd5cd5cd54b06b2b35d28d97bb7ac3c3cf022a697f6111a2.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE job_executions AS je\n            SET state = 'pending', execute_at = u.execute_at, attempt_index = 1,\n                poller_instance_id = NULL\n            FROM UNNEST($1::uuid[], $2::timestamptz[]) AS u(id, execute_at)\n            WHERE je.id = u.id AND je.poller_instance_id = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TimestamptzArray",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5a71ac3f9107bd2bbd5cd5cd54b06b2b35d28d97bb7ac3c3cf022a697f6111a2"
+}

--- a/cala-ledger/.sqlx/query-61f22dc336d52d7f3898e28088df3d08e6413d2e1dfd92af5d22f9ae9dfc8e82.json
+++ b/cala-ledger/.sqlx/query-61f22dc336d52d7f3898e28088df3d08e6413d2e1dfd92af5d22f9ae9dfc8e82.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE job_executions AS je\n                SET state = 'pending', execute_at = u.execute_at,\n                    attempt_index = u.attempt_index, poller_instance_id = NULL\n                FROM UNNEST($1::uuid[], $2::timestamptz[], $3::int4[])\n                    AS u(id, execute_at, attempt_index)\n                WHERE je.id = u.id AND je.poller_instance_id = $4\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "TimestamptzArray",
+        "Int4Array",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "61f22dc336d52d7f3898e28088df3d08e6413d2e1dfd92af5d22f9ae9dfc8e82"
+}

--- a/cala-ledger/.sqlx/query-83a57fe9f4eef92fbf7cfb496ae1fb77556e6a2ccc45d4f1380da0695919b330.json
+++ b/cala-ledger/.sqlx/query-83a57fe9f4eef92fbf7cfb496ae1fb77556e6a2ccc45d4f1380da0695919b330.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO job_events (id, recorded_at, sequence, event_type, event) SELECT $1, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "83a57fe9f4eef92fbf7cfb496ae1fb77556e6a2ccc45d4f1380da0695919b330"
+}

--- a/cala-ledger/.sqlx/query-885f4d8bd1409e7d117ea6dbe07ff93a3740a7d39c9155bb81e67a9f9d924889.json
+++ b/cala-ledger/.sqlx/query-885f4d8bd1409e7d117ea6dbe07ff93a3740a7d39c9155bb81e67a9f9d924889.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT created_at, id FROM jobs WHERE ((created_at, id) < ($3, $2)) AND ($2 IS NOT NULL) ORDER BY created_at DESC, id DESC LIMIT $1) UNION ALL (SELECT created_at, id FROM jobs WHERE ($2 IS NULL) ORDER BY created_at DESC, id DESC LIMIT $1) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "885f4d8bd1409e7d117ea6dbe07ff93a3740a7d39c9155bb81e67a9f9d924889"
+}

--- a/cala-ledger/.sqlx/query-8f352d7dfd354f0f7de531d1983f1b495a3d720ebc39238c5e8b2b982d185309.json
+++ b/cala-ledger/.sqlx/query-8f352d7dfd354f0f7de531d1983f1b495a3d720ebc39238c5e8b2b982d185309.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        -- Narrowest set first: only due jobs, in execute_at order,\n        -- bounded by a small overscan of the poll limit.\n        -- idx_job_executions_pending_job_type_execute_at serves this as\n        -- an ordered index scan; future-scheduled jobs never reach the\n        -- anti-join / window-function work below.\n        WITH limits AS (\n            -- One row per pollable type carrying how many rows this poll may\n            -- claim for it. For a batched type that is\n            -- `max_batch_size * free batch slots`, so no more rows are taken\n            -- than a batch is free to execute immediately; the rest of the\n            -- backlog stays unclaimed for other pollers and accumulates into\n            -- fuller later batches. Types with no free slot are absent from\n            -- $4 entirely and never reach `due`.\n            SELECT * FROM UNNEST($4::text[], $6::int4[]) AS l(job_type, row_limit)\n        ),\n        due AS (\n            SELECT id, queue_id, execute_at, job_type\n            FROM job_executions\n            WHERE state = 'pending'\n            AND job_type = ANY($4)\n            AND execute_at <= $2::timestamptz\n            ORDER BY execute_at\n            LIMIT $1 * 4\n        ),\n        candidates AS (\n            -- The 1-at-a-time-per-queue anti-join and the queue-dedup\n            -- window run only over the bounded due set instead of every\n            -- pending row.\n            SELECT id, execute_at, job_type,\n                   ROW_NUMBER() OVER (\n                       PARTITION BY COALESCE(queue_id, id::text)\n                       ORDER BY execute_at\n                   ) AS rn\n            FROM due\n            WHERE NOT EXISTS (\n                SELECT 1 FROM job_executions AS running\n                WHERE running.state = 'running'\n                AND running.queue_id IS NOT NULL\n                AND running.queue_id = due.queue_id\n            )\n        ),\n        locked AS (\n            -- The wide execution_state_json is fetched only for the\n            -- ~$1 winners, not carried through the CTEs and the window\n            -- sort for every pending job.\n            --\n            -- Every queue-head is eligible here, deliberately: the per-type\n            -- cap is applied *after* this lock, never before it. Filtering to\n            -- each type's cap first would make every instance rank the same\n            -- global candidate set and target an identical head slice, so a\n            -- poller that lost the race would skip that whole slice and fall\n            -- through to nothing while due work sat unclaimed. SKIP LOCKED can\n            -- only route around a concurrent poller if there is something\n            -- past its rows left to see.\n            SELECT je.id, je.execution_state_json AS data_json, je.attempt_index,\n                   c.job_type, je.execute_at\n            FROM candidates c\n            JOIN job_executions je ON je.id = c.id\n            WHERE c.rn = 1\n            ORDER BY je.execute_at ASC\n            LIMIT $1\n            FOR UPDATE OF je SKIP LOCKED\n        ),\n        selected_jobs AS (\n            -- Enforce each type's cap on the rows this poller actually holds.\n            -- Rows over the cap are simply not claimed: they stay `pending`\n            -- and their lock is released when this short poll transaction\n            -- commits, so they remain visible to other instances and\n            -- accumulate into fuller later batches.\n            --\n            -- A type present in `limits` always has row_limit >= 1 (saturated\n            -- types are dropped from $4 entirely), so its first row always\n            -- survives — `selected_jobs` is never empty while `locked` isn't.\n            SELECT t.id, t.data_json, t.attempt_index\n            FROM (\n                SELECT l.*,\n                       ROW_NUMBER() OVER (\n                           PARTITION BY l.job_type ORDER BY l.execute_at\n                       ) AS type_rn\n                FROM locked l\n            ) t\n            JOIN limits lim ON lim.job_type = t.job_type\n            WHERE t.type_rn <= lim.row_limit\n        ),\n        updated AS (\n            -- queue_id rides along in the projection (it is already read by\n            -- `due`): batch formation needs it as the canonical ordering key,\n            -- and batched runners surface it per item.\n            UPDATE job_executions AS je\n            SET state = 'running', alive_at = $5, execute_at = NULL, poller_instance_id = $3\n            FROM selected_jobs\n            WHERE je.id = selected_jobs.id\n              AND je.state = 'pending'\n            RETURNING je.id, selected_jobs.data_json, je.attempt_index, je.queue_id\n        ),\n        min_wait AS (\n            -- Index-only scan over the pending partial index, no\n            -- anti-join. May wake slightly early when the nearest\n            -- future job is queue-blocked — one wasted wake-up at\n            -- worst, only while its queue stays busy.\n            SELECT MIN(execute_at) - $2::timestamptz AS wait_time\n            FROM job_executions\n            WHERE state = 'pending'\n            AND job_type = ANY($4)\n            AND execute_at > $2::timestamptz\n        )\n        SELECT * FROM (\n            SELECT\n                u.id AS \"id?: JobId\",\n                u.data_json AS \"data_json?: JsonValue\",\n                u.attempt_index AS \"attempt_index?\",\n                u.queue_id AS \"queue_id?\",\n                NULL::INTERVAL AS \"max_wait?: PgInterval\"\n            FROM updated u\n            UNION ALL\n            SELECT\n                NULL::UUID AS \"id?: JobId\",\n                NULL::JSONB AS \"data_json?: JsonValue\",\n                NULL::INT AS \"attempt_index?\",\n                NULL::VARCHAR AS \"queue_id?\",\n                mw.wait_time AS \"max_wait?: PgInterval\"\n            FROM min_wait mw\n            WHERE NOT EXISTS (SELECT 1 FROM updated)\n        ) AS result\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id?: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "data_json?: JsonValue",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempt_index?",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "queue_id?",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "max_wait?: PgInterval",
+        "type_info": "Interval"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Timestamptz",
+        "Uuid",
+        "TextArray",
+        "Timestamptz",
+        "Int4Array"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "8f352d7dfd354f0f7de531d1983f1b495a3d720ebc39238c5e8b2b982d185309"
+}

--- a/cala-ledger/.sqlx/query-932da1ca0fcd83172902956efaaa7dfed872f1aa8be8c117d0c1fbb02f4fa4aa.json
+++ b/cala-ledger/.sqlx/query-932da1ca0fcd83172902956efaaa7dfed872f1aa8be8c117d0c1fbb02f4fa4aa.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        UPDATE job_executions\n                        SET alive_at = $1\n                        WHERE poller_instance_id = $2\n                          AND state = 'running'\n                          AND id = ANY($3)\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "932da1ca0fcd83172902956efaaa7dfed872f1aa8be8c117d0c1fbb02f4fa4aa"
+}

--- a/cala-ledger/.sqlx/query-96551551b5b3cbb383f450ee4377202e4eee8cb286a9427e9ae575be986bbed6.json
+++ b/cala-ledger/.sqlx/query-96551551b5b3cbb383f450ee4377202e4eee8cb286a9427e9ae575be986bbed6.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE id = ANY($1)) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "96551551b5b3cbb383f450ee4377202e4eee8cb286a9427e9ae575be986bbed6"
+}

--- a/cala-ledger/.sqlx/query-9ab25bea85f68a606013136bf1d70be5173a6b992936215300ad0737c46bfeec.json
+++ b/cala-ledger/.sqlx/query-9ab25bea85f68a606013136bf1d70be5173a6b992936215300ad0737c46bfeec.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE job_executions\n                SET state = 'pending', execute_at = $2, attempt_index = $3, poller_instance_id = NULL\n                WHERE id = $1 AND poller_instance_id = $4\n              ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int4",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9ab25bea85f68a606013136bf1d70be5173a6b992936215300ad0737c46bfeec"
+}

--- a/cala-ledger/.sqlx/query-9dfde3af91c25ffd1500260f7be13a627e0493708352937e960710fd038bc93b.json
+++ b/cala-ledger/.sqlx/query-9dfde3af91c25ffd1500260f7be13a627e0493708352937e960710fd038bc93b.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS ((SELECT created_at, id FROM jobs WHERE ((created_at, id) > ($3, $2)) AND ($2 IS NOT NULL) ORDER BY created_at ASC, id ASC LIMIT $1) UNION ALL (SELECT created_at, id FROM jobs WHERE ($2 IS NULL) ORDER BY created_at ASC, id ASC LIMIT $1) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "9dfde3af91c25ffd1500260f7be13a627e0493708352937e960710fd038bc93b"
+}

--- a/cala-ledger/.sqlx/query-9fe15942e7a33e1d163bcbb15911ef59fa764db26e161d1a16f3a56b82c62c83.json
+++ b/cala-ledger/.sqlx/query-9fe15942e7a33e1d163bcbb15911ef59fa764db26e161d1a16f3a56b82c62c83.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE job_type = $1 AND unique_per_type = TRUE) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "9fe15942e7a33e1d163bcbb15911ef59fa764db26e161d1a16f3a56b82c62c83"
+}

--- a/cala-ledger/.sqlx/query-b6947548f9642e663dfa4e1945352a53d9d6400a9d31df017c39934f4edc690c.json
+++ b/cala-ledger/.sqlx/query-b6947548f9642e663dfa4e1945352a53d9d6400a9d31df017c39934f4edc690c.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE id = $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "b6947548f9642e663dfa4e1945352a53d9d6400a9d31df017c39934f4edc690c"
+}

--- a/cala-ledger/.sqlx/query-caf6d17dfbae985a68af1173d30222d220079e05ec0f33854a8f7c2dfeab75a1.json
+++ b/cala-ledger/.sqlx/query-caf6d17dfbae985a68af1173d30222d220079e05ec0f33854a8f7c2dfeab75a1.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        SELECT\n                            job_type,\n                            COUNT(*)::INT4 AS \"count!: i32\",\n                            EXTRACT(EPOCH FROM ($1::timestamptz - MIN(execute_at)))::FLOAT8\n                                AS \"max_pending_duration_secs!: f64\"\n                        FROM job_executions\n                        WHERE state = 'pending'\n                        AND execute_at <= $1::timestamptz\n                        AND job_type = ANY($2)\n                        GROUP BY job_type\n                        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "job_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "count!: i32",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "max_pending_duration_secs!: f64",
+        "type_info": "Float8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "caf6d17dfbae985a68af1173d30222d220079e05ec0f33854a8f7c2dfeab75a1"
+}

--- a/cala-ledger/.sqlx/query-da784a4b6e5dc9736e8ea219951cd3941a6a978efdd3a9825473500f7b881dfd.json
+++ b/cala-ledger/.sqlx/query-da784a4b6e5dc9736e8ea219951cd3941a6a978efdd3a9825473500f7b881dfd.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM jobs WHERE unique_per_type = $1) SELECT i.id AS \"entity_id!: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at, NULL::jsonb as \"forgettable_payload?\" FROM entities i JOIN job_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id!: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "forgettable_payload?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false,
+      null
+    ]
+  },
+  "hash": "da784a4b6e5dc9736e8ea219951cd3941a6a978efdd3a9825473500f7b881dfd"
+}

--- a/cala-ledger/.sqlx/query-e666d2e28c76cab9ed701d49d72646ee304f6574e4749f2f1878947b89ce6ae3.json
+++ b/cala-ledger/.sqlx/query-e666d2e28c76cab9ed701d49d72646ee304f6574e4749f2f1878947b89ce6ae3.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          UPDATE job_executions\n          SET execution_state_json = $1\n          WHERE id = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e666d2e28c76cab9ed701d49d72646ee304f6574e4749f2f1878947b89ce6ae3"
+}

--- a/cala-ledger/.sqlx/query-e67fb92be8782f30d872b37b7a8efdaae473009d3dc398aacff73a58eb0e0ad7.json
+++ b/cala-ledger/.sqlx/query-e67fb92be8782f30d872b37b7a8efdaae473009d3dc398aacff73a58eb0e0ad7.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n          UPDATE job_executions\n          SET state = 'pending', execute_at = $2, attempt_index = 1, poller_instance_id = NULL\n          WHERE id = $1 AND poller_instance_id = $3\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e67fb92be8782f30d872b37b7a8efdaae473009d3dc398aacff73a58eb0e0ad7"
+}

--- a/cala-ledger/.sqlx/query-eb0894fb9b083139322efab13d30f0f5c957907007b9926b6d89e75a766d9a7a.json
+++ b/cala-ledger/.sqlx/query-eb0894fb9b083139322efab13d30f0f5c957907007b9926b6d89e75a766d9a7a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE job_executions\n        SET state = 'pending', execute_at = $3, attempt_index = attempt_index + 1, poller_instance_id = NULL\n        WHERE state = 'running'\n          AND alive_at < $1::timestamptz\n          AND job_type = ANY($2)\n          AND (poller_instance_id IS DISTINCT FROM $4 OR id <> ALL($5))\n        RETURNING id AS \"id!: JobId\", job_type AS \"job_type!: JobType\"\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: JobId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "job_type!: JobType",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Timestamptz",
+        "TextArray",
+        "Timestamptz",
+        "Uuid",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "eb0894fb9b083139322efab13d30f0f5c957907007b9926b6d89e75a766d9a7a"
+}

--- a/cala-ledger/migrations/20250904065521_job_setup.sql
+++ b/cala-ledger/migrations/20250904065521_job_setup.sql
@@ -2,11 +2,10 @@ CREATE TABLE jobs (
   id UUID PRIMARY KEY,
   unique_per_type BOOLEAN NOT NULL,
   job_type VARCHAR NOT NULL,
-  parent_job_id UUID REFERENCES jobs(id),
+  queue_id VARCHAR,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 CREATE UNIQUE INDEX idx_unique_job_type ON jobs (job_type) WHERE unique_per_type = TRUE;
-CREATE INDEX idx_jobs_parent_job_id ON jobs (parent_job_id);
 
 CREATE TABLE job_events (
   id UUID NOT NULL REFERENCES jobs(id),

--- a/cala-ledger/src/ec_rollup.rs
+++ b/cala-ledger/src/ec_rollup.rs
@@ -48,9 +48,12 @@ use chrono::{DateTime, NaiveDate, Utc};
 use std::collections::{HashMap, HashSet};
 
 use job::{JobType, Jobs};
-use obix::out::{
-    EventCtx, EventSubscription, FlushOp, Handled, OutboxEventHandler, OutboxEventJobConfig,
-    PersistentOutboxEvent,
+use obix::{
+    out::{
+        EventCtx, EventSubscription, FlushOp, Handled, HandlerStreamStatus, OutboxEventHandler,
+        OutboxEventJobConfig, PersistentOutboxEvent, RegisteredEventHandler,
+    },
+    EventSequence,
 };
 
 use cala_types::entry::EntryValues;
@@ -58,7 +61,8 @@ use cala_types::entry::EntryValues;
 use crate::{
     balance::{Balances, EcRollupTxn},
     entry::{Entries, Entry},
-    outbox::{ObixOutbox, OutboxEventPayload},
+    ledger::error::LedgerError,
+    outbox::{CalaMailboxTables, ObixOutbox, OutboxEventPayload},
     primitives::{EntryId, JournalId, TransactionId},
 };
 
@@ -73,14 +77,15 @@ const MAX_EVENTS_PER_BATCH: usize = 1_000;
 /// Register the streaming EC-balance rollup and spawn its single instance.
 ///
 /// Must be called **before** [`Jobs::start_poll`] (`add_initializer`
-/// panics once polling has started). Idempotent via `spawn_unique`.
+/// panics once polling has started). Idempotent via `spawn_unique`. The
+/// returned handle is the ledger's observation point on the rollup.
 pub(crate) async fn register_ec_balance_rollup(
     jobs: &mut Jobs,
     outbox: &ObixOutbox,
     balances: &Balances,
     entries: &Entries,
-) -> Result<(), crate::ledger::error::LedgerError> {
-    outbox
+) -> Result<RegisteredEventHandler<OutboxEventPayload, CalaMailboxTables>, LedgerError> {
+    Ok(outbox
         .register_event_handler(
             jobs,
             OutboxEventJobConfig::new(EC_BALANCE_ROLLUP_JOB)
@@ -90,8 +95,7 @@ pub(crate) async fn register_ec_balance_rollup(
                 entries: entries.clone(),
             },
         )
-        .await
-        .map_err(crate::ledger::error::LedgerError::EcRollupRegistration)
+        .await?)
 }
 
 /// A transaction pulled from a `TransactionCreated` event, carrying just
@@ -293,3 +297,78 @@ mod __fuzz {
 
 #[cfg(feature = "fuzz")]
 pub use __fuzz::fuzz_batch;
+
+/// A snapshot of the rollup's position. Every outbox event with sequence ≤
+/// `applied` is folded into EC balances (settled and effective) and
+/// committed.
+///
+/// `frontier` is pinned at construction. [`refresh`](Self::refresh) advances
+/// `applied` against that same fence, so [`lag`](Self::lag) drains toward it
+/// instead of chasing a frontier that new postings keep moving.
+#[derive(Debug, Clone)]
+pub struct EcRollupStatus {
+    /// The rollup job's committed checkpoint.
+    pub applied: EventSequence,
+    /// The outbox frontier pinned when this snapshot was taken.
+    pub frontier: EventSequence,
+    handle: RegisteredEventHandler<OutboxEventPayload, CalaMailboxTables>,
+}
+
+impl EcRollupStatus {
+    pub(crate) fn new(
+        status: HandlerStreamStatus,
+        handle: RegisteredEventHandler<OutboxEventPayload, CalaMailboxTables>,
+    ) -> Self {
+        Self {
+            applied: status.checkpoint,
+            frontier: status.frontier,
+            handle,
+        }
+    }
+
+    /// Re-read the committed checkpoint, keeping the pinned `frontier`, so
+    /// repeated calls watch the lag drain toward the fence this snapshot
+    /// captured.
+    pub async fn refresh(&mut self) -> Result<(), LedgerError> {
+        self.applied = self.handle.load().await?.checkpoint();
+        Ok(())
+    }
+
+    /// Await the rollup applying everything up to this snapshot's pinned
+    /// `frontier`.
+    ///
+    /// On `Ok(())` every posting that had been assigned an outbox sequence
+    /// when the snapshot was taken — committed or still in flight — is folded
+    /// into EC balances (settled and effective) and visible to subsequent
+    /// reads.
+    ///
+    /// This is what makes `close_books(); ec_rollup_status().await?
+    /// .await_completion(..)` free of straggler holes: sequences are assigned
+    /// at entry insert, *before* velocity enforcement, so anything that saw
+    /// the period as open sits at or below the pinned frontier, and gapless
+    /// delivery means the wait covers each one. The checkpoint only *trails*
+    /// the applied state, so the fence never returns early.
+    ///
+    /// The fence does not move: unlike re-reading status, the frontier stays
+    /// where the snapshot pinned it, so a rollup publishing `BalanceUpdated`
+    /// events as it drains cannot extend its own barrier.
+    ///
+    /// `timeout` is mandatory: a wedged rollup surfaces as
+    /// [`LedgerError::EcCaughtUpTimeout`], never a silent hang.
+    pub async fn await_completion(&self, timeout: std::time::Duration) -> Result<(), LedgerError> {
+        self.handle.await_sequence(self.frontier, timeout).await?;
+        Ok(())
+    }
+
+    /// Outbox positions the rollup has yet to consume — the stream-lag SLO
+    /// metric. Counts the `BalanceUpdated` events the rollup publishes
+    /// itself and later crosses as skips, so a healthy stream can report a
+    /// small nonzero lag; alert on lag that is large or not shrinking.
+    pub fn lag(&self) -> u64 {
+        u64::from(self.frontier).saturating_sub(u64::from(self.applied))
+    }
+
+    pub fn is_caught_up(&self) -> bool {
+        self.applied >= self.frontier
+    }
+}

--- a/cala-ledger/src/ec_rollup.rs
+++ b/cala-ledger/src/ec_rollup.rs
@@ -329,8 +329,19 @@ impl EcRollupStatus {
     /// Re-read the committed checkpoint, keeping the pinned `frontier`, so
     /// repeated calls watch the lag drain toward the fence this snapshot
     /// captured.
+    #[tracing::instrument(
+        level = "debug",
+        name = "cala_ledger.ec_rollup_status.refresh",
+        skip_all,
+        fields(frontier = %self.frontier, applied, lag)
+    )]
     pub async fn refresh(&mut self) -> Result<(), LedgerError> {
         self.applied = self.handle.load().await?.checkpoint();
+
+        let span = tracing::Span::current();
+        span.record("applied", u64::from(self.applied));
+        span.record("lag", self.lag());
+
         Ok(())
     }
 

--- a/cala-ledger/src/ledger/error.rs
+++ b/cala-ledger/src/ledger/error.rs
@@ -37,7 +37,18 @@ pub enum LedgerError {
     #[error("LedgerError - PostingError: {0}")]
     PostingError(#[from] PostingError),
     #[error("LedgerError - EcRollupRegistration: {0}")]
-    EcRollupRegistration(Box<dyn std::error::Error + Send + Sync>),
+    EcRollupRegistration(#[from] Box<dyn std::error::Error + Send + Sync>),
+    #[error("LedgerError - EcRollupCheckpoint: {0}")]
+    EcRollupCheckpoint(obix::out::HandlerCheckpointError),
+    #[error(
+        "LedgerError - EcCaughtUpTimeout: EC rollup checkpoint {applied} had not reached the \
+         outbox frontier {frontier} after waiting {waited:?}"
+    )]
+    EcCaughtUpTimeout {
+        applied: obix::EventSequence,
+        frontier: obix::EventSequence,
+        waited: std::time::Duration,
+    },
     #[error(
         "LedgerError - EntryTargetsAccountSet: an entry may not be posted directly to an \
          account-set backing account; an account set's balance is derived from its members"
@@ -52,6 +63,26 @@ impl From<EntryError> for LedgerError {
             // callers don't have to dig through the entry-error nesting.
             EntryError::EntryTargetsAccountSet => Self::EntryTargetsAccountSet,
             other => Self::EntryError(other),
+        }
+    }
+}
+
+/// Manual, not `#[from]`: the timeout case is remapped so callers
+/// destructure ledger vocabulary (`applied`) rather than obix's
+/// (`checkpoint`). Everything else passes through.
+impl From<obix::out::HandlerCheckpointError> for LedgerError {
+    fn from(e: obix::out::HandlerCheckpointError) -> Self {
+        match e {
+            obix::out::HandlerCheckpointError::CaughtUpTimeout {
+                checkpoint,
+                target,
+                waited,
+            } => Self::EcCaughtUpTimeout {
+                applied: checkpoint,
+                frontier: target,
+                waited,
+            },
+            other => Self::EcRollupCheckpoint(other),
         }
     }
 }

--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -272,13 +272,48 @@ impl CalaLedger {
     /// as a stream-lag SLO metric, or block on the fence with
     /// [`await_completion`](crate::EcRollupStatus::await_completion). Works
     /// from any node (both sides are read from the database).
-    #[instrument(level = "debug", name = "cala_ledger.ec_rollup_status", skip_all)]
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.ec_rollup_status",
+        skip_all,
+        fields(applied, frontier, lag)
+    )]
     pub async fn ec_rollup_status(&self) -> Result<crate::EcRollupStatus, LedgerError> {
         let snapshot = self.ec_rollup.load().await?;
-        Ok(crate::EcRollupStatus::new(
-            snapshot.stream_status(),
-            self.ec_rollup.clone(),
-        ))
+        let status = crate::EcRollupStatus::new(snapshot.stream_status(), self.ec_rollup.clone());
+
+        let span = tracing::Span::current();
+        span.record("applied", u64::from(status.applied));
+        span.record("frontier", u64::from(status.frontier));
+        span.record("lag", status.lag());
+
+        Ok(status)
+    }
+
+    /// Await the rollup applying through `frontier` — an outbox sequence
+    /// obtained some other way than the snapshot this call is on, e.g. a
+    /// [`EcRollupStatus::frontier`](crate::EcRollupStatus) read earlier and
+    /// carried across a boundary the snapshot itself can't cross (stored,
+    /// passed to another task, awaited from a different call site than the
+    /// one that captured it).
+    ///
+    /// Unlike [`EcRollupStatus::await_completion`](crate::EcRollupStatus::await_completion),
+    /// which is bound to the fence its own snapshot pinned, this takes any
+    /// `frontier` value directly — the ledger itself is the only handle you
+    /// need to hold onto. Prefer `await_completion` when the snapshot that
+    /// pinned the fence is still in scope; reach for this when only the
+    /// sequence survived.
+    ///
+    /// `timeout` is mandatory: a wedged rollup surfaces as
+    /// [`LedgerError::EcCaughtUpTimeout`], never a silent hang.
+    #[instrument(level = "debug", name = "cala_ledger.await_frontier", skip(self), fields(timeout = ?timeout))]
+    pub async fn await_frontier(
+        &self,
+        frontier: obix::EventSequence,
+        timeout: std::time::Duration,
+    ) -> Result<(), LedgerError> {
+        self.ec_rollup.await_sequence(frontier, timeout).await?;
+        Ok(())
     }
 
     pub fn outbox(&self) -> &crate::outbox::ObixOutbox {

--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -37,6 +37,10 @@ pub struct CalaLedger {
     balances: Balances,
     postings: Postings,
     publisher: OutboxPublisher,
+    ec_rollup: obix::out::RegisteredEventHandler<
+        crate::outbox::OutboxEventPayload,
+        crate::outbox::CalaMailboxTables,
+    >,
 }
 
 impl CalaLedger {
@@ -88,10 +92,16 @@ impl CalaLedger {
             &velocities,
         );
 
-        crate::ec_rollup::register_ec_balance_rollup(jobs, publisher.inner(), &balances, &entries)
-            .await?;
+        let ec_rollup = crate::ec_rollup::register_ec_balance_rollup(
+            jobs,
+            publisher.inner(),
+            &balances,
+            &entries,
+        )
+        .await?;
 
         Ok(Self {
+            ec_rollup,
             accounts,
             account_sets,
             postings,
@@ -255,6 +265,20 @@ impl CalaLedger {
         batch: Vec<PostingInput>,
     ) -> Result<Vec<Transaction>, LedgerError> {
         Ok(self.postings.post_all_in_op(db, batch).await?)
+    }
+
+    /// Snapshot the rollup's position, pinning the outbox frontier as a
+    /// fence. Cheap and read-only — poll [`lag`](crate::EcRollupStatus::lag)
+    /// as a stream-lag SLO metric, or block on the fence with
+    /// [`await_completion`](crate::EcRollupStatus::await_completion). Works
+    /// from any node (both sides are read from the database).
+    #[instrument(level = "debug", name = "cala_ledger.ec_rollup_status", skip_all)]
+    pub async fn ec_rollup_status(&self) -> Result<crate::EcRollupStatus, LedgerError> {
+        let snapshot = self.ec_rollup.load().await?;
+        Ok(crate::EcRollupStatus::new(
+            snapshot.stream_status(),
+            self.ec_rollup.clone(),
+        ))
     }
 
     pub fn outbox(&self) -> &crate::outbox::ObixOutbox {

--- a/cala-ledger/src/lib.rs
+++ b/cala-ledger/src/lib.rs
@@ -158,6 +158,7 @@ pub use job;
 mod ledger;
 pub mod outbox;
 
+pub use ec_rollup::EcRollupStatus;
 pub use ledger::*;
 
 pub mod primitives {

--- a/cala-ledger/tests/ec_streaming_rollup.rs
+++ b/cala-ledger/tests/ec_streaming_rollup.rs
@@ -815,3 +815,104 @@ async fn await_completion_times_out_when_rollup_is_stalled() -> anyhow::Result<(
     }
     Ok(())
 }
+
+/// `await_frontier` targets a caller-supplied sequence directly, rather
+/// than sampling the frontier at call time like `EcRollupStatus` does. The
+/// value can be captured once and carried across a boundary the pinned
+/// snapshot itself can't cross — stored, passed to another task, awaited
+/// later — since only the plain `EventSequence` survives, not the
+/// `EcRollupStatus` (and its handle) that produced it.
+#[tokio::test]
+async fn await_frontier_waits_for_a_previously_captured_sequence() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool, helpers::test_journal_with_effective_balances()).await?;
+
+    let ec_set = create_ec_set(
+        &fixture.cala,
+        fixture.journal_id,
+        "captured-frontier EC set",
+    )
+    .await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_posts = 8;
+    post_round_robin(&fixture, n_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    // Capture just the plain sequence value — the `EcRollupStatus` that
+    // read it is dropped immediately, proving it isn't needed again.
+    let frontier = fixture.cala.ec_rollup_status().await?.frontier;
+
+    jobs.start_poll().await?;
+    fixture
+        .cala
+        .await_frontier(frontier, std::time::Duration::from_secs(60))
+        .await?;
+
+    let bal = fixture
+        .cala
+        .balances()
+        .find(fixture.journal_id, ec_set.id(), usd)
+        .await?;
+    assert_eq!(
+        bal.settled(),
+        expected,
+        "EC set balance must be complete once the captured frontier is reached",
+    );
+    assert_member_sum(&fixture, usd, expected).await?;
+    Ok(())
+}
+
+/// A target beyond anything the outbox has assigned can never be
+/// satisfied — unlike `await_completion`'s call-time frontier, which is
+/// always reachable once applied. The timeout error must report the exact
+/// sequence requested, not a resampled "current" frontier, which is the
+/// property that distinguishes `await_frontier` from the snapshot-bound
+/// wait.
+#[tokio::test]
+async fn await_frontier_times_out_for_a_sequence_beyond_the_stream() -> anyhow::Result<()> {
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool, helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(
+        &fixture.cala,
+        fixture.journal_id,
+        "unreachable-frontier EC set",
+    )
+    .await?;
+    fixture
+        .cala
+        .account_sets()
+        .add_member(ec_set.id(), fixture.members[0].id())
+        .await?;
+    post_to(&fixture, fixture.members[0].id(), 3).await?;
+    jobs.start_poll().await?;
+
+    let current = fixture.cala.ec_rollup_status().await?.frontier;
+    let unreachable = obix::EventSequence::from(u64::from(current) + 1_000);
+
+    let timeout = std::time::Duration::from_millis(300);
+    match fixture.cala.await_frontier(unreachable, timeout).await {
+        Err(LedgerError::EcCaughtUpTimeout {
+            frontier, waited, ..
+        }) => {
+            assert_eq!(
+                frontier, unreachable,
+                "error must report the exact target requested, not a resampled frontier",
+            );
+            assert!(
+                waited >= timeout,
+                "error must report the full wait, got {waited:?}",
+            );
+        }
+        other => panic!("expected EcCaughtUpTimeout, got {other:?}"),
+    }
+    Ok(())
+}

--- a/cala-ledger/tests/ec_streaming_rollup.rs
+++ b/cala-ledger/tests/ec_streaming_rollup.rs
@@ -651,3 +651,167 @@ async fn synchronous_plain_account_is_readable_immediately() -> anyhow::Result<(
     assert_eq!(bal.settled(), expected);
     Ok(())
 }
+
+/// The caught-up barrier: after `await_completion` returns `Ok`, every
+/// transaction committed before the snapshot was taken is folded into EC
+/// balances — settled *and* cumulative-effective (same commit) — and
+/// readable immediately, with **no** further polling. A second fence after
+/// more posts renews the guarantee (the semantics are self-renewing, not
+/// one-shot).
+#[tokio::test]
+async fn await_completion_fences_backlog_and_renews() -> anyhow::Result<()> {
+    let usd: Currency = "USD".parse().unwrap();
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, mut jobs) = setup(pool, helpers::test_journal_with_effective_balances()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "barrier EC set").await?;
+    for m in &fixture.members {
+        fixture
+            .cala
+            .account_sets()
+            .add_member(ec_set.id(), m.id())
+            .await?;
+    }
+
+    let n_posts = 12;
+    post_round_robin(&fixture, n_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts);
+
+    // Poller not started: the status snapshot must report honest lag.
+    let status = fixture.cala.ec_rollup_status().await?;
+    assert!(
+        !status.is_caught_up() && status.lag() > 0,
+        "rollup must lag behind a posted backlog before the poller runs, got {status:?}",
+    );
+
+    // The fence pinned above, before the poller existed, is the one awaited:
+    // the frontier does not move under the wait.
+    jobs.start_poll().await?;
+    status
+        .await_completion(std::time::Duration::from_secs(60))
+        .await?;
+
+    // The ordering guarantee: read EC balances *immediately* — no
+    // wait_for_settled polling.
+    let bal = fixture
+        .cala
+        .balances()
+        .find(fixture.journal_id, ec_set.id(), usd)
+        .await?;
+    assert_eq!(
+        bal.settled(),
+        expected,
+        "EC set balance must be complete immediately after the fence",
+    );
+    let today = fixture.cala.clock().now().date_naive();
+    let effective = fixture
+        .cala
+        .balances()
+        .effective()
+        .find_cumulative(fixture.journal_id, ec_set.id(), usd, today)
+        .await?;
+    assert_eq!(
+        effective.settled(),
+        expected,
+        "cumulative-effective EC balance must be complete immediately after the fence",
+    );
+    assert_member_sum(&fixture, usd, expected).await?;
+
+    // The rollup's own applies published `BalanceUpdated` events *behind*
+    // the fence's frontier snapshot, so a status taken right after the
+    // fence may transiently report lag (a skip-only tail the checkpoint
+    // crosses lazily). A second fence drains it; with no further activity
+    // the status is then stably caught up.
+    fixture
+        .cala
+        .ec_rollup_status()
+        .await?
+        .await_completion(std::time::Duration::from_secs(60))
+        .await?;
+    assert!(
+        fixture.cala.ec_rollup_status().await?.is_caught_up(),
+        "status must report caught-up once the self-published tail is drained",
+    );
+
+    // Self-renewing: a second backlog + second fence must again be fully
+    // reflected on return.
+    let more_posts = 5;
+    post_round_robin(&fixture, more_posts).await?;
+    let expected = POST_AMOUNT * Decimal::from(n_posts + more_posts);
+    fixture
+        .cala
+        .ec_rollup_status()
+        .await?
+        .await_completion(std::time::Duration::from_secs(60))
+        .await?;
+    let bal = fixture
+        .cala
+        .balances()
+        .find(fixture.journal_id, ec_set.id(), usd)
+        .await?;
+    assert_eq!(
+        bal.settled(),
+        expected,
+        "second fence must reflect the second backlog immediately",
+    );
+    Ok(())
+}
+
+/// A stopped (or wedged) rollup must surface as a rich, alertable
+/// [`LedgerError::EcCaughtUpTimeout`] — never a silent hang. The error
+/// carries the observed checkpoint and frontier so an operator can see
+/// exactly how far behind the stream is.
+#[tokio::test]
+async fn await_completion_times_out_when_rollup_is_stalled() -> anyhow::Result<()> {
+    let pool = helpers::init_isolated_pool().await?;
+    let (fixture, _jobs) = setup(pool, helpers::test_journal()).await?;
+
+    let ec_set = create_ec_set(&fixture.cala, fixture.journal_id, "stalled EC set").await?;
+    fixture
+        .cala
+        .account_sets()
+        .add_member(ec_set.id(), fixture.members[0].id())
+        .await?;
+    post_to(&fixture, fixture.members[0].id(), 3).await?;
+
+    // Poller never started. A zero timeout still runs one check and
+    // errors immediately.
+    match fixture
+        .cala
+        .ec_rollup_status()
+        .await?
+        .await_completion(std::time::Duration::ZERO)
+        .await
+    {
+        Err(LedgerError::EcCaughtUpTimeout {
+            applied, frontier, ..
+        }) => {
+            assert_eq!(
+                u64::from(applied),
+                0,
+                "a never-run rollup reports checkpoint BEGIN",
+            );
+            assert!(applied < frontier, "frontier must be ahead of checkpoint");
+        }
+        other => panic!("expected EcCaughtUpTimeout, got {other:?}"),
+    }
+
+    // A nonzero timeout polls with backoff and reports how long it waited.
+    let timeout = std::time::Duration::from_millis(400);
+    match fixture
+        .cala
+        .ec_rollup_status()
+        .await?
+        .await_completion(timeout)
+        .await
+    {
+        Err(LedgerError::EcCaughtUpTimeout { waited, .. }) => {
+            assert!(
+                waited >= timeout,
+                "error must report the full wait, got {waited:?}",
+            );
+        }
+        other => panic!("expected EcCaughtUpTimeout, got {other:?}"),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The EC rollup caught-up barrier from
[`cala-dev/design-ec-caught-up-barrier.md`](https://github.com/GaloyMoney/drua-library/blob/main/spaces/cala-dev/design-ec-caught-up-barrier.md),
reworked per
[`cala-dev/impl-pr-ec-barrier-handle-rework.md`](https://github.com/GaloyMoney/drua-library/blob/main/spaces/cala-dev/impl-pr-ec-barrier-handle-rework.md)
to delegate to obix's `RegisteredEventHandler` (obix
[#126](https://github.com/GaloyMoney/obix/pull/126), over job
[#153](https://github.com/GaloyMoney/job/pull/153)) instead of an ad-hoc
`SELECT execution_state_json FROM job_executions` and a hand-rolled poll
loop. cala no longer reads job's tables at all.

With the EOD recalc phase deleted (#811) and EC balances (sets #811 +
plain accounts #813) maintained by the streaming rollup, callers had no
way to assert "the stream has consumed everything relevant" before
closing a period or generating reports from EC balances. This closes
that gap.

## API

`ec_rollup_status()` hands back a snapshot pinned to the outbox frontier
at read time, which you can poll cheaply or block on:

```rust
pub async fn ec_rollup_status(&self) -> Result<EcRollupStatus, LedgerError>;
```

```rust
let mut status = cala.ec_rollup_status().await?;

status.lag();                                   // stream-lag SLO metric
status.is_caught_up();                          // bool

status.refresh().await?;                        // re-read `applied`;
                                                  // `frontier` stays pinned,
                                                  // so lag() drains toward
                                                  // the fence you captured

status.await_completion(Duration::from_secs(300)).await?;
// Err(EcCaughtUpTimeout { applied, frontier, waited }) — alertable,
// never a silent hang
```

On `Ok(())` from `await_completion`: every transaction committed before
the snapshot was taken — and every posting that had already been
assigned an outbox sequence, committed or still in flight — is folded
into EC balances (settled **and** effective, same commit) and visible to
subsequent reads. The close-books straggler argument (outbox sequences
assigned before velocity enforcement + gapless delivery ⇒ the
argument-less fence is sufficient) is documented on the method.

`await_completion` is bound to the snapshot that pinned its fence —
convenient when that snapshot stays in scope for the whole wait. When
only the sequence survives — captured earlier, then carried across a
boundary the snapshot itself can't cross (stored, handed to another
task, awaited from a different call site than the one that read it) —
`CalaLedger::await_frontier` takes the bare value directly:

```rust
pub async fn await_frontier(
    &self,
    frontier: obix::EventSequence,
    timeout: Duration,
) -> Result<(), LedgerError>;
```

Intended lana usage, replacing the deleted EOD recalc phase — the simple
case, snapshot pinned and awaited in the same scope:

```rust
accounting.close_by_chart_root_account_set_as_of(..).await?;      // velocity metadata close
let status = ledger.ec_rollup_status().await?;                    // pin the fence
status.await_completion(Duration::from_secs(300)).await?;         // wait on it
generate_period_reports().await?;                                 // EC balances now complete
```

And the deferred case — the fence is pinned before other work runs, then
awaited later by value, with no snapshot object threaded through:

```rust
let frontier = ledger.ec_rollup_status().await?.frontier;         // pin the fence, keep only the sequence
accounting.close_by_chart_root_account_set_as_of(..).await?;      // other work runs in between
// ... possibly a different function, task, or persisted job payload ...
ledger.await_frontier(frontier, Duration::from_secs(300)).await?; // wait on the value alone
generate_period_reports().await?;
```

There is no `CalaLedger::await_ec_caught_up` — it would have been the
same wait with the frontier anchored internally, which became redundant
once a pinned fence could be blocked on both ways.

## Why a pinned frontier instead of a bare `await_ec_caught_up(timeout)`

The original design put the wait directly on `CalaLedger`, anchoring the
frontier at call time inside the method. Delegating that straight to
obix's `await_caught_up` would work for a one-shot wait, but the fence
would re-anchor on every retry — under load the frontier keeps moving,
so a caller polling status while waiting could never see the lag
provably converge to zero, and a target captured earlier couldn't be
carried anywhere and awaited later. Pinning the frontier at read time —
either inside `EcRollupStatus` (`refresh()`, `await_completion()`) or as
a bare `EventSequence` (`await_frontier`) — gives all three needs one
mechanism: cheap observation, a snapshot-bound wait, and a value-bound
wait that survives being carried elsewhere.

## Mechanics

`register_ec_balance_rollup` now returns the `RegisteredEventHandler`
obix hands back from `register_event_handler`, and `CalaLedger` holds
onto it. `ec_rollup_status()` is `handle.load().await?` translated into
ledger vocabulary (obix's `checkpoint` → cala's `applied`); both
`await_completion` and `await_frontier` are
`handle.await_sequence(target, timeout)` — the pinned snapshot's frontier
in one case, a caller-supplied value in the other. `await_sequence` was
added to obix at this PR's request specifically so a pinned target — not
just "the frontier as of right now" — could be awaited without cala
reimplementing the poll loop.

The DB polling happens inside obix, not cala: the rollup is
`spawn_unique` — it runs on one node cluster-wide while the caller (EOD
orchestrator, metrics poller) may be elsewhere — so observation has to
go through the database either way.

`ec_rollup_status()` and `EcRollupStatus::refresh()` record
`applied`/`frontier`/`lag` onto their OTel spans, so both the initial
load and every subsequent poll carry the rollup's position without a log
line.

## Tests (live-PG, isolated DB per test, in `ec_streaming_rollup.rs`)

- `await_completion_fences_backlog_and_renews` — pins a fence before the
  poller even starts, confirms honest lag beforehand, then awaits that
  exact snapshot once polling begins: backlog → fence → EC set balance
  (settled **and** cumulative-effective) readable at the exact expected
  value *immediately*, no further polling. A second backlog + second
  fence renews the guarantee (self-renewing, not one-shot); status
  reports caught-up once the rollup's self-published `BalanceUpdated`
  tail is drained.
- `await_completion_times_out_when_rollup_is_stalled` — poller never
  started: zero timeout errors immediately with `applied = BEGIN <
  frontier`; nonzero timeout polls with backoff and reports the full
  wait.
- `await_frontier_waits_for_a_previously_captured_sequence` — the
  captured `EventSequence` is carried past the `EcRollupStatus` that read
  it (dropped immediately) and awaited later via the ledger alone;
  balances are complete once the target is reached.
- `await_frontier_times_out_for_a_sequence_beyond_the_stream` — a target
  manufactured beyond anything the outbox has assigned
  (`EventSequence::from(u64)`) times out reporting *that exact requested
  sequence*, not a resampled "current" frontier — the property that
  distinguishes this from the snapshot-bound wait.

One semantic worth naming (surfaced by the tests): applying the awaited
batches publishes `BalanceUpdated` events *behind* the fence's frontier
snapshot, so a status snapshot taken right after `Ok(())` may transiently
report a small lag (a skip-only tail the checkpoint crosses lazily).
Documented on `EcRollupStatus::lag` — alert on lag that is large or not
shrinking, not on `!= 0`.

## Dependencies

`job` 0.9.1, `obix` 0.8.0, `es-entity` 0.12.7 — all released, all
resolved from the registry. No git dependencies. `nix flake check` is
clean (20/20, no exemption); it briefly needed one while this PR tracked
obix #126's unreleased branch (crane can't re-include `.sqlx` inside a
vendored git dependency), which cleared once #126 merged and released.

The vendored job DDL (`migrations/20250904065521_job_setup.sql`) is
byte-identical to job's released copy.

## Notes

- **Broader context**: perf-review roadmap memory `019fd1f5` (drua
  `cala-dev/analysis-locks-holistic-perf-review.md`).
- **Downstream consumers**: lana admin/EOD workflows that today poll
  balances ad hoc or race the rollup.
- **Semver**: additive minor — new public methods and type, new
  `LedgerError` variants, no behavior change to the rollup applier.
- `EcRollupRegistration` and the new `EcRollupCheckpoint` passthrough
  propagate via `#[from]`/`?`. No blanket `#[from]` on obix's
  `HandlerCheckpointError`: only its `CaughtUpTimeout` variant is
  remapped, so callers destructure ledger vocabulary (`applied`) rather
  than obix's (`checkpoint`).
- Not fixing (acknowledged): this PR edits an already-shipped migration
  in place rather than shipping an additive `ALTER` — Bugbot flagged the
  checksum/schema break for any DB that already migrated. Accepted since
  this environment isn't live yet (`make reset-deps` is the cheap path);
  the migration is re-verified byte-identical to job's actual **released**
  0.9.1 copy either way. Once this repo has real deployments, an in-place
  rewrite of a shipped migration should become the standing exception,
  not the default.
- Hands-off honored: no changes to attach-fence code (#816), class-1
  doctrine comments, or `balance/repo.rs`.
- `.sqlx` regenerated after `make reset-deps`.

## Verification

`nix flake check` (20/20) · 189/189 workspace tests (live PG) · barrier
and `await_frontier` tests stable 3×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core job polling and EC rollup checkpoint semantics used for EOD-style barriers; behavior is additive but timeouts and pinned-frontier semantics must be correct for period-close workflows.
> 
> **Overview**
> Adds a **caught-up barrier** so callers can assert the EC balance rollup has consumed the outbox through a known sequence before period close or EC-based reporting.
> 
> **`EcRollupStatus`** (from `ec_rollup_status()`) pins the outbox **frontier** at read time and exposes `applied`, `lag()`, `refresh()`, and **`await_completion(timeout)`**. On success, postings assigned at or below that fence are reflected in EC balances (settled and effective) without extra polling.
> 
> **`CalaLedger::await_frontier`** blocks on a caller-supplied `EventSequence` when only the sequence survives (not the snapshot handle). Stalled rollups return **`LedgerError::EcCaughtUpTimeout`** with `applied`, `frontier`, and `waited` instead of hanging.
> 
> Rollup registration now keeps obix’s **`RegisteredEventHandler`** on the ledger; observation goes through obix (`load` / `await_sequence`), not direct `job_executions` reads. Bumps **`job`** to 0.9.1 and **`obix`** to 0.8.0; job DDL drops `parent_job_id` and adds `queue_id`. Regenerated **`.sqlx`** for the new job queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aeca9768817f65611909bc48c905e708d6c31a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
