### PR TITLE
fix(cel-interpreter): compile CEL on a dedicated big-stack thread — root cause of lana-bank#8011 stack overflows

### DIFF
--- a/cala-cel-interpreter/src/interpreter.rs
+++ b/cala-cel-interpreter/src/interpreter.rs
@@ -5,18 +5,51 @@ use cel::Program;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
+/// Stack size for the dedicated CEL compilation thread.
+///
+/// The `cel` crate parses with an ANTLR-generated recursive-descent parser
+/// that carries no stack guard and consumes large amounts of stack in debug
+/// builds: ~350KiB for a trivial two-operator expression and >8MiB for
+/// expressions at its own grammar-recursion cap (96). 32MiB gives the worst
+/// accepted input a >2x margin. The reservation is virtual — only pages that
+/// are actually touched get committed.
+const COMPILE_STACK_BYTES: usize = 32 * 1024 * 1024;
+
 /// Globally memoized CEL program compilation.
 ///
 /// `CelExpression`s are frequently re-created from the same source string
 /// (e.g. velocity controls deserialized from the DB on every transaction),
 /// so compilation results are cached to avoid re-compiling the same
 /// expression multiple times.
+///
+/// Compilation runs on a dedicated thread with a fixed, known-large stack so
+/// that success never depends on how much stack the *caller* has left —
+/// compilation regularly runs on top of deep async state machines whose debug
+/// frames leave far less headroom than the parser needs (stack overflows in
+/// downstream debug tests; see GaloyMoney/lana-bank#8011). The spawn cost is
+/// paid once per unique expression thanks to the memoization above.
 #[cached(max_size = 10000, cache_err = true)]
 #[instrument(name = "cel.compile", skip(source), fields(expression = %source), err(level = tracing::Level::WARN))]
 fn compile_program(source: String) -> Result<Arc<Program>, String> {
-    Program::compile(&source)
-        .map(Arc::new)
-        .map_err(|e| e.to_string())
+    let started = std::time::Instant::now();
+    let expression = source.clone();
+    let result = std::thread::Builder::new()
+        .name("cel-compile".to_string())
+        .stack_size(COMPILE_STACK_BYTES)
+        .spawn(move || {
+            Program::compile(&source)
+                .map(Arc::new)
+                .map_err(|e| e.to_string())
+        })
+        .expect("failed to spawn cel-compile thread")
+        .join()
+        .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+    tracing::debug!(
+        expression = %expression,
+        elapsed = ?started.elapsed(),
+        "compiled CEL program on dedicated thread"
+    );
+    result
 }
 
 use crate::{context::*, error::*, value::*};

--- a/cala-cel-interpreter/tests/compile_stack.rs
+++ b/cala-cel-interpreter/tests/compile_stack.rs
@@ -1,0 +1,66 @@
+//! Regression tests: CEL compilation must not depend on the caller's stack.
+//!
+//! The `cel` crate parses with an ANTLR-generated recursive-descent parser
+//! whose debug-build frames are enormous: ~350KiB of stack for a trivial
+//! two-operator expression and >8MiB for expressions at its grammar-recursion
+//! cap (96). When compilation ran on the caller's thread it would overflow
+//! whenever the caller sat on top of deep async state machines (stack
+//! overflows in downstream debug tests — see GaloyMoney/lana-bank#8011, which
+//! papered over it with RUST_MIN_STACK=8388608).
+//!
+//! `CelExpression` now compiles on a dedicated thread with a known-large
+//! stack. These tests construct expressions from threads with tiny stacks —
+//! far smaller than the parser alone needs — to pin that independence: before
+//! the fix every one of them dies with SIGABRT (stack overflow).
+
+use cala_cel_interpreter::{CelContext, CelExpression, CelValue};
+
+const SMALL_CALLER_STACK: usize = 128 * 1024;
+
+fn on_small_stack<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    std::thread::Builder::new()
+        .stack_size(SMALL_CALLER_STACK)
+        .spawn(f)
+        .expect("spawn small-stack thread")
+        .join()
+        .expect("small-stack thread panicked")
+}
+
+#[test]
+fn compiles_realistic_velocity_expression_on_small_caller_stack() {
+    // A flat velocity-limit style condition: needs ~350KiB to parse in debug,
+    // i.e. it cannot possibly have parsed on this 128KiB thread.
+    on_small_stack(|| {
+        CelExpression::try_from(
+            "context.vars.entry.units > decimal('100') && context.vars.entry.currency == 'USD'",
+        )
+        .expect("realistic velocity expression must compile");
+    });
+}
+
+#[test]
+fn compiles_and_evaluates_deeply_nested_expression_on_small_caller_stack() {
+    // Depth 64 is accepted by cel's grammar-recursion cap (96) but needs
+    // >4MiB of parser stack in debug builds — more than lana-bank's 8MiB
+    // RUST_MIN_STACK workaround could guarantee as headroom.
+    on_small_stack(|| {
+        let source = format!("{}1{}", "(".repeat(64), ")".repeat(64));
+        let expression = CelExpression::try_from(source).expect("depth-64 nesting must compile");
+        let context = CelContext::new();
+        assert_eq!(
+            expression.evaluate(&context).expect("evaluate"),
+            CelValue::Int(1)
+        );
+    });
+}
+
+#[test]
+fn nesting_beyond_recursion_cap_errors_without_crashing() {
+    // Reaching the cap requires the parser to recurse to depth 96 first
+    // (>8MiB of stack in debug) before it reports the error — the caller's
+    // stack must not be what decides between Err and SIGABRT.
+    on_small_stack(|| {
+        let source = format!("{}1{}", "(".repeat(200), ")".repeat(200));
+        assert!(CelExpression::try_from(source).is_err());
+    });
+}


### PR DESCRIPTION
## Symptom

GaloyMoney/lana-bank#8011 (cala 0.21.1 → 0.22.0 lockstep bump): debug-build tests SIGABRT'd with stack overflow when CEL/velocity validation ran on default test threads. lana-bank #8011 added `RUST_MIN_STACK=8388608` to `.cargo/config.toml` as a symptom cover; this fix removes the dependence entirely and enables the workaround's removal in a follow-up.

## Root cause

`cala-cel-interpreter` compiles CEL synchronously on the **caller's** thread: `CelExpression::try_from → compile_program → cel::Program::compile`. Since the cel-rust swap (#718, shipped in 0.20.0), `cel` 0.14.1 parses with an **antlr4rust-generated recursive-descent parser** (`src/parser/gen/celparser.rs`, 6.7k lines) that has no stack guard and enormous debug-build frames (~16 machinery frames per grammar rule descent).

Measured (debug build, aarch64-darwin, compile on a thread of size N):

| input | overflows at | passes at |
|---|---|---|
| flat 2-operator velocity condition | ≤ 320 KiB | ≥ 384 KiB |
| depth-48 nesting (accepted by cel's recursion cap of 96) | 4 MiB | 8 MiB |
| cap-tripping input (depth 96 reached before `Err`) | 8 MiB | 16 MiB |

So a **trivial** velocity expression needs ~350 KiB of headroom just to parse. Velocity-limit validation (`NewBalanceLimitBuilder::build → validate_expression`) and entity hydration run this at the top of deep async state machines; cala 0.22's extra layers shrank the remaining headroom on lana's default 2 MiB test threads below that, and it tipped over. The `cel` crate itself was **unchanged** across the bump — the base stack grew, the parser did the exploding.

Worse: the 8 MiB `RUST_MIN_STACK` workaround is *beatable by valid input* — depth-64 nesting is accepted by the parser's own recursion cap and needs > 4 MiB of parser stack on its own.

## Fix

`compile_program` now runs `Program::compile` on a dedicated thread with a fixed 32 MiB stack (> 2x margin over the measured worst *accepted* input; the reservation is virtual — only touched pages commit). Compilation success no longer depends on how much stack the caller has left, at any thread size.

- Cost: one thread spawn per **unique** expression per process — amortized to ~zero by the existing `#[cached]` memoization.
- Zero new dependencies (std only). `stacker` was considered and rejected: its red-zone would have to equal the worst case anyway (≈ always-grow) and it drags in the `psm` native dep.
- The evaluation path was measured safe (max-accepted-depth expression evaluates fine on a 128 KiB thread) and is untouched.
- A `tracing::debug!` with expression + compile duration fires per actual (non-memoized) compile for future cache-miss debugging.

## Tests

`cala-cel-interpreter/tests/compile_stack.rs` constructs `CelExpression`s from **128 KiB** caller threads — far less than the parser alone needs, and much harsher than the default 2 MiB:

- realistic velocity condition (needs ~350 KiB to parse) — SIGABRT before, passes now
- depth-64 nested expression (needs > 4 MiB) compiles **and evaluates** — SIGABRT before, passes now
- past-the-cap input returns `Err` gracefully instead of the caller's stack deciding between `Err` and SIGABRT

Verified the pin: reverting `interpreter.rs` makes both compile tests SIGABRT again.

## Downstream follow-up

Once this ships, lana-bank can revert the `.cargo/config.toml` `RUST_MIN_STACK=8388608` workaround added in GaloyMoney/lana-bank#8011 (not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every CEL expression is compiled (thread spawn + join on cache misses), which affects reliability under low caller stack but adds concurrency and panic-handling behavior on a hot path; evaluation is untouched.
> 
> **Overview**
> **CEL compilation no longer runs on the caller’s thread**, fixing debug-build stack overflows when expressions are built under deep async stacks (e.g. lana-bank#8011).
> 
> `compile_program` spawns a named `cel-compile` thread with a **32MiB** stack and runs `Program::compile` there; panics propagate via `resume_unwind`, and a **debug** log records expression plus compile duration on each non-cached compile. Memoized `#[cached]` behavior is unchanged, so the extra spawn is effectively once per unique expression.
> 
> New regression tests in `compile_stack.rs` build `CelExpression` from **128KiB** caller threads: realistic velocity conditions, deep nesting (compile + evaluate), and over-cap nesting that must return `Err` instead of aborting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e990c5c4590074ed8007694289589668f88d7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->