### PR TITLE
chore(deps): bump es-entity 0.12.0 → 0.12.2 + typed constraint detection (drops FK-name string comparison)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,9 +897,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eaffadefdf3b88dc6b00398313b2689bed1517bd0ed9cb2fa64761e8d7f2d70"
+checksum = "62dd39d5e6af1512de5211a3b6c8cef90c7daded8877d21c4248b57f401e3bcd"
 dependencies = [
  "async-stream",
  "chrono",
@@ -925,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58fe4c10966dffe8e62a4fd7def3806bdae30abf8cfdda5dde9f9918073a620"
+checksum = "9575dbf11a419964e542b899e8540b3e760ef0f6da0a6b494b81492cddb783e5"
 dependencies = [
  "convert_case",
  "darling 0.24.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ cala-types = { path = "cala-ledger-core-types", package = "cala-ledger-core-type
 cala-ledger = { path = "cala-ledger", version = "0.21.1-dev" }
 
 cel = "0.14.1"
-es-entity = "0.12.0"
+es-entity = "0.12.2"
 job = { version = "0.7.0", features = ["es-entity"] }
 obix = { version = "0.7.0", default-features = false }
 

--- a/cala-ledger/src/entry/error.rs
+++ b/cala-ledger/src/entry/error.rs
@@ -1,14 +1,8 @@
 use thiserror::Error;
 
-use super::repo::{EntryCreateError, EntryFindError, EntryModifyError, EntryQueryError};
-
-/// Composite FK forbidding a `cala_entries` row from targeting an
-/// account-set backing account (#802). Hand-written in the migrations,
-/// so es-entity's schema parsing does not model it — `ConstraintViolation`
-/// is generated for unique violations only; FK violations surface as the
-/// raw `Sqlx` error and are mapped to a domain variant by constraint
-/// name below, per the house pattern (cf. `AccountSetError::MemberAlreadyAdded`).
-const ENTRY_ACCOUNT_SET_FK: &str = "cala_entries_account_not_account_set_fkey";
+use super::repo::{
+    EntryConstraint, EntryCreateError, EntryFindError, EntryModifyError, EntryQueryError,
+};
 
 #[derive(Error, Debug)]
 pub enum EntryError {
@@ -29,32 +23,12 @@ pub enum EntryError {
     EntryTargetsAccountSet,
 }
 
-fn violates_entry_account_set_fk(e: &sqlx::Error) -> bool {
-    e.as_database_error().and_then(|db| db.constraint()) == Some(ENTRY_ACCOUNT_SET_FK)
-}
-
 impl From<EntryCreateError> for EntryError {
     fn from(error: EntryCreateError) -> Self {
-        match error {
-            // es-entity (as of 0.12) classifies only the entity's own
-            // recognized *unique* constraints as `ConstraintViolation`;
-            // any other constraint violation — this hand-written FK
-            // included — falls through as raw `Sqlx` (verified: the
-            // `rejects_direct_entry_to_account_set` test passes via this
-            // arm). That classification gap should be fixed upstream so
-            // every named-constraint violation surfaces as
-            // `ConstraintViolation { column: None, inner }`; the second
-            // arm already handles that shape so the mapping survives the
-            // upstream fix unchanged.
-            EntryCreateError::Sqlx(e) if violates_entry_account_set_fk(&e) => {
-                Self::EntryTargetsAccountSet
-            }
-            EntryCreateError::ConstraintViolation { inner, .. }
-                if violates_entry_account_set_fk(&inner) =>
-            {
-                Self::EntryTargetsAccountSet
-            }
-            other => Self::Create(other),
+        if error.violated_constraint() == Some(EntryConstraint::AccountNotAccountSetFkey) {
+            Self::EntryTargetsAccountSet
+        } else {
+            Self::Create(error)
         }
     }
 }


### PR DESCRIPTION
## What

Bumps es-entity `0.12.0 → 0.12.2` and adopts the new typed-constraint feature to remove the FK-name string comparison used to detect the #802 set-guard FK violation (`cala_entries → cala_accounts(id, is_account_set=const-false)`, introduced in #813, restructured by #816).

## Why

es-entity 0.12.2 ships [GaloyMoney/es-entity#184](https://github.com/GaloyMoney/es-entity/pull/184), which fixes the bug documented in the drua library space ([`es-entity-dev/bug-constraint-violation-unique-only.md`](https://raw.githubusercontent.com/GaloyMoney/drua-library/main/spaces/es-entity-dev/bug-constraint-violation-unique-only.md)): the generated repo error classifier only recognized unique violations (23505), so FK (23503) / CHECK (23514) violations fell through as raw `Sqlx` errors — forcing cala to string-match `constraint()` against `"cala_entries_account_not_account_set_fkey"` (defensively, in two arms, since #816).

With 0.12.2:
- FK/CHECK violations from generated ops classify as `ConstraintViolation`
- a typed `EntryConstraint` enum is derived from the migration catalog (zero annotations — the migrations directory is the source of truth)
- `violated_constraint()` on `EntryCreateError` dispatches without string literals; a constraint renamed in a future migration becomes a **compile error** instead of a silently dead match arm

## Change

All in `cala-ledger/src/entry/error.rs` (net −38/+12; rebased on top of #816, which had centralized the detection there):

- **removed** `ENTRY_ACCOUNT_SET_FK` const + `violates_entry_account_set_fk()` (`db.constraint()` compared against a string literal)
- **removed** the two defensive match arms in `From<EntryCreateError> for EntryError` (`Sqlx(e)` + `ConstraintViolation { inner, .. }`, each string-matching the constraint name)
- **replaced** with a single typed check: `error.violated_constraint() == Some(EntryConstraint::AccountNotAccountSetFkey)`

`EntryError::EntryTargetsAccountSet` and `LedgerError::EntryTargetsAccountSet` are **unchanged** in name and shape — downstream pattern-matches survive. `ledger/mod.rs` / `ledger/error.rs` are untouched relative to main (#816's `From`-chain routing stays as-is).

## Downstream ripple (flagged, not touched)

- es-entity 0.12.2 changes the error **shape** for FK/CHECK violations raised inside generated ops: `{Entity}CreateError::Sqlx(e)` → `ConstraintViolation { column: None, value: None, inner }`. obix / lana-bank arms matching `Sqlx(e)` for FK errors should be audited when they take the bump.
- `account_set/error.rs` (`MemberAlreadyAdded`) and `velocity/error.rs` (`LimitAlreadyAddedToControl`) string comparisons are raised via raw sqlx in repo code (not generated ops) → unaffected, left as-is per scope.
- `job 0.7.0` unifies cleanly on es-entity ^0.12 (single `es-entity` entry in `Cargo.lock`). No peer-dep bumps needed.
- No query text changed → no `.sqlx` regeneration needed.

## Verification (re-run after rebase onto `61aebdea`)

- `cargo fmt` ✓
- `git add -A && nix flake check` ✓ — all 14 checks passed (fmt / clippy `-D warnings` / deny / audit / offline nextest), es-entity 0.12.2 vendored
- Live PG (`make reset-deps`), pinned regression tests from #813:
  - `ec_streaming_rollup::rejects_direct_entry_to_account_set` **PASS** — typed detection still maps the set-guard FK to `LedgerError::EntryTargetsAccountSet`
  - `ec_streaming_rollup::missing_account_is_not_reported_as_account_set` **PASS** — plain `cala_entries_account_id_fkey` (missing account) still does *not* misreport as set-targeting
- Full live-PG suite: **124/124 passed**

Semver: minor — public `LedgerError` / `EntryError` APIs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency minor bump with localized error-mapping refactor; same domain error surface and regression tests cover the set-guard FK path.
> 
> **Overview**
> Bumps **es-entity** from `0.12.0` to `0.12.2` in the workspace and lockfile so FK/CHECK violations from generated repo ops classify as `ConstraintViolation` instead of raw `Sqlx` errors.
> 
> In `entry/error.rs`, the account-set guard mapping no longer compares `db.constraint()` against the string `cala_entries_account_not_account_set_fkey` (including the duplicate `Sqlx` and `ConstraintViolation` arms). **`From<EntryCreateError>`** now uses **`error.violated_constraint() == Some(EntryConstraint::AccountNotAccountSetFkey)`** to produce **`EntryError::EntryTargetsAccountSet`**. Public **`LedgerError`** / **`EntryError`** variants and downstream matches are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100a7f2391568bd6d0babcbe4bf775cfe253c96d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->