### PR TITLE
ci(fuzz): pull SQLX_OFFLINE + crash-preserving fuzz.sh from galoy-concourse-shared

### DIFF
--- a/ci/vendir.lock.yml
+++ b/ci/vendir.lock.yml
@@ -8,8 +8,8 @@ directories:
   path: ../.github/workflows/vendor
 - contents:
   - git:
-      commitTitle: 'feat(fuzz): default SQLX_OFFLINE=true in the fuzz build...'
-      sha: 0cde7c61a95c856565a1a028a876ebaf60df3adc
+      commitTitle: 'fix(fuzz): preserve corpus + artifacts when a target crashes...'
+      sha: 1285fea1165e38202ca627ad27d993dcaff4eef5
     path: .
   path: vendor
 kind: LockConfig

--- a/ci/vendir.lock.yml
+++ b/ci/vendir.lock.yml
@@ -8,9 +8,8 @@ directories:
   path: ../.github/workflows/vendor
 - contents:
   - git:
-      commitTitle: 'feat(fuzz): merge fuzz/seeds/<target>/ into the corpus before
-        each run...'
-      sha: 0564af2488d0d64fae1f2345b1d23b3b09f65ee6
+      commitTitle: 'feat(fuzz): default SQLX_OFFLINE=true in the fuzz build...'
+      sha: 0cde7c61a95c856565a1a028a876ebaf60df3adc
     path: .
   path: vendor
 kind: LockConfig

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: .
     git:
       url: https://github.com/GaloyMoney/galoy-concourse-shared.git
-      ref: 0564af2488d0d64fae1f2345b1d23b3b09f65ee6
+      ref: 0cde7c61a95c856565a1a028a876ebaf60df3adc
     includePaths:
     - shared/ci/**/*
     excludePaths:

--- a/ci/vendir.yml
+++ b/ci/vendir.yml
@@ -22,7 +22,7 @@ directories:
   - path: .
     git:
       url: https://github.com/GaloyMoney/galoy-concourse-shared.git
-      ref: 0cde7c61a95c856565a1a028a876ebaf60df3adc
+      ref: 1285fea1165e38202ca627ad27d993dcaff4eef5
     includePaths:
     - shared/ci/**/*
     excludePaths:

--- a/ci/vendor/pipeline-fragments.lib.yml
+++ b/ci/vendor/pipeline-fragments.lib.yml
@@ -550,6 +550,7 @@ plan:
     - { name: corpus }
     outputs:
     - { name: corpus-out }
+    - { name: artifacts-out }
     caches:
     - { path: cargo-home }
     - { path: cargo-target-dir }
@@ -567,35 +568,61 @@ plan:
           export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
           export CORPUS_TARBALL_IN="../corpus/*.tgz"
           export CORPUS_TARBALL_OUT="../corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
+          export ARTIFACTS_TARBALL_OUT="../artifacts-out/artifacts-v$(date -u +%Y%m%d-%H%M%S).tgz"
           bash ci/vendor/tasks/fuzz.sh
         '
     params:
       CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
       CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
       FUZZ_SECONDS: #@ fuzz_seconds
-- task: store-corpus
-  config:
-    platform: linux
-    image_resource:
-      type: registry-image
-      source: { repository: google/cloud-sdk }
-    inputs:
-    - { name: corpus-out }
-    params:
-      GCS_BUCKET: ((staging-gcp-creds.bucket_name))
-      GCS_CREDS: ((staging-gcp-creds.creds_json))
-      GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
-    run:
-      path: sh
-      args:
-      - -exc
-      - |
-        set -euo pipefail
-        if ! ls corpus-out/*.tgz >/dev/null 2>&1; then echo "no corpus to store; nothing was packaged"; exit 0; fi
-        printf '%s' "$GCS_CREDS" > /tmp/key.json
-        gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
-        gsutil cp corpus-out/corpus-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
-        echo "stored corpus"
+  ensure:
+    do:
+    - task: store-corpus
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: { repository: google/cloud-sdk }
+        inputs:
+        - { name: corpus-out }
+        params:
+          GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+          GCS_CREDS: ((staging-gcp-creds.creds_json))
+          GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            set -euo pipefail
+            if ! ls corpus-out/*.tgz >/dev/null 2>&1; then echo "no corpus to store; nothing was packaged"; exit 0; fi
+            printf '%s' "$GCS_CREDS" > /tmp/key.json
+            gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+            gsutil cp corpus-out/corpus-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
+            echo "stored corpus"
+    - task: store-artifacts
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: { repository: google/cloud-sdk }
+        inputs:
+        - { name: artifacts-out }
+        params:
+          GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+          GCS_CREDS: ((staging-gcp-creds.creds_json))
+          GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-artifacts"
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            set -euo pipefail
+            if ! ls artifacts-out/*.tgz >/dev/null 2>&1; then echo "no artifacts to store"; exit 0; fi
+            printf '%s' "$GCS_CREDS" > /tmp/key.json
+            gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+            gsutil cp artifacts-out/artifacts-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
+            echo "stored artifacts"
 on_failure: #@ zenduty_notification_hook()
 on_error: #@ zenduty_notification_hook()
 #@ end

--- a/ci/vendor/tasks/fuzz.sh
+++ b/ci/vendor/tasks/fuzz.sh
@@ -16,7 +16,14 @@
 #!   FUZZ_SECONDS        seconds to fuzz each target (default: 60)
 #!   FUZZ_JOBS           libFuzzer `-jobs` per target; cores ~= #targets * FUZZ_JOBS
 #!   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
-#!   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
+#!   CORPUS_TARBALL_OUT    path to write the evolved corpus tarball after fuzzing
+#!   ARTIFACTS_TARBALL_OUT path to write a tarball of crash/oom artifacts (if any)
+#!
+#! A repo may optionally ship a curated seed corpus at `fuzz/seeds/<target>/`
+#! (one input per file). It is merged into `fuzz/corpus/<target>/` before every
+#! run, after the stored corpus is restored — so coverage re-bootstraps even if
+#! the stored corpus is pruned, and seed changes travel with the code. Repos
+#! without `fuzz/seeds/` are unaffected (backward compatible).
 #!
 #! Requires: bash, git, cargo, tar, and cargo-fuzz (auto-installed if missing).
 
@@ -49,6 +56,21 @@ fi
 mapfile -t targets < <(cd fuzz && cargo fuzz list)
 echo "discovered ${#targets[@]} target(s): ${targets[*]}"
 
+#! Merge any committed seed corpus (fuzz/seeds/<target>/) into fuzz/corpus/.
+#! Optional + backward compatible: skipped per-target when the dir is absent,
+#! so repos without seeds (e.g. es-entity) are unaffected. Done after the
+#! stored corpus is restored and per discovered target (no phantom corpus dirs
+#! for stale seed folders). libFuzzer de-duplicates, so re-merging each run is
+#! cheap and keeps the curated baseline present even if the corpus is pruned.
+for target in "${targets[@]}"; do
+  seed_dir="fuzz/seeds/$target"
+  [ -d "$seed_dir" ] || continue
+  mkdir -p "fuzz/corpus/$target"
+  # `/.` copies the directory's contents (incl. dotfiles) into the corpus.
+  cp -R "$seed_dir"/. "fuzz/corpus/$target/" 2>/dev/null || true
+done
+[ -d fuzz/seeds ] && echo "merged fuzz/seeds/ into fuzz/corpus/"
+
 (cd fuzz && cargo fuzz build --sanitizer=none)
 
 JOBS_ARG=""
@@ -72,12 +94,23 @@ done
 if [ "$rc" -ne 0 ]; then
   echo "==== FUZZ CRASH DETECTED ===="
   find fuzz/artifacts -type f -print || true
-  exit "$rc"
 fi
 
-#! Package the evolved corpus (no-op unless CORPUS_TARBALL_OUT is set).
+#! Always package the corpus and any crash artifacts — even when a target
+#! crashed. A discovery must not discard the run's coverage gains or the
+#! failing input. Packaging runs before the (possible) non-zero exit so the
+#! job's ensure-steps can still upload both; the script still exits non-zero
+#! so the build surfaces the discovery (e.g. via on_failure).
 if [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
   mkdir -p "$(dirname "$CORPUS_TARBALL_OUT")"
   tar -czf "$CORPUS_TARBALL_OUT" -C fuzz corpus
   echo "packaged corpus -> $CORPUS_TARBALL_OUT"
 fi
+if [ -n "${ARTIFACTS_TARBALL_OUT:-}" ] && [ -d fuzz/artifacts ] && \
+   [ -n "$(find fuzz/artifacts -type f 2>/dev/null | head -1)" ]; then
+  mkdir -p "$(dirname "$ARTIFACTS_TARBALL_OUT")"
+  tar -czf "$ARTIFACTS_TARBALL_OUT" -C fuzz artifacts
+  echo "packaged artifacts -> $ARTIFACTS_TARBALL_OUT"
+fi
+
+exit "$rc"

--- a/ci/vendor/tasks/fuzz.sh
+++ b/ci/vendor/tasks/fuzz.sh
@@ -18,12 +18,6 @@
 #!   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
 #!   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
 #!
-#! A repo may optionally ship a curated seed corpus at `fuzz/seeds/<target>/`
-#! (one input per file). It is merged into `fuzz/corpus/<target>/` before every
-#! run, after the stored corpus is restored — so coverage re-bootstraps even if
-#! the stored corpus is pruned, and seed changes travel with the code. Repos
-#! without `fuzz/seeds/` are unaffected (backward compatible).
-#!
 #! Requires: bash, git, cargo, tar, and cargo-fuzz (auto-installed if missing).
 
 set -euo pipefail
@@ -38,6 +32,13 @@ fi
 
 FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 
+#! Build with the committed SQLx offline cache (.sqlx/) instead of connecting to
+#! a database — there is no Postgres in a fuzz build, and coverage-guided fuzzing
+#! wants pure, deterministic targets anyway. Harmless for non-SQLx repos (the
+#! var is ignored) and overridable via the environment. Mirrors what each repo's
+#! local `make fuzz` already does.
+export SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+
 #! Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
 mkdir -p fuzz/corpus
 if [ -n "${CORPUS_TARBALL_IN:-}" ] && ls -d $CORPUS_TARBALL_IN >/dev/null 2>&1; then
@@ -47,21 +48,6 @@ fi
 
 mapfile -t targets < <(cd fuzz && cargo fuzz list)
 echo "discovered ${#targets[@]} target(s): ${targets[*]}"
-
-#! Merge any committed seed corpus (fuzz/seeds/<target>/) into fuzz/corpus/.
-#! Optional + backward compatible: skipped per-target when the dir is absent,
-#! so repos without seeds (e.g. es-entity) are unaffected. Done after the
-#! stored corpus is restored and per discovered target (no phantom corpus dirs
-#! for stale seed folders). libFuzzer de-duplicates, so re-merging each run is
-#! cheap and keeps the curated baseline present even if the corpus is pruned.
-for target in "${targets[@]}"; do
-  seed_dir="fuzz/seeds/$target"
-  [ -d "$seed_dir" ] || continue
-  mkdir -p "fuzz/corpus/$target"
-  # `/.` copies the directory's contents (incl. dotfiles) into the corpus.
-  cp -R "$seed_dir"/. "fuzz/corpus/$target/" 2>/dev/null || true
-done
-[ -d fuzz/seeds ] && echo "merged fuzz/seeds/ into fuzz/corpus/"
 
 (cd fuzz && cargo fuzz build --sanitizer=none)
 


### PR DESCRIPTION
## What

Bumps the ci/ vendor ref → `1285fea`, picking up two galoy-concourse-shared fixes for the `fuzz` job:

### 1. `SQLX_OFFLINE=true` default ([shared#24](https://github.com/GaloyMoney/galoy-concourse-shared/pull/24), merged)
Without it the fuzz build dies: `error communicating with database: Connection refused` (sqlx tries a Postgres that isn't there). Verified — the job only built once this was set.

### 2. Preserve corpus + artifacts on a crash ([shared#25](https://github.com/GaloyMoney/galoy-concourse-shared/pull/25), open)
A discovery used to discard the whole run: `fuzz.sh` exited before packaging and `store-corpus` was a plain step (skipped on failure). Now `fuzz.sh` always packages corpus + artifacts, and `store-corpus`/`store-artifacts` run under `ensure` (success **and** failure). A discovery still fails the build (Zenduty) but no longer throws away ~24h of coverage or the failing input.

Surfaced by cala's first 24h run: `velocity_enforce` OOM'd (upstream [cel-rust#306](https://github.com/cel-rust/cel-rust/issues/306), via `CelExpression` deserialization) — without #2 the run's corpus and the OOM input would be lost.

## Dependency & sequencing
Depends on [shared#25](https://github.com/GaloyMoney/galoy-concourse-shared/pull/25) merging (merge commit → pinned SHA `1285fea` stays reachable). Merge order: **shared#25 → this PR → `ci/repipe` → re-run `fuzz`**.

## Test plan
- [x] `vendir sync` clean; vendored `fuzz.sh` has both `SQLX_OFFLINE` + `packaged artifacts`; fragment has `ensure`/`store-artifacts`
- [x] `ytt -f ci` renders cala's pipeline without error
- [ ] after shared#25 merges: merge this, repipe, re-run `fuzz` — a crash should now still `stored corpus` + `stored artifacts`
