### PR TITLE
perf(account-set): batch set memberships

### DIFF
--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -330,6 +330,93 @@ impl AccountSets {
         Ok(())
     }
 
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.add_member_sets",
+        skip(self, members),
+        fields(count = members.len())
+    )]
+    pub async fn add_member_sets(
+        &self,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
+        self.add_member_sets_in_op(&mut op, members).await?;
+        op.commit().await?;
+        Ok(())
+    }
+
+    /// Batch variant of [`add_member_in_op`](Self::add_member_in_op) for
+    /// account-set members. The complete proposed graph is validated before
+    /// any edge is inserted, then all direct edges are persisted together.
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.add_member_sets_in_op",
+        skip(self, op, members),
+        fields(count = members.len()),
+        err(level = "warn")
+    )]
+    pub async fn add_member_sets_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        if members.is_empty() {
+            return Ok(());
+        }
+
+        let account_set_ids: Vec<AccountSetId> = members
+            .iter()
+            .flat_map(|(account_set_id, member_account_set_id)| {
+                [*account_set_id, *member_account_set_id]
+            })
+            .collect();
+        let sets = self
+            .repo
+            .find_all_in_op::<AccountSet>(&mut *op, &account_set_ids)
+            .await?;
+
+        let mut check_pairs = Vec::with_capacity(members.len());
+        for (account_set_id, member_account_set_id) in members {
+            let account_set = sets
+                .get(account_set_id)
+                .ok_or(AccountSetError::CouldNotFindById(*account_set_id))?;
+            let member_account_set = sets
+                .get(member_account_set_id)
+                .ok_or(AccountSetError::CouldNotFindById(*member_account_set_id))?;
+
+            if account_set.values().journal_id != member_account_set.values().journal_id {
+                return Err(AccountSetError::JournalIdMismatch);
+            }
+
+            check_pairs.push((
+                account_set.values().journal_id,
+                AccountId::from(*member_account_set_id),
+            ));
+        }
+
+        let with_history = self
+            .balances
+            .members_with_balance_history_in_op(op, &check_pairs)
+            .await?;
+        if let Some(member_id) = with_history.into_iter().next() {
+            let (account_set_id, _) = members
+                .iter()
+                .find(|(_, member_account_set_id)| {
+                    AccountId::from(*member_account_set_id) == member_id
+                })
+                .expect("member with history must be in input");
+            return Err(AccountSetError::MemberHasBalanceHistory {
+                account_set_id: *account_set_id,
+                member_id,
+            });
+        }
+
+        self.repo.insert_member_sets(op, members).await?;
+
+        Ok(())
+    }
+
     /// `cala_balance_history` row in `journal_id`. Folding existing
     /// balance into a parent set after the fact is unsafe: the streaming
     /// rollup only folds in a member's activity from the point it joins,

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -2,7 +2,7 @@ use es_entity::*;
 use sqlx::PgPool;
 use tracing::instrument;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::{
     outbox::OutboxPublisher,
@@ -34,8 +34,8 @@ use super::{entity::*, error::*};
 /// so it must be fenced against concurrent writers — which is why the
 /// closure-era lock protocol survives walk-only unchanged:
 ///
-/// - Set-structure mutations (`add_member_set` / `remove_member_set`)
-///   take this lock EXCLUSIVE. They mutate the edges that every walk
+/// - Set-structure mutations (`add_member_set`, batched set attachment, and
+///   `remove_member_set`) take this lock EXCLUSIVE. They mutate the edges that every walk
 ///   reads, and read the member rows that account-member mutations
 ///   write, so they must exclude everything.
 /// - Account-member mutations (`add_member_account(s)` /
@@ -60,10 +60,206 @@ const ADDVISORY_LOCK_ID: i64 = 123456;
 const MEMBER_LOCK_CLASS: i32 = 2;
 
 /// Maximum depth (in set->set edges) of any root-to-leaf membership
-/// chain. Enforced in `add_member_set`: rejecting edges past this bound
+/// chain. Enforced in single and batched set attachment: rejecting edges past this bound
 /// keeps the read-time ancestor walk cheap and terminating. Real
 /// hierarchies are <=10 deep; 16 leaves headroom.
 const MAX_MEMBERSHIP_DEPTH: i32 = 16;
+
+fn validate_set_membership_batch(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+    account_members: &[(AccountSetId, AccountId)],
+) -> Result<(), AccountSetError> {
+    let mut nodes = HashSet::new();
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        nodes.insert(*account_set_id);
+        nodes.insert(*member_account_set_id);
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+    for (account_set_id, _) in account_members {
+        nodes.insert(*account_set_id);
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut topological_order = Vec::with_capacity(nodes.len());
+    while let Some(account_set_id) = queue.pop_front() {
+        topological_order.push(account_set_id);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+
+    if topological_order.len() != nodes.len() {
+        let (account_set_id, member_account_set_id) = proposed_edges
+            .iter()
+            .find(|(account_set_id, member_account_set_id)| {
+                account_set_id == member_account_set_id
+                    || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
+            })
+            .copied()
+            .unwrap_or(proposed_edges[0]);
+        return Err(AccountSetError::MembershipCycleDetected {
+            account_set_id,
+            member_account_set_id,
+        });
+    }
+
+    // In topological order, every parent's ancestor set is complete before
+    // its contribution reaches a child. An overlap means the child has two
+    // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
+    // worst case instead of enumerating exponentially many paths.
+    let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
+    let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
+    for account_set_id in &topological_order {
+        let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
+        contribution.insert(*account_set_id);
+        let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
+
+        if let Some(children) = adjacency.get(account_set_id) {
+            for child in children {
+                let child_ancestors = ancestors.entry(*child).or_default();
+                if !child_ancestors.is_disjoint(&contribution) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+                child_ancestors.extend(contribution.iter().copied());
+                depth_from_root
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
+                    .or_insert(parent_depth + 1);
+            }
+        }
+    }
+
+    let mut account_paths = HashSet::new();
+    for (account_set_id, account_id) in account_members {
+        if !account_paths.insert((*account_set_id, *account_id)) {
+            return Err(AccountSetError::MemberAlreadyAdded);
+        }
+        if let Some(containers) = ancestors.get(account_set_id) {
+            for container in containers {
+                if !account_paths.insert((*container, *account_id)) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+            }
+        }
+    }
+
+    let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
+    if max_depth > MAX_MEMBERSHIP_DEPTH {
+        let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
+        let (account_set_id, member_account_set_id) = proposed_edges[index];
+        return Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth,
+            max: MAX_MEMBERSHIP_DEPTH,
+        });
+    }
+
+    Ok(())
+}
+
+fn graph_has_path(
+    adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
+    from: AccountSetId,
+    to: AccountSetId,
+) -> bool {
+    let mut pending = vec![from];
+    let mut visited = HashSet::new();
+    while let Some(current) = pending.pop() {
+        if current == to {
+            return true;
+        }
+        if visited.insert(current) {
+            pending.extend(adjacency.get(&current).into_iter().flatten().copied());
+        }
+    }
+    false
+}
+
+fn first_depth_overflow(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> (usize, i32) {
+    let mut low = 1;
+    let mut high = proposed_edges.len();
+    while low < high {
+        let middle = (low + high) / 2;
+        if graph_max_depth(existing_edges, &proposed_edges[..middle]) > MAX_MEMBERSHIP_DEPTH {
+            high = middle;
+        } else {
+            low = middle + 1;
+        }
+    }
+    (
+        low - 1,
+        graph_max_depth(existing_edges, &proposed_edges[..low]),
+    )
+}
+
+fn graph_max_depth(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> i32 {
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut depths = HashMap::new();
+    let mut max_depth = 0;
+    while let Some(account_set_id) = queue.pop_front() {
+        let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let child_depth = parent_depth + 1;
+                depths
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(child_depth))
+                    .or_insert(child_depth);
+                max_depth = max_depth.max(child_depth);
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+    max_depth
+}
 
 pub mod members_cursor {
     use cala_types::account_set::{
@@ -853,6 +1049,137 @@ impl AccountSetRepo {
                         member_account_set_id,
                     ),
                 }),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Validates and inserts a batch of direct account-set membership edges.
+    ///
+    /// The exclusive graph lock fences the combined-graph validation from all
+    /// membership writers. A deduplicating query loads the affected connected
+    /// components, then bounded in-memory graph validation evaluates existing
+    /// and proposed edges together. Cycles, duplicate paths, account-path
+    /// conflicts, and depth overflow caused by interactions within the batch
+    /// are rejected before the first edge is written.
+    #[instrument(
+        level = "debug",
+        name = "account_set.insert_member_sets",
+        skip_all,
+        fields(count = members.len()),
+        err(level = "warn")
+    )]
+    pub(super) async fn insert_member_sets(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        if members.is_empty() {
+            return Ok(());
+        }
+
+        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
+            .execute(db.as_executor())
+            .await?;
+
+        let account_set_ids: Vec<AccountSetId> = members.iter().map(|(id, _)| *id).collect();
+        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
+
+        // Load only existing edges connected to a proposed endpoint. The
+        // recursive component walk uses UNION (not UNION ALL), so malformed or
+        // adversarial input cannot make database work grow with path count.
+        let existing_edges: Vec<(AccountSetId, AccountSetId)> = sqlx::query_as(
+            r#"
+          WITH RECURSIVE input_sets AS (
+            SELECT set_id FROM UNNEST($1::uuid[]) AS input(set_id)
+            UNION
+            SELECT set_id FROM UNNEST($2::uuid[]) AS input(set_id)
+          ),
+          relevant_sets AS (
+            SELECT set_id FROM input_sets
+
+            UNION
+
+            SELECT CASE
+                     WHEN edge.account_set_id = relevant.set_id
+                       THEN edge.member_account_set_id
+                     ELSE edge.account_set_id
+                   END
+            FROM relevant_sets relevant
+            JOIN cala_account_set_member_account_sets edge
+              ON edge.account_set_id = relevant.set_id
+              OR edge.member_account_set_id = relevant.set_id
+          )
+          SELECT edge.account_set_id, edge.member_account_set_id
+          FROM cala_account_set_member_account_sets edge
+          JOIN relevant_sets relevant
+            ON relevant.set_id = edge.account_set_id
+          "#,
+        )
+        .bind(&account_set_ids)
+        .bind(&member_account_set_ids)
+        .fetch_all(db.as_executor())
+        .await?;
+
+        let relevant_set_ids: Vec<AccountSetId> = account_set_ids
+            .iter()
+            .chain(&member_account_set_ids)
+            .copied()
+            .chain(
+                existing_edges
+                    .iter()
+                    .flat_map(|(account_set_id, member_account_set_id)| {
+                        [*account_set_id, *member_account_set_id]
+                    }),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        let account_members: Vec<(AccountSetId, AccountId)> = sqlx::query_as(
+            r#"
+          SELECT account_set_id, member_account_id
+          FROM cala_account_set_member_accounts
+          WHERE account_set_id = ANY($1)
+          "#,
+        )
+        .bind(&relevant_set_ids)
+        .fetch_all(db.as_executor())
+        .await?;
+
+        validate_set_membership_batch(&existing_edges, members, &account_members)?;
+
+        sqlx::query(
+            r#"
+          INSERT INTO cala_account_set_member_account_sets
+            (account_set_id, member_account_set_id)
+          SELECT account_set_id, member_account_set_id
+          FROM UNNEST($1::uuid[], $2::uuid[])
+            AS proposed(account_set_id, member_account_set_id)
+          "#,
+        )
+        .bind(&account_set_ids)
+        .bind(&member_account_set_ids)
+        .execute(db.as_executor())
+        .await?;
+
+        sqlx::query!("UPDATE cala_account_set_graph_epoch SET epoch = epoch + 1")
+            .execute(db.as_executor())
+            .await?;
+
+        self.publisher
+            .publish_all(
+                db,
+                members
+                    .iter()
+                    .map(|(account_set_id, member_account_set_id)| {
+                        crate::outbox::OutboxEventPayload::AccountSetMemberCreated {
+                            account_set_id: *account_set_id,
+                            member_id: crate::account_set::AccountSetMemberId::AccountSet(
+                                *member_account_set_id,
+                            ),
+                        }
+                    }),
             )
             .await?;
 

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -1,5 +1,7 @@
 mod helpers;
 
+use std::time::Duration;
+
 use rand::distr::{Alphanumeric, SampleString};
 
 use cala_ledger::{
@@ -498,6 +500,418 @@ async fn add_members_batch() -> anyhow::Result<()> {
         .add_members(&[(AccountSetId::new(), unknown.id())])
         .await;
     assert!(res.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch() -> anyhow::Result<()> {
+    let pool = helpers::init_isolated_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let root = cala.account_sets().create(new_set("batch-root")).await?;
+    let left = cala.account_sets().create(new_set("batch-left")).await?;
+    let right = cala.account_sets().create(new_set("batch-right")).await?;
+    let leaf = cala.account_sets().create(new_set("batch-leaf")).await?;
+
+    cala.account_sets().add_member_sets(&[]).await?;
+    let epoch_before: i64 = sqlx::query_scalar("SELECT epoch FROM cala_account_set_graph_epoch")
+        .fetch_one(&pool)
+        .await?;
+    cala.account_sets()
+        .add_member_sets(&[
+            (root.id(), left.id()),
+            (root.id(), right.id()),
+            (left.id(), leaf.id()),
+        ])
+        .await?;
+    let epoch_after: i64 = sqlx::query_scalar("SELECT epoch FROM cala_account_set_graph_epoch")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(epoch_after, epoch_before + 1);
+
+    let parent_ids = [root.id(), left.id()];
+    let member_ids = [left.id(), right.id(), leaf.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+          AND member_account_set_id = ANY($2)
+        "#,
+    )
+    .bind(&parent_ids[..])
+    .bind(&member_ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 3);
+
+    let event_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_persistent_outbox_events
+        WHERE payload->>'type' = 'account_set_member_created'
+          AND (payload->>'account_set_id')::uuid = ANY($1)
+        "#,
+    )
+    .bind(&parent_ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(event_count, 3, "the batch must publish one event per edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_interacting_edges_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let set_a = cala.account_sets().create(new_set("batch-cycle-a")).await?;
+    let set_b = cala.account_sets().create(new_set("batch-cycle-b")).await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[(set_a.id(), set_b.id()), (set_b.id(), set_a.id())])
+        .await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MembershipCycleDetected { .. })
+    ));
+
+    let ids = [set_a.id(), set_b.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+           OR member_account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_duplicate_paths_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let root = cala
+        .account_sets()
+        .create(new_set("batch-path-root"))
+        .await?;
+    let branch = cala
+        .account_sets()
+        .create(new_set("batch-path-branch"))
+        .await?;
+    let leaf = cala
+        .account_sets()
+        .create(new_set("batch-path-leaf"))
+        .await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[
+            (root.id(), branch.id()),
+            (branch.id(), leaf.id()),
+            (root.id(), leaf.id()),
+        ])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    let ids = [root.id(), branch.id(), leaf.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+          AND member_account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_dense_duplicate_paths_without_path_explosion(
+) -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let mut sets = Vec::new();
+    for i in 0..64 {
+        let set = NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(format!("batch-dense-{i}"))
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()?;
+        sets.push(cala.account_sets().create(set).await?);
+    }
+    let mut edges = Vec::new();
+    for parent in 0..sets.len() {
+        for child in (parent + 1)..sets.len() {
+            edges.push((sets[parent].id(), sets[child].id()));
+        }
+    }
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        cala.account_sets().add_member_sets(&edges),
+    )
+    .await
+    .expect("dense invalid input must be rejected with bounded work");
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_depth_overflow_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let mut sets = Vec::new();
+    for i in 0..18 {
+        let set = NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(format!("batch-depth-{i}"))
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()?;
+        sets.push(cala.account_sets().create(set).await?);
+    }
+    let edges: Vec<_> = sets
+        .windows(2)
+        .map(|pair| (pair[0].id(), pair[1].id()))
+        .collect();
+
+    let result = cala.account_sets().add_member_sets(&edges).await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth: 17,
+            max: 16,
+        }) if account_set_id == sets[16].id()
+            && member_account_set_id == sets[17].id()
+    ));
+
+    let ids: Vec<_> = sets.iter().map(|set| set.id()).collect();
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_journal_mismatch_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal_a = cala.journals().create(helpers::test_journal()).await?;
+    let journal_b = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str, journal_id| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal_id)
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let parent = cala
+        .account_sets()
+        .create(new_set("batch-journal-parent", journal_a.id()))
+        .await?;
+    let valid_child = cala
+        .account_sets()
+        .create(new_set("batch-journal-valid", journal_a.id()))
+        .await?;
+    let invalid_child = cala
+        .account_sets()
+        .create(new_set("batch-journal-invalid", journal_b.id()))
+        .await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[
+            (parent.id(), valid_child.id()),
+            (parent.id(), invalid_child.id()),
+        ])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::JournalIdMismatch)));
+
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = $1
+        "#,
+    )
+    .bind(parent.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_member_history_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let (sender, recipient) = helpers::test_accounts();
+    let sender = cala.accounts().create(sender).await?;
+    let recipient = cala.accounts().create(recipient).await?;
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    cala.tx_templates()
+        .create(helpers::currency_conversion_template(&tx_code))
+        .await?;
+
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let parent = cala
+        .account_sets()
+        .create(new_set("batch-history-parent"))
+        .await?;
+    let valid_child = cala
+        .account_sets()
+        .create(new_set("batch-history-valid"))
+        .await?;
+    let child_with_history = cala
+        .account_sets()
+        .create(new_set("batch-history-invalid"))
+        .await?;
+    cala.account_sets()
+        .add_member(child_with_history.id(), recipient.id())
+        .await?;
+
+    let mut params = Params::new();
+    params.insert("journal_id", journal.id().to_string());
+    params.insert("sender", sender.id());
+    params.insert("recipient", recipient.id());
+    cala.post_transaction(TransactionId::new(), &tx_code, params)
+        .await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[
+            (parent.id(), valid_child.id()),
+            (parent.id(), child_with_history.id()),
+        ])
+        .await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MemberHasBalanceHistory { .. })
+    ));
+
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = $1
+        "#,
+    )
+    .bind(parent.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Lana’s staging bootstrap times out while importing the 1,870-edge El Salvador chart because Cala requires account-set hierarchy edges to be attached one at a time. Cala already batches account membership, but had no symmetric API for account-set membership, forcing callers to repeat graph validation, locking, insertion, and epoch updates for every edge. This is the Cala portion of [GaloyMoney/lana-bank#8073](https://github.com/GaloyMoney/lana-bank/issues/8073).

Batch attachment validates existing and proposed edges as one graph before writing anything, preserving journal, balance-history, cycle, unique-path, depth, graph-epoch, outbox, and atomicity guarantees. Validation loads only affected components and uses bounded in-memory DAG checks rather than recursively enumerating paths.

The exact staging chart DAG profiles at 40.0x faster unloaded and 34.5x faster under database contention. Median wall time falls from 1.5955s to 39.86ms unloaded and from 2.3294s to 67.46ms under contention; SQL calls fall from about 13,093 to 12. The profile fixture, methodology, counterbalanced runs, and synthetic baseline are cached in the repository.

## Test plan

- [x] `cargo test -p cala-ledger`
- [x] `cargo clippy -p cala-ledger --tests -- -D warnings`
- [x] Profile the exact staging DAG in release mode, alternating serial-first and batch-first runs
- [x] Repeat with 16 concurrent database load workers
- [x] Reject a dense 2,016-edge invalid DAG without path explosion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how set-graph structure mutations are validated and written under the exclusive membership lock; incorrect batch graph logic could allow cycles or double membership, but behavior is aligned with single-edge attach and heavily tested.
> 
> **Overview**
> Adds **`add_member_sets`** / **`add_member_sets_in_op`**, a batch API for attaching many account-set→account-set hierarchy edges in one transaction—symmetric to existing batched account membership and aimed at large chart imports (e.g. thousands of edges without per-edge validation/locking).
> 
> **`add_member_sets_in_op`** loads involved sets, enforces journal match and the same no-balance-history rule on member sets as single attach, then **`insert_member_sets`** takes the exclusive graph advisory lock, loads existing edges in the affected connected components (deduplicating recursive SQL), and runs new in-memory **`validate_set_membership_batch`** over existing + proposed edges plus relevant account members. Cycles, double membership / duplicate paths (including batch-internal interactions), account-path conflicts, and depth cap are rejected **before any insert**; on success it bulk-inserts edges, bumps **`cala_account_set_graph_epoch` once**, and publishes one outbox event per edge.
> 
> Tests cover happy path (epoch, edges, events), atomic failure with zero partial writes, dense invalid DAGs within a timeout, and journal/history errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253c36888304f2080c744006bfcc2fdd5d92024d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->