### PR TITLE
fix(cel-interpreter): surface fuzz-found panic paths as errors

### DIFF
--- a/cala-cel-interpreter/src/builtins/mod.rs
+++ b/cala-cel-interpreter/src/builtins/mod.rs
@@ -118,9 +118,25 @@ fn decimal_binary_args(args: &[Value]) -> Result<(rust_decimal::Decimal, rust_de
 
 pub(crate) fn timestamp_format(This(this): This<Value>, format: Arc<String>) -> Result<Value> {
     match this {
-        Value::Timestamp(ts) => Ok(Value::String(
-            ts.with_timezone(&Utc).format(&format).to_string().into(),
-        )),
+        Value::Timestamp(ts) => {
+            // `DelayedFormat`'s `Display` impl returns `fmt::Error` for
+            // invalid format specifiers, and `.to_string()` panics on that
+            // ("a Display implementation returned an error unexpectedly").
+            // Write manually so bad format strings surface as a CEL error
+            // instead of panicking.
+            let mut buf = String::new();
+            std::fmt::Write::write_fmt(
+                &mut buf,
+                format_args!("{}", ts.with_timezone(&Utc).format(&format)),
+            )
+            .map_err(|_| {
+                ExecutionError::function_error(
+                    "format",
+                    format!("invalid timestamp format string: '{format}'"),
+                )
+            })?;
+            Ok(Value::String(buf.into()))
+        }
         v => Err(ExecutionError::function_error(
             "format",
             format!("cannot format {v:?} as timestamp"),

--- a/cala-cel-interpreter/src/interpreter.rs
+++ b/cala-cel-interpreter/src/interpreter.rs
@@ -43,7 +43,18 @@ fn compile_program(source: String) -> Result<Arc<Program>, String> {
         })
         .expect("failed to spawn cel-compile thread")
         .join()
-        .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+        .unwrap_or_else(|panic| {
+            // The upstream `cel` parser can panic on adversarial input
+            // (e.g. its RecursionListener depth counter underflows when a
+            // syntax error is followed by deep nesting). A library must not
+            // crash its caller, so surface the panic as a parse error.
+            let msg = panic
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| panic.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".to_string());
+            Err(format!("CEL parser panicked during compilation: {msg}"))
+        });
     tracing::debug!(
         expression = %expression,
         elapsed = ?started.elapsed(),
@@ -136,6 +147,25 @@ impl std::str::FromStr for CelExpression {
 mod tests {
     use super::*;
     use chrono::NaiveDate;
+
+    #[test]
+    fn parser_panic_surfaces_as_error() {
+        // Regression test (found by fuzzing): a leading syntax error followed
+        // by deep nesting makes the upstream `cel` parser's RecursionListener
+        // underflow its depth counter (`exit_expr`: `self.depth -= 1`),
+        // panicking with "attempt to subtract with overflow" in builds with
+        // overflow checks. Compilation must surface this as a parse error,
+        // not propagate the panic to the caller.
+        let mut source = String::from(">");
+        source.push_str(&"{".repeat(63));
+        source.push_str("?[");
+        source.push_str(&"(".repeat(11));
+        source.push_str(&"{".repeat(26));
+        source.push_str("l\u{0}?(-");
+
+        let err = source.parse::<CelExpression>().unwrap_err();
+        assert!(matches!(err, CelError::CelParseError(_)));
+    }
 
     #[test]
     fn literals() {
@@ -271,6 +301,36 @@ mod tests {
             expression.evaluate(&context).unwrap(),
             CelValue::Bool(false)
         );
+    }
+
+    #[test]
+    fn invalid_format_on_timestamp_is_error_not_panic() {
+        // Regression test (found by fuzzing): chrono's `DelayedFormat`
+        // `Display` impl returns `fmt::Error` for unknown specifiers like
+        // `%Q`; formatting must surface a CEL evaluation error, not panic.
+        let expression = "now.format('%Q')".parse::<CelExpression>().unwrap();
+        let mut context = CelContext::new();
+        context.add_variable(
+            "now",
+            chrono::NaiveDate::from_ymd_opt(1940, 12, 21)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap()
+                .and_utc(),
+        );
+        let err = expression.evaluate(&context).unwrap_err();
+        assert!(matches!(err, CelError::EvaluationError(_, _)));
+    }
+
+    #[test]
+    fn bytes_to_json_is_error_not_panic() {
+        // Regression test (found by fuzzing): coercing a bytes value (e.g.
+        // from `{'a': b': x'}`) to serde_json::Value used to hit
+        // `unimplemented!()`. It must return a coercion error instead.
+        let expression = "{'a': b'x'}".parse::<CelExpression>().unwrap();
+        let context = CelContext::new();
+        let res: Result<serde_json::Value, _> = expression.try_evaluate(&context);
+        assert!(res.is_err());
     }
 
     #[test]

--- a/cala-cel-interpreter/src/value.rs
+++ b/cala-cel-interpreter/src/value.rs
@@ -552,7 +552,13 @@ impl TryFrom<CelResult<'_>> for serde_json::Value {
                 Value::from(res)
             }
             CelValue::Decimal(d) => Value::from(d.to_string()),
-            CelValue::Bytes(_) => unimplemented!(),
+            CelValue::Bytes(_) => {
+                return Err(ResultCoercionError::BadExternalTypeCoercion(
+                    expr.to_string(),
+                    CelType::Bytes,
+                    "serde_json::Value",
+                ));
+            }
         })
     }
 }


### PR DESCRIPTION
## Summary

Fixes three panic paths in `cala-cel-interpreter` found by fuzzing the library with cargo-fuzz (fuzzing infrastructure is in a separate PR).

### Bugs fixed

- **`timestamp.format('%Q')` panic** — invalid chrono format specifiers make `DelayedFormat`'s `Display` impl return `fmt::Error`, which panics inside `.to_string()` ("a Display implementation returned an error unexpectedly"). Formatting now writes manually and returns an `ExecutionError`. Previously, any velocity control / tx template with a bad format string could crash the server.
- **Bytes→JSON coercion panic** — `TryFrom<CelResult> for serde_json::Value` hit `unimplemented!()` on `CelValue::Bytes` (e.g. `{'a': b'x'}`). Now returns a `ResultCoercionError`.
- **Upstream `cel` parser panic made non-fatal** — the parser's `RecursionListener` depth counter underflows on adversarial input ([cel-rust#305](https://github.com/cel-rust/cel-rust/issues/305)). `compile_program` previously used `resume_unwind`, crashing the caller; it now converts compile-thread panics into `CelParseError`.

Each fix has a regression test.

### Related

- [cel-rust#305](https://github.com/cel-rust/cel-rust/issues/305) — depth-counter underflow panic (fix suggested upstream, verified locally)
- [cel-rust#306](https://github.com/cel-rust/cel-rust/issues/306) — **not addressed here**: exponential memory blowup parsing ~125-byte adversarial input (remote DoS when compiling user-supplied CEL). Needs an upstream fix or a sandboxing decision on our side.

## Test plan

- [x] `cargo test -p cala-cel-interpreter` — 13 tests pass, incl. 3 new regression tests
- [x] `cargo clippy -p cala-cel-interpreter -p cala-ledger-core-types` — clean
- [ ] CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on user-supplied CEL compile/eval paths; behavior shifts from process crash to errors, which is safer for production but callers must handle new error cases.
> 
> **Overview**
> Replaces three **fuzz-found panic paths** in `cala-cel-interpreter` with normal CEL errors so adversarial or bad user expressions do not crash the host (e.g. velocity controls / tx templates).
> 
> **Timestamp `format`** — Invalid chrono specifiers (e.g. `%Q`) no longer go through `.to_string()` on `DelayedFormat`; formatting writes via `write_fmt` and returns an `ExecutionError` for bad format strings.
> 
> **Compile thread** — Panics from the upstream `cel` parser on adversarial input (e.g. `RecursionListener` depth underflow) are no longer re-propagated with `resume_unwind`; they become `CelParseError` with a panic message.
> 
> **Bytes → JSON** — `TryFrom<CelResult> for serde_json::Value` on `CelValue::Bytes` returns `ResultCoercionError` instead of `unimplemented!()`.
> 
> Three regression tests cover parser panic, invalid timestamp format, and bytes coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfcfb9d5055661f9f4d3ba1766412efb2149d042. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->