### PR TITLE
perf(account-set): batch set memberships

### DIFF
--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -119,6 +119,10 @@ struct GraphSnapshot {
     /// member set -> direct parent sets (upward edges). Sets with no
     /// parents have no entry.
     parents: HashMap<AccountSetId, Vec<AccountSetId>>,
+    /// parent set -> direct member sets (downward edges). Kept alongside
+    /// `parents` so batch validation can find affected components without
+    /// repeatedly inverting the snapshot.
+    children: HashMap<AccountSetId, Vec<AccountSetId>>,
     /// Every set known at snapshot time. Also the known-set universe for
     /// expansion: an id absent here forces the supplement/fallback path.
     meta: HashMap<AccountSetId, SetMeta>,
@@ -129,8 +133,37 @@ impl GraphSnapshot {
         Self {
             epoch: COLD_EPOCH,
             parents: HashMap::new(),
+            children: HashMap::new(),
             meta: HashMap::new(),
         }
+    }
+
+    fn edges_connected_to(
+        &self,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Vec<(AccountSetId, AccountSetId)> {
+        let mut pending: Vec<_> = members
+            .iter()
+            .flat_map(|(account_set_id, member_account_set_id)| {
+                [*account_set_id, *member_account_set_id]
+            })
+            .collect();
+        let mut visited = HashSet::new();
+        let mut edges = HashSet::new();
+        while let Some(account_set_id) = pending.pop() {
+            if !visited.insert(account_set_id) {
+                continue;
+            }
+            for parent_id in self.parents.get(&account_set_id).into_iter().flatten() {
+                edges.insert((*parent_id, account_set_id));
+                pending.push(*parent_id);
+            }
+            for member_id in self.children.get(&account_set_id).into_iter().flatten() {
+                edges.insert((account_set_id, *member_id));
+                pending.push(*member_id);
+            }
+        }
+        edges.into_iter().collect()
     }
 }
 
@@ -138,6 +171,12 @@ impl GraphSnapshot {
 /// (sets created after the last refresh). Never installed.
 struct Overlay {
     parents: HashMap<AccountSetId, Vec<AccountSetId>>,
+    meta: HashMap<AccountSetId, SetMeta>,
+}
+
+struct IndexedNodes {
+    parents: HashMap<AccountSetId, Vec<AccountSetId>>,
+    children: HashMap<AccountSetId, Vec<AccountSetId>>,
     meta: HashMap<AccountSetId, SetMeta>,
 }
 
@@ -290,7 +329,7 @@ impl SetGraphCache {
                 .repo
                 .fetch_set_graph_nodes_in_op(op, &missing)
                 .await?;
-            let (parents, meta) = Self::index_nodes(nodes);
+            let IndexedNodes { parents, meta, .. } = Self::index_nodes(nodes);
             Some(Overlay { parents, meta })
         };
 
@@ -438,7 +477,7 @@ impl SetGraphCache {
                 .repo
                 .fetch_set_graph_nodes_in_op(op, &missing)
                 .await?;
-            let (parents, meta) = Self::index_nodes(nodes);
+            let IndexedNodes { parents, meta, .. } = Self::index_nodes(nodes);
             Some(Overlay { parents, meta })
         };
 
@@ -497,15 +536,45 @@ impl SetGraphCache {
     /// Validate a batch of set-to-set memberships against the graph read
     /// inside `op`. The caller must hold the exclusive structure lock so the
     /// graph cannot change between this check and persistence.
+    ///
+    /// An epoch match proves the cached edges equal the committed graph, so the
+    /// affected components are selected in memory. A cold or stale snapshot
+    /// falls back to one flat op-local edge read, which also sees same-op
+    /// mutations that have already bumped the epoch.
+    #[instrument(
+        level = "debug",
+        name = "account_set.assert_valid_set_memberships",
+        skip_all,
+        fields(count = members.len(), path = tracing::field::Empty),
+        err(level = "warn")
+    )]
     pub(super) async fn assert_valid_set_memberships_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
         members: &[(AccountSetId, AccountSetId)],
     ) -> Result<(), AccountSetError> {
-        let (existing_edges, account_members) = self
+        let span = tracing::Span::current();
+        let snapshot = self.load();
+        let epoch = self.inner.repo.fetch_set_graph_epoch_in_op(op).await?;
+        let existing_edges = if snapshot.epoch == epoch {
+            span.record("path", "memory");
+            snapshot.edges_connected_to(members)
+        } else {
+            span.record(
+                "path",
+                if snapshot.epoch == COLD_EPOCH {
+                    "fallback_cold"
+                } else {
+                    "fallback_epoch"
+                },
+            );
+            self.spawn_refresh();
+            self.inner.repo.fetch_set_membership_edges_in_op(op).await?
+        };
+        let account_members = self
             .inner
             .repo
-            .fetch_set_membership_validation_data_in_op(op, members)
+            .fetch_affected_account_memberships_in_op(op, &existing_edges, members)
             .await?;
         validate_set_memberships(&existing_edges, members, &account_members)
     }
@@ -518,13 +587,9 @@ impl SetGraphCache {
             .clone()
     }
 
-    fn index_nodes(
-        nodes: Vec<SetGraphNode>,
-    ) -> (
-        HashMap<AccountSetId, Vec<AccountSetId>>,
-        HashMap<AccountSetId, SetMeta>,
-    ) {
+    fn index_nodes(nodes: Vec<SetGraphNode>) -> IndexedNodes {
         let mut parents: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+        let mut children: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
         let mut meta = HashMap::new();
         for node in nodes {
             meta.insert(
@@ -536,9 +601,14 @@ impl SetGraphCache {
             );
             if let Some(parent_id) = node.parent_id {
                 parents.entry(node.id).or_default().push(parent_id);
+                children.entry(parent_id).or_default().push(node.id);
             }
         }
-        (parents, meta)
+        IndexedNodes {
+            parents,
+            children,
+            meta,
+        }
     }
 
     /// In-memory BFS expansion of the probed seeds over snapshot +
@@ -653,10 +723,15 @@ impl SetGraphCache {
             return Ok(());
         };
         let data = inner.repo.fetch_set_graph().await?;
-        let (parents, meta) = Self::index_nodes(data.nodes);
+        let IndexedNodes {
+            parents,
+            children,
+            meta,
+        } = Self::index_nodes(data.nodes);
         let new = GraphSnapshot {
             epoch: data.epoch,
             parents,
+            children,
             meta,
         };
         tracing::Span::current().record("epoch", new.epoch);
@@ -673,5 +748,75 @@ impl SetGraphCache {
             *current = Arc::new(new);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_validation_selects_only_connected_snapshot_edges() {
+        let root = AccountSetId::new();
+        let branch = AccountSetId::new();
+        let leaf = AccountSetId::new();
+        let proposed_leaf = AccountSetId::new();
+        let unrelated_root = AccountSetId::new();
+        let unrelated_leaf = AccountSetId::new();
+        let snapshot = GraphSnapshot {
+            epoch: 1,
+            parents: HashMap::from([
+                (branch, vec![root]),
+                (leaf, vec![branch]),
+                (unrelated_leaf, vec![unrelated_root]),
+            ]),
+            children: HashMap::from([
+                (root, vec![branch]),
+                (branch, vec![leaf]),
+                (unrelated_root, vec![unrelated_leaf]),
+            ]),
+            meta: HashMap::new(),
+        };
+
+        let edges: HashSet<_> = snapshot
+            .edges_connected_to(&[(branch, proposed_leaf)])
+            .into_iter()
+            .collect();
+
+        assert_eq!(edges, HashSet::from([(root, branch), (branch, leaf)]));
+    }
+
+    #[test]
+    fn batch_validation_selects_each_component_joined_by_proposed_edges() {
+        let left_root = AccountSetId::new();
+        let left_leaf = AccountSetId::new();
+        let right_root = AccountSetId::new();
+        let right_leaf = AccountSetId::new();
+        let unrelated_root = AccountSetId::new();
+        let unrelated_leaf = AccountSetId::new();
+        let snapshot = GraphSnapshot {
+            epoch: 1,
+            parents: HashMap::from([
+                (left_leaf, vec![left_root]),
+                (right_leaf, vec![right_root]),
+                (unrelated_leaf, vec![unrelated_root]),
+            ]),
+            children: HashMap::from([
+                (left_root, vec![left_leaf]),
+                (right_root, vec![right_leaf]),
+                (unrelated_root, vec![unrelated_leaf]),
+            ]),
+            meta: HashMap::new(),
+        };
+
+        let edges: HashSet<_> = snapshot
+            .edges_connected_to(&[(left_leaf, right_root)])
+            .into_iter()
+            .collect();
+
+        assert_eq!(
+            edges,
+            HashSet::from([(left_root, left_leaf), (right_root, right_leaf)])
+        );
     }
 }

--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -106,6 +106,12 @@ const TIMER_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// takes the op-local fallback (and triggers the installing refresh).
 const COLD_EPOCH: i64 = -1;
 
+/// Maximum depth (in set->set edges) of any root-to-leaf membership
+/// chain. Rejecting edges past this bound keeps the read-time ancestor
+/// walk cheap and terminating. Real hierarchies are <=10 deep; 16 leaves
+/// headroom.
+pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
+
 #[derive(Debug, Clone, Copy)]
 struct SetMeta {
     journal_id: JournalId,
@@ -535,6 +541,220 @@ impl SetGraphCache {
             }
         }
         Some(false)
+    }
+
+    /// Validate a batch of set-to-set memberships against the graph read
+    /// inside `op`. The caller must hold the exclusive structure lock so the
+    /// graph cannot change between this check and persistence.
+    pub(super) async fn assert_valid_set_memberships_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        let (existing_edges, account_members) = self
+            .inner
+            .repo
+            .fetch_set_membership_validation_data_in_op(op, members)
+            .await?;
+        Self::validate_set_memberships(&existing_edges, members, &account_members)
+    }
+
+    fn validate_set_memberships(
+        existing_edges: &[(AccountSetId, AccountSetId)],
+        proposed_edges: &[(AccountSetId, AccountSetId)],
+        account_members: &[(AccountSetId, AccountId)],
+    ) -> Result<(), AccountSetError> {
+        let mut nodes = HashSet::new();
+        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+
+        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+            nodes.insert(*account_set_id);
+            nodes.insert(*member_account_set_id);
+            adjacency
+                .entry(*account_set_id)
+                .or_default()
+                .push(*member_account_set_id);
+            *indegree.entry(*member_account_set_id).or_default() += 1;
+            indegree.entry(*account_set_id).or_default();
+        }
+        for (account_set_id, _) in account_members {
+            nodes.insert(*account_set_id);
+            indegree.entry(*account_set_id).or_default();
+        }
+
+        let mut queue: VecDeque<AccountSetId> = indegree
+            .iter()
+            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+            .collect();
+        let mut topological_order = Vec::with_capacity(nodes.len());
+        while let Some(account_set_id) = queue.pop_front() {
+            topological_order.push(account_set_id);
+            if let Some(children) = adjacency.get(&account_set_id) {
+                for child in children {
+                    let degree = indegree
+                        .get_mut(child)
+                        .expect("every child must have an indegree");
+                    *degree -= 1;
+                    if *degree == 0 {
+                        queue.push_back(*child);
+                    }
+                }
+            }
+        }
+
+        if topological_order.len() != nodes.len() {
+            let (account_set_id, member_account_set_id) = proposed_edges
+                .iter()
+                .find(|(account_set_id, member_account_set_id)| {
+                    account_set_id == member_account_set_id
+                        || Self::graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
+                })
+                .copied()
+                .unwrap_or(proposed_edges[0]);
+            return Err(AccountSetError::MembershipCycleDetected {
+                account_set_id,
+                member_account_set_id,
+            });
+        }
+
+        // In topological order, every parent's ancestor set is complete before
+        // its contribution reaches a child. An overlap means the child has two
+        // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
+        // worst case instead of enumerating exponentially many paths.
+        let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
+        let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
+        for account_set_id in &topological_order {
+            let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
+            contribution.insert(*account_set_id);
+            let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
+
+            if let Some(children) = adjacency.get(account_set_id) {
+                for child in children {
+                    let child_ancestors = ancestors.entry(*child).or_default();
+                    if !child_ancestors.is_disjoint(&contribution) {
+                        return Err(AccountSetError::MemberAlreadyAdded);
+                    }
+                    child_ancestors.extend(contribution.iter().copied());
+                    depth_from_root
+                        .entry(*child)
+                        .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
+                        .or_insert(parent_depth + 1);
+                }
+            }
+        }
+
+        let mut account_paths = HashSet::new();
+        for (account_set_id, account_id) in account_members {
+            if !account_paths.insert((*account_set_id, *account_id)) {
+                return Err(AccountSetError::MemberAlreadyAdded);
+            }
+            if let Some(containers) = ancestors.get(account_set_id) {
+                for container in containers {
+                    if !account_paths.insert((*container, *account_id)) {
+                        return Err(AccountSetError::MemberAlreadyAdded);
+                    }
+                }
+            }
+        }
+
+        let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
+        if max_depth > MAX_MEMBERSHIP_DEPTH {
+            let (index, depth) = Self::first_depth_overflow(existing_edges, proposed_edges);
+            let (account_set_id, member_account_set_id) = proposed_edges[index];
+            return Err(AccountSetError::MembershipDepthExceeded {
+                account_set_id,
+                member_account_set_id,
+                depth,
+                max: MAX_MEMBERSHIP_DEPTH,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn graph_has_path(
+        adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
+        from: AccountSetId,
+        to: AccountSetId,
+    ) -> bool {
+        let mut pending = vec![from];
+        let mut visited = HashSet::new();
+        while let Some(current) = pending.pop() {
+            if current == to {
+                return true;
+            }
+            if visited.insert(current) {
+                pending.extend(adjacency.get(&current).into_iter().flatten().copied());
+            }
+        }
+        false
+    }
+
+    fn first_depth_overflow(
+        existing_edges: &[(AccountSetId, AccountSetId)],
+        proposed_edges: &[(AccountSetId, AccountSetId)],
+    ) -> (usize, i32) {
+        let mut low = 1;
+        let mut high = proposed_edges.len();
+        while low < high {
+            let middle = (low + high) / 2;
+            if Self::graph_max_depth(existing_edges, &proposed_edges[..middle])
+                > MAX_MEMBERSHIP_DEPTH
+            {
+                high = middle;
+            } else {
+                low = middle + 1;
+            }
+        }
+        (
+            low - 1,
+            Self::graph_max_depth(existing_edges, &proposed_edges[..low]),
+        )
+    }
+
+    fn graph_max_depth(
+        existing_edges: &[(AccountSetId, AccountSetId)],
+        proposed_edges: &[(AccountSetId, AccountSetId)],
+    ) -> i32 {
+        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+            adjacency
+                .entry(*account_set_id)
+                .or_default()
+                .push(*member_account_set_id);
+            *indegree.entry(*member_account_set_id).or_default() += 1;
+            indegree.entry(*account_set_id).or_default();
+        }
+
+        let mut queue: VecDeque<AccountSetId> = indegree
+            .iter()
+            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+            .collect();
+        let mut depths = HashMap::new();
+        let mut max_depth = 0;
+        while let Some(account_set_id) = queue.pop_front() {
+            let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
+            if let Some(children) = adjacency.get(&account_set_id) {
+                for child in children {
+                    let child_depth = parent_depth + 1;
+                    depths
+                        .entry(*child)
+                        .and_modify(|depth| *depth = (*depth).max(child_depth))
+                        .or_insert(child_depth);
+                    max_depth = max_depth.max(child_depth);
+                    let degree = indegree
+                        .get_mut(child)
+                        .expect("every child must have an indegree");
+                    *degree -= 1;
+                    if *degree == 0 {
+                        queue.push_back(*child);
+                    }
+                }
+            }
+        }
+        max_depth
     }
 
     fn load(&self) -> Arc<GraphSnapshot> {

--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -31,8 +31,8 @@
 //!   depends on reading these fresh — an account-attach mutates exactly
 //!   the rows we still read from the DB, never the cache.
 //! - **Set->set edges + per-set metadata** (cold, small; edges mutated
-//!   only by `add_member_set` / `remove_member_set`, both already
-//!   serialized under the exclusive coarse membership lock): cached
+//!   only by `add_member_set` / `add_member_sets` / `remove_member_set`,
+//!   all already serialized under the exclusive coarse membership lock): cached
 //!   in-process, validated by the `cala_account_set_graph_epoch`
 //!   counter read in the SAME statement/snapshot as the probe. Per-set
 //!   metadata (`journal_id`, `eventually_consistent`) is immutable
@@ -51,7 +51,8 @@
 //! resolution costs one round trip, exactly like the pre-cache path:
 //!
 //! - **Epoch mismatch** (structure op committed since the last refresh,
-//!   or a same-op `add_member_set` bumped it locally): walk op-locally
+//!   or a same-op `add_member_set` / `add_member_sets` bumped it
+//!   locally): walk op-locally
 //!   and separately trigger a background refresh from the **pool**.
 //!   Op-local results are NEVER installed into the shared snapshot — an
 //!   in-op read can see the op's own uncommitted writes, and installing
@@ -399,9 +400,9 @@ impl SetGraphCache {
     ///   op's own earlier attaches, and the per-member EXCLUSIVE lock
     ///   serializes concurrent mutations of the same member — the only
     ///   interleavings that could invalidate the count.
-    /// - A same-op `add_member_set` bumps the epoch in-op, so the probe
-    ///   reads the bumped value, mismatches every shared snapshot, and
-    ///   this method falls back to the SQL walk, which sees the op's
+    /// - A same-op `add_member_set` / `add_member_sets` bumps the epoch
+    ///   in-op, so the probe reads the bumped value, mismatches every
+    ///   shared snapshot, and this method falls back to the SQL walk, which sees the op's
     ///   uncommitted edge.
     ///
     /// Fallbacks (epoch mismatch, unknown set id mid-walk) run the SQL

--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -19,9 +19,9 @@
 //!
 //! Layering: `AccountSets` (service) calls this cache; this cache holds
 //! a handle on `AccountSetRepo` and orchestrates — ALL SQL lives in
-//! `repo.rs`, all cache state and in-memory graph logic lives here. The
-//! call graph is strictly service -> cache -> repo; the repo never
-//! calls back up into the cache.
+//! `repo.rs`, cache state and account-path graph logic live here, and pure
+//! set-membership invariants live in `graph_validation.rs`. The call graph is
+//! strictly service -> cache -> repo; the repo never calls back up into the cache.
 //!
 //! Why the split read is safe — the two inputs have opposite write
 //! rates:
@@ -92,6 +92,7 @@ use crate::primitives::{AccountId, AccountSetId, JournalId};
 
 use super::{
     error::AccountSetError,
+    graph_validation::validate_set_memberships,
     repo::{AccountSetRepo, DirectMembershipProbe, SetGraphNode},
 };
 
@@ -105,12 +106,6 @@ const TIMER_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// increments, so this never matches and the first resolution always
 /// takes the op-local fallback (and triggers the installing refresh).
 const COLD_EPOCH: i64 = -1;
-
-/// Maximum depth (in set->set edges) of any root-to-leaf membership
-/// chain. Rejecting edges past this bound keeps the read-time ancestor
-/// walk cheap and terminating. Real hierarchies are <=10 deep; 16 leaves
-/// headroom.
-pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
 
 #[derive(Debug, Clone, Copy)]
 struct SetMeta {
@@ -556,205 +551,7 @@ impl SetGraphCache {
             .repo
             .fetch_set_membership_validation_data_in_op(op, members)
             .await?;
-        Self::validate_set_memberships(&existing_edges, members, &account_members)
-    }
-
-    fn validate_set_memberships(
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        proposed_edges: &[(AccountSetId, AccountSetId)],
-        account_members: &[(AccountSetId, AccountId)],
-    ) -> Result<(), AccountSetError> {
-        let mut nodes = HashSet::new();
-        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-
-        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-            nodes.insert(*account_set_id);
-            nodes.insert(*member_account_set_id);
-            adjacency
-                .entry(*account_set_id)
-                .or_default()
-                .push(*member_account_set_id);
-            *indegree.entry(*member_account_set_id).or_default() += 1;
-            indegree.entry(*account_set_id).or_default();
-        }
-        for (account_set_id, _) in account_members {
-            nodes.insert(*account_set_id);
-            indegree.entry(*account_set_id).or_default();
-        }
-
-        let mut queue: VecDeque<AccountSetId> = indegree
-            .iter()
-            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-            .collect();
-        let mut topological_order = Vec::with_capacity(nodes.len());
-        while let Some(account_set_id) = queue.pop_front() {
-            topological_order.push(account_set_id);
-            if let Some(children) = adjacency.get(&account_set_id) {
-                for child in children {
-                    let degree = indegree
-                        .get_mut(child)
-                        .expect("every child must have an indegree");
-                    *degree -= 1;
-                    if *degree == 0 {
-                        queue.push_back(*child);
-                    }
-                }
-            }
-        }
-
-        if topological_order.len() != nodes.len() {
-            let (account_set_id, member_account_set_id) = proposed_edges
-                .iter()
-                .find(|(account_set_id, member_account_set_id)| {
-                    account_set_id == member_account_set_id
-                        || Self::graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
-                })
-                .copied()
-                .unwrap_or(proposed_edges[0]);
-            return Err(AccountSetError::MembershipCycleDetected {
-                account_set_id,
-                member_account_set_id,
-            });
-        }
-
-        // In topological order, every parent's ancestor set is complete before
-        // its contribution reaches a child. An overlap means the child has two
-        // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
-        // worst case instead of enumerating exponentially many paths.
-        let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
-        let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
-        for account_set_id in &topological_order {
-            let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
-            contribution.insert(*account_set_id);
-            let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
-
-            if let Some(children) = adjacency.get(account_set_id) {
-                for child in children {
-                    let child_ancestors = ancestors.entry(*child).or_default();
-                    if !child_ancestors.is_disjoint(&contribution) {
-                        return Err(AccountSetError::MemberAlreadyAdded);
-                    }
-                    child_ancestors.extend(contribution.iter().copied());
-                    depth_from_root
-                        .entry(*child)
-                        .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
-                        .or_insert(parent_depth + 1);
-                }
-            }
-        }
-
-        let mut account_paths = HashSet::new();
-        for (account_set_id, account_id) in account_members {
-            if !account_paths.insert((*account_set_id, *account_id)) {
-                return Err(AccountSetError::MemberAlreadyAdded);
-            }
-            if let Some(containers) = ancestors.get(account_set_id) {
-                for container in containers {
-                    if !account_paths.insert((*container, *account_id)) {
-                        return Err(AccountSetError::MemberAlreadyAdded);
-                    }
-                }
-            }
-        }
-
-        let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
-        if max_depth > MAX_MEMBERSHIP_DEPTH {
-            let (index, depth) = Self::first_depth_overflow(existing_edges, proposed_edges);
-            let (account_set_id, member_account_set_id) = proposed_edges[index];
-            return Err(AccountSetError::MembershipDepthExceeded {
-                account_set_id,
-                member_account_set_id,
-                depth,
-                max: MAX_MEMBERSHIP_DEPTH,
-            });
-        }
-
-        Ok(())
-    }
-
-    fn graph_has_path(
-        adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
-        from: AccountSetId,
-        to: AccountSetId,
-    ) -> bool {
-        let mut pending = vec![from];
-        let mut visited = HashSet::new();
-        while let Some(current) = pending.pop() {
-            if current == to {
-                return true;
-            }
-            if visited.insert(current) {
-                pending.extend(adjacency.get(&current).into_iter().flatten().copied());
-            }
-        }
-        false
-    }
-
-    fn first_depth_overflow(
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        proposed_edges: &[(AccountSetId, AccountSetId)],
-    ) -> (usize, i32) {
-        let mut low = 1;
-        let mut high = proposed_edges.len();
-        while low < high {
-            let middle = (low + high) / 2;
-            if Self::graph_max_depth(existing_edges, &proposed_edges[..middle])
-                > MAX_MEMBERSHIP_DEPTH
-            {
-                high = middle;
-            } else {
-                low = middle + 1;
-            }
-        }
-        (
-            low - 1,
-            Self::graph_max_depth(existing_edges, &proposed_edges[..low]),
-        )
-    }
-
-    fn graph_max_depth(
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        proposed_edges: &[(AccountSetId, AccountSetId)],
-    ) -> i32 {
-        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-            adjacency
-                .entry(*account_set_id)
-                .or_default()
-                .push(*member_account_set_id);
-            *indegree.entry(*member_account_set_id).or_default() += 1;
-            indegree.entry(*account_set_id).or_default();
-        }
-
-        let mut queue: VecDeque<AccountSetId> = indegree
-            .iter()
-            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-            .collect();
-        let mut depths = HashMap::new();
-        let mut max_depth = 0;
-        while let Some(account_set_id) = queue.pop_front() {
-            let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
-            if let Some(children) = adjacency.get(&account_set_id) {
-                for child in children {
-                    let child_depth = parent_depth + 1;
-                    depths
-                        .entry(*child)
-                        .and_modify(|depth| *depth = (*depth).max(child_depth))
-                        .or_insert(child_depth);
-                    max_depth = max_depth.max(child_depth);
-                    let degree = indegree
-                        .get_mut(child)
-                        .expect("every child must have an indegree");
-                    *degree -= 1;
-                    if *degree == 0 {
-                        queue.push_back(*child);
-                    }
-                }
-            }
-        }
-        max_depth
+        validate_set_memberships(&existing_edges, members, &account_members)
     }
 
     fn load(&self) -> Arc<GraphSnapshot> {

--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -19,9 +19,9 @@
 //!
 //! Layering: `AccountSets` (service) calls this cache; this cache holds
 //! a handle on `AccountSetRepo` and orchestrates — ALL SQL lives in
-//! `repo.rs`, cache state and account-path graph logic live here, and pure
-//! set-membership invariants live in `graph_validation.rs`. The call graph is
-//! strictly service -> cache -> repo; the repo never calls back up into the cache.
+//! `repo.rs`, cache state and snapshot adaptation live here, and pure graph
+//! invariants live in `graph_validation.rs`. The call graph is strictly
+//! service -> cache -> repo; the repo never calls back up into the cache.
 //!
 //! Why the split read is safe — the two inputs have opposite write
 //! rates:
@@ -92,7 +92,7 @@ use crate::primitives::{AccountId, AccountSetId, JournalId};
 
 use super::{
     error::AccountSetError,
-    graph_validation::validate_set_memberships,
+    graph_validation::{has_duplicate_account_membership_paths, validate_set_memberships},
     repo::{AccountSetRepo, DirectMembershipProbe, SetGraphNode},
 };
 
@@ -442,12 +442,31 @@ impl SetGraphCache {
             Some(Overlay { parents, meta })
         };
 
-        match Self::count_membership_paths(
-            &snapshot,
-            overlay.as_ref(),
+        let is_known = |set_id: &AccountSetId| -> bool {
+            snapshot.meta.contains_key(set_id)
+                || overlay
+                    .as_ref()
+                    .is_some_and(|overlay| overlay.meta.contains_key(set_id))
+        };
+        let parents_of = |set_id: &AccountSetId| -> &[AccountSetId] {
+            snapshot
+                .parents
+                .get(set_id)
+                .or_else(|| {
+                    overlay
+                        .as_ref()
+                        .and_then(|overlay| overlay.parents.get(set_id))
+                })
+                .map(Vec::as_slice)
+                .unwrap_or(&[])
+        };
+
+        match has_duplicate_account_membership_paths(
             account_set_ids,
             account_ids,
             &probe.seeds,
+            is_known,
+            parents_of,
         ) {
             Some(false) => {
                 span.record(
@@ -473,69 +492,6 @@ impl SetGraphCache {
                     .await
             }
         }
-    }
-
-    /// The in-memory mirror of the SQL walk's conflict predicate: seed
-    /// each account with its new target sets (pair multiplicity
-    /// preserved) plus its existing direct memberships, expand every
-    /// seed upward over snapshot + overlay counting *paths* (unlike
-    /// [`Self::expand`], which dedups via a visited set — reachability
-    /// is the wrong question here), and report a conflict as soon as any
-    /// `(account, set)` is reached twice.
-    ///
-    /// Returns `None` if a set id is unknown to snapshot + overlay —
-    /// caller falls back to the SQL walk.
-    ///
-    /// Terminates unconditionally: every pop increments some count and
-    /// the second increment of any count returns immediately, so pops
-    /// are bounded by (known sets + 1) per account. A corrupted cyclic
-    /// graph revisits a set and reports a conflict — a conservative
-    /// reject, where the SQL walk's unbounded UNION ALL recursion would
-    /// not terminate at all.
-    fn count_membership_paths(
-        snapshot: &GraphSnapshot,
-        overlay: Option<&Overlay>,
-        new_set_ids: &[AccountSetId],
-        new_account_ids: &[AccountId],
-        existing_seeds: &[(AccountId, AccountSetId)],
-    ) -> Option<bool> {
-        let known = |set_id: &AccountSetId| -> bool {
-            snapshot.meta.contains_key(set_id)
-                || overlay.is_some_and(|o| o.meta.contains_key(set_id))
-        };
-        let parents_of = |set_id: &AccountSetId| -> &[AccountSetId] {
-            snapshot
-                .parents
-                .get(set_id)
-                .or_else(|| overlay.and_then(|o| o.parents.get(set_id)))
-                .map(Vec::as_slice)
-                .unwrap_or(&[])
-        };
-
-        let mut per_account: HashMap<AccountId, Vec<AccountSetId>> = HashMap::new();
-        for (set_id, account_id) in new_set_ids.iter().zip(new_account_ids) {
-            per_account.entry(*account_id).or_default().push(*set_id);
-        }
-        for (account_id, set_id) in existing_seeds {
-            per_account.entry(*account_id).or_default().push(*set_id);
-        }
-
-        for seeds in per_account.into_values() {
-            let mut path_counts: HashMap<AccountSetId, u32> = HashMap::new();
-            let mut queue: VecDeque<AccountSetId> = seeds.into();
-            while let Some(set_id) = queue.pop_front() {
-                if !known(&set_id) {
-                    return None;
-                }
-                let count = path_counts.entry(set_id).or_default();
-                *count += 1;
-                if *count > 1 {
-                    return Some(true);
-                }
-                queue.extend(parents_of(&set_id));
-            }
-        }
-        Some(false)
     }
 
     /// Validate a batch of set-to-set memberships against the graph read

--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -93,7 +93,10 @@ use crate::primitives::{AccountId, AccountSetId, JournalId};
 
 use super::{
     error::AccountSetError,
-    graph_validation::{has_duplicate_account_membership_paths, validate_set_memberships},
+    graph_validation::{
+        has_duplicate_account_membership_paths, validate_set_memberships, AccountMembership,
+        SetMembership,
+    },
     repo::{AccountSetRepo, DirectMembershipProbe, SetGraphNode},
 };
 
@@ -139,15 +142,10 @@ impl GraphSnapshot {
         }
     }
 
-    fn edges_connected_to(
-        &self,
-        members: &[(AccountSetId, AccountSetId)],
-    ) -> Vec<(AccountSetId, AccountSetId)> {
+    fn edges_connected_to(&self, members: &[SetMembership]) -> Vec<SetMembership> {
         let mut pending: Vec<_> = members
             .iter()
-            .flat_map(|(account_set_id, member_account_set_id)| {
-                [*account_set_id, *member_account_set_id]
-            })
+            .flat_map(|edge| [edge.account_set_id, edge.member_account_set_id])
             .collect();
         let mut visited = HashSet::new();
         let mut edges = HashSet::new();
@@ -156,11 +154,17 @@ impl GraphSnapshot {
                 continue;
             }
             for parent_id in self.parents.get(&account_set_id).into_iter().flatten() {
-                edges.insert((*parent_id, account_set_id));
+                edges.insert(SetMembership {
+                    account_set_id: *parent_id,
+                    member_account_set_id: account_set_id,
+                });
                 pending.push(*parent_id);
             }
             for member_id in self.children.get(&account_set_id).into_iter().flatten() {
-                edges.insert((account_set_id, *member_id));
+                edges.insert(SetMembership {
+                    account_set_id,
+                    member_account_set_id: *member_id,
+                });
                 pending.push(*member_id);
             }
         }
@@ -271,7 +275,7 @@ impl SetGraphCache {
         op: &mut impl es_entity::AtomicOperation,
         journal_id: JournalId,
         probe_epoch: i64,
-        probe_seeds: &[(AccountId, AccountSetId)],
+        probe_seeds: &[AccountMembership],
         entry_pairs: &(Vec<AccountId>, Vec<&str>),
     ) -> Result<HashMap<AccountId, Vec<AccountSetId>>, AccountSetError> {
         let span = tracing::Span::current();
@@ -315,7 +319,7 @@ impl SetGraphCache {
             let mut missing: Vec<_> = probe
                 .seeds
                 .iter()
-                .map(|(_, set_id)| *set_id)
+                .map(|seed| seed.account_set_id)
                 .filter(|set_id| !snapshot.meta.contains_key(set_id))
                 .collect();
             missing.sort_unstable();
@@ -413,20 +417,19 @@ impl SetGraphCache {
     #[instrument(
         level = "debug",
         name = "account_set.assert_no_double_membership",
-        skip(self, op, account_set_ids, account_ids),
-        fields(pairs = account_ids.len(), path = tracing::field::Empty),
+        skip(self, op, members),
+        fields(pairs = members.len(), path = tracing::field::Empty),
         err(level = "warn")
     )]
     pub(super) async fn assert_no_double_membership_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
-        account_set_ids: &[AccountSetId],
-        account_ids: &[AccountId],
+        members: &[AccountMembership],
     ) -> Result<(), AccountSetError> {
         let span = tracing::Span::current();
 
         let distinct_account_ids: Vec<AccountId> = {
-            let mut ids = account_ids.to_vec();
+            let mut ids: Vec<AccountId> = members.iter().map(|m| m.account_id).collect();
             ids.sort_unstable();
             ids.dedup();
             ids
@@ -451,7 +454,7 @@ impl SetGraphCache {
             return self
                 .inner
                 .repo
-                .assert_no_double_membership(op, account_set_ids, account_ids)
+                .assert_no_double_membership(op, members)
                 .await;
         }
 
@@ -460,10 +463,10 @@ impl SetGraphCache {
         // last refresh — including in this op. Fetch them op-locally as an
         // overlay; never installed.
         let missing: Vec<AccountSetId> = {
-            let mut missing: Vec<_> = account_set_ids
+            let mut missing: Vec<_> = members
                 .iter()
-                .chain(probe.seeds.iter().map(|(_, set_id)| set_id))
-                .copied()
+                .chain(probe.seeds.iter())
+                .map(|membership| membership.account_set_id)
                 .filter(|set_id| !snapshot.meta.contains_key(set_id))
                 .collect();
             missing.sort_unstable();
@@ -482,32 +485,29 @@ impl SetGraphCache {
             Some(Overlay { parents, meta })
         };
 
-        let is_known = |set_id: &AccountSetId| -> bool {
-            snapshot.meta.contains_key(set_id)
+        // One lookup carries all three states the walk distinguishes: `None`
+        // for a set neither the snapshot nor the overlay knows (defer to SQL),
+        // `Some(&[])` for a known root, `Some(parents)` otherwise.
+        let parents_of = |set_id: &AccountSetId| -> Option<&[AccountSetId]> {
+            let known = snapshot.meta.contains_key(set_id)
                 || overlay
                     .as_ref()
-                    .is_some_and(|overlay| overlay.meta.contains_key(set_id))
-        };
-        let parents_of = |set_id: &AccountSetId| -> &[AccountSetId] {
-            snapshot
-                .parents
-                .get(set_id)
-                .or_else(|| {
-                    overlay
-                        .as_ref()
-                        .and_then(|overlay| overlay.parents.get(set_id))
-                })
-                .map(Vec::as_slice)
-                .unwrap_or(&[])
+                    .is_some_and(|overlay| overlay.meta.contains_key(set_id));
+            known.then(|| {
+                snapshot
+                    .parents
+                    .get(set_id)
+                    .or_else(|| {
+                        overlay
+                            .as_ref()
+                            .and_then(|overlay| overlay.parents.get(set_id))
+                    })
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[])
+            })
         };
 
-        match has_duplicate_account_membership_paths(
-            account_set_ids,
-            account_ids,
-            &probe.seeds,
-            is_known,
-            parents_of,
-        ) {
+        match has_duplicate_account_membership_paths(members, &probe.seeds, parents_of) {
             Some(false) => {
                 span.record(
                     "path",
@@ -528,7 +528,7 @@ impl SetGraphCache {
                 span.record("path", "fallback_unknown");
                 self.inner
                     .repo
-                    .assert_no_double_membership(op, account_set_ids, account_ids)
+                    .assert_no_double_membership(op, members)
                     .await
             }
         }
@@ -552,7 +552,7 @@ impl SetGraphCache {
     pub(super) async fn assert_valid_set_memberships_in_op(
         &self,
         op: &mut impl es_entity::AtomicOperation,
-        members: &[(AccountSetId, AccountSetId)],
+        members: &[SetMembership],
     ) -> Result<(), AccountSetError> {
         let span = tracing::Span::current();
         let snapshot = self.load();
@@ -627,7 +627,7 @@ impl SetGraphCache {
         snapshot: &GraphSnapshot,
         overlay: Option<&Overlay>,
         journal_id: JournalId,
-        seeds: &[(AccountId, AccountSetId)],
+        seeds: &[AccountMembership],
         (entry_account_ids, entry_currencies): &(Vec<AccountId>, Vec<&'c str>),
     ) -> Option<(
         HashMap<AccountId, Vec<AccountSetId>>,
@@ -650,8 +650,11 @@ impl SetGraphCache {
         };
 
         let mut per_account: HashMap<AccountId, Vec<AccountSetId>> = HashMap::new();
-        for (account_id, set_id) in seeds {
-            per_account.entry(*account_id).or_default().push(*set_id);
+        for seed in seeds {
+            per_account
+                .entry(seed.account_id)
+                .or_default()
+                .push(seed.account_set_id);
         }
 
         let mut mappings = HashMap::new();
@@ -756,6 +759,13 @@ impl SetGraphCache {
 mod tests {
     use super::*;
 
+    fn edge(account_set_id: AccountSetId, member_account_set_id: AccountSetId) -> SetMembership {
+        SetMembership {
+            account_set_id,
+            member_account_set_id,
+        }
+    }
+
     #[test]
     fn batch_validation_selects_only_connected_snapshot_edges() {
         let root = AccountSetId::new();
@@ -780,11 +790,14 @@ mod tests {
         };
 
         let edges: HashSet<_> = snapshot
-            .edges_connected_to(&[(branch, proposed_leaf)])
+            .edges_connected_to(&[edge(branch, proposed_leaf)])
             .into_iter()
             .collect();
 
-        assert_eq!(edges, HashSet::from([(root, branch), (branch, leaf)]));
+        assert_eq!(
+            edges,
+            HashSet::from([edge(root, branch), edge(branch, leaf)])
+        );
     }
 
     #[test]
@@ -811,13 +824,13 @@ mod tests {
         };
 
         let edges: HashSet<_> = snapshot
-            .edges_connected_to(&[(left_leaf, right_root)])
+            .edges_connected_to(&[edge(left_leaf, right_root)])
             .into_iter()
             .collect();
 
         assert_eq!(
             edges,
-            HashSet::from([(left_root, left_leaf), (right_root, right_leaf)])
+            HashSet::from([edge(left_root, left_leaf), edge(right_root, right_leaf)])
         );
     }
 }

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -10,64 +10,112 @@ use super::error::AccountSetError;
 /// headroom.
 pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
 
-/// Count paths from each account's proposed and existing direct memberships
-/// through the supplied parent graph. Returns `None` when the graph view does
-/// not know a traversed set, allowing the cache adapter to fall back to SQL.
+/// A directed hierarchy edge: `member_account_set_id` is a direct member of
+/// `account_set_id`.
+///
+/// Both ends are `AccountSetId`, so a bare pair offers no protection against
+/// transposing container and member — a swap type-checks and silently inverts
+/// the graph. Naming the ends makes the direction explicit at every call site.
+/// The field names mirror the `cala_account_set_member_account_sets` columns
+/// and the outbox payload, so one vocabulary carries from SQL through the cache
+/// into this validator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct SetMembership {
+    pub account_set_id: AccountSetId,
+    pub member_account_set_id: AccountSetId,
+}
+
+impl From<(AccountSetId, AccountSetId)> for SetMembership {
+    fn from((account_set_id, member_account_set_id): (AccountSetId, AccountSetId)) -> Self {
+        Self {
+            account_set_id,
+            member_account_set_id,
+        }
+    }
+}
+
+/// An account's direct membership in a set.
+///
+/// This replaces the two transposed pair shapes the module previously carried
+/// for one concept — `(set, account)` for proposed members and account-member
+/// rows, `(account, set)` for probed seeds. A single orientation means code
+/// that consumes both sources (the path walk below) can no longer read one of
+/// them backwards. Only the canonical `(set, account)` `From` is provided, so
+/// the transposed order cannot be converted in by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct AccountMembership {
+    pub account_set_id: AccountSetId,
+    pub account_id: AccountId,
+}
+
+impl From<(AccountSetId, AccountId)> for AccountMembership {
+    fn from((account_set_id, account_id): (AccountSetId, AccountId)) -> Self {
+        Self {
+            account_set_id,
+            account_id,
+        }
+    }
+}
+
+/// Count containment paths from each account's proposed and existing direct
+/// memberships upward through `parents_of`.
+///
+/// `parents_of` answers every state the walk distinguishes: `None` for a set
+/// the graph view does not know (the caller falls back to SQL), `Some(&[])`
+/// for a known root, and `Some(parents)` otherwise. Returns `None` when any
+/// traversed set is unknown, `Some(true)` when some account reaches the same
+/// set twice, `Some(false)` when every path is unique.
 pub(super) fn has_duplicate_account_membership_paths<'a>(
-    new_set_ids: &[AccountSetId],
-    new_account_ids: &[AccountId],
-    existing_seeds: &[(AccountId, AccountSetId)],
-    is_known: impl Fn(&AccountSetId) -> bool,
-    parents_of: impl Fn(&AccountSetId) -> &'a [AccountSetId],
+    proposed: &[AccountMembership],
+    existing: &[AccountMembership],
+    parents_of: impl Fn(&AccountSetId) -> Option<&'a [AccountSetId]>,
 ) -> Option<bool> {
     let mut per_account: HashMap<AccountId, Vec<AccountSetId>> = HashMap::new();
-    for (set_id, account_id) in new_set_ids.iter().zip(new_account_ids) {
-        per_account.entry(*account_id).or_default().push(*set_id);
-    }
-    for (account_id, set_id) in existing_seeds {
-        per_account.entry(*account_id).or_default().push(*set_id);
+    for membership in proposed.iter().chain(existing) {
+        per_account
+            .entry(membership.account_id)
+            .or_default()
+            .push(membership.account_set_id);
     }
 
     for seeds in per_account.into_values() {
         let mut path_counts: HashMap<AccountSetId, u32> = HashMap::new();
         let mut queue: VecDeque<AccountSetId> = seeds.into();
-        while let Some(set_id) = queue.pop_front() {
-            if !is_known(&set_id) {
-                return None;
-            }
-            let count = path_counts.entry(set_id).or_default();
+        while let Some(account_set_id) = queue.pop_front() {
+            let parents = parents_of(&account_set_id)?;
+            let count = path_counts.entry(account_set_id).or_default();
             *count += 1;
             if *count > 1 {
                 return Some(true);
             }
-            queue.extend(parents_of(&set_id));
+            queue.extend(parents);
         }
     }
     Some(false)
 }
 
 pub(super) fn validate_set_memberships(
-    existing_edges: &[(AccountSetId, AccountSetId)],
-    proposed_edges: &[(AccountSetId, AccountSetId)],
-    account_members: &[(AccountSetId, AccountId)],
+    existing_edges: &[SetMembership],
+    proposed_edges: &[SetMembership],
+    account_members: &[AccountMembership],
 ) -> Result<(), AccountSetError> {
     let mut nodes = HashSet::new();
     let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
     let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
 
-    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-        nodes.insert(*account_set_id);
-        nodes.insert(*member_account_set_id);
+    for edge in existing_edges.iter().chain(proposed_edges) {
+        nodes.insert(edge.account_set_id);
+        nodes.insert(edge.member_account_set_id);
         adjacency
-            .entry(*account_set_id)
+            .entry(edge.account_set_id)
             .or_default()
-            .push(*member_account_set_id);
-        *indegree.entry(*member_account_set_id).or_default() += 1;
-        indegree.entry(*account_set_id).or_default();
+            .push(edge.member_account_set_id);
+        *indegree.entry(edge.member_account_set_id).or_default() += 1;
+        indegree.entry(edge.account_set_id).or_default();
     }
-    for (account_set_id, _) in account_members {
-        nodes.insert(*account_set_id);
-        indegree.entry(*account_set_id).or_default();
+    for membership in account_members {
+        nodes.insert(membership.account_set_id);
+        indegree.entry(membership.account_set_id).or_default();
     }
 
     let mut queue: VecDeque<AccountSetId> = indegree
@@ -95,18 +143,18 @@ pub(super) fn validate_set_memberships(
         // graph is a DAG). If it is in the existing graph that is
         // corrupted state; attribute to the first existing edge so the
         // fallback never indexes an empty proposed-edges slice.
-        let (account_set_id, member_account_set_id) = proposed_edges
+        let edge = proposed_edges
             .iter()
-            .find(|(account_set_id, member_account_set_id)| {
-                account_set_id == member_account_set_id
-                    || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
+            .find(|edge| {
+                edge.account_set_id == edge.member_account_set_id
+                    || graph_has_path(&adjacency, edge.member_account_set_id, edge.account_set_id)
             })
             .copied()
             .or_else(|| existing_edges.first().copied())
             .expect("cycle detected in a graph with no edges");
         return Err(AccountSetError::MembershipCycleDetected {
-            account_set_id,
-            member_account_set_id,
+            account_set_id: edge.account_set_id,
+            member_account_set_id: edge.member_account_set_id,
         });
     }
 
@@ -136,14 +184,20 @@ pub(super) fn validate_set_memberships(
         }
     }
 
+    // Every containment an account gains, direct or inherited, must be
+    // reached exactly once. `AccountMembership` is the natural set element:
+    // a repeated insert *is* a duplicate containment path.
     let mut account_paths = HashSet::new();
-    for (account_set_id, account_id) in account_members {
-        if !account_paths.insert((*account_set_id, *account_id)) {
+    for membership in account_members {
+        if !account_paths.insert(*membership) {
             return Err(AccountSetError::MemberAlreadyAdded);
         }
-        if let Some(containers) = ancestors.get(account_set_id) {
+        if let Some(containers) = ancestors.get(&membership.account_set_id) {
             for container in containers {
-                if !account_paths.insert((*container, *account_id)) {
+                if !account_paths.insert(AccountMembership {
+                    account_set_id: *container,
+                    account_id: membership.account_id,
+                }) {
                     return Err(AccountSetError::MemberAlreadyAdded);
                 }
             }
@@ -153,10 +207,10 @@ pub(super) fn validate_set_memberships(
     let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
     if max_depth > MAX_MEMBERSHIP_DEPTH {
         let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
-        let (account_set_id, member_account_set_id) = proposed_edges[index];
+        let edge = proposed_edges[index];
         return Err(AccountSetError::MembershipDepthExceeded {
-            account_set_id,
-            member_account_set_id,
+            account_set_id: edge.account_set_id,
+            member_account_set_id: edge.member_account_set_id,
             depth,
             max: MAX_MEMBERSHIP_DEPTH,
         });
@@ -191,8 +245,8 @@ fn graph_has_path(
 /// reported `depth` therefore reflects the bound that was exceeded, and the
 /// returned index identifies the first edge responsible.
 fn first_depth_overflow(
-    existing_edges: &[(AccountSetId, AccountSetId)],
-    proposed_edges: &[(AccountSetId, AccountSetId)],
+    existing_edges: &[SetMembership],
+    proposed_edges: &[SetMembership],
 ) -> (usize, i32) {
     let mut low = 1;
     let mut high = proposed_edges.len();
@@ -210,19 +264,16 @@ fn first_depth_overflow(
     )
 }
 
-fn graph_max_depth(
-    existing_edges: &[(AccountSetId, AccountSetId)],
-    proposed_edges: &[(AccountSetId, AccountSetId)],
-) -> i32 {
+fn graph_max_depth(existing_edges: &[SetMembership], proposed_edges: &[SetMembership]) -> i32 {
     let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
     let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+    for edge in existing_edges.iter().chain(proposed_edges) {
         adjacency
-            .entry(*account_set_id)
+            .entry(edge.account_set_id)
             .or_default()
-            .push(*member_account_set_id);
-        *indegree.entry(*member_account_set_id).or_default() += 1;
-        indegree.entry(*account_set_id).or_default();
+            .push(edge.member_account_set_id);
+        *indegree.entry(edge.member_account_set_id).or_default() += 1;
+        indegree.entry(edge.account_set_id).or_default();
     }
 
     let mut queue: VecDeque<AccountSetId> = indegree
@@ -262,6 +313,20 @@ mod tests {
         std::array::from_fn(|_| AccountSetId::new())
     }
 
+    fn edge(account_set_id: AccountSetId, member_account_set_id: AccountSetId) -> SetMembership {
+        SetMembership {
+            account_set_id,
+            member_account_set_id,
+        }
+    }
+
+    fn member(account_set_id: AccountSetId, account_id: AccountId) -> AccountMembership {
+        AccountMembership {
+            account_set_id,
+            account_id,
+        }
+    }
+
     #[test]
     fn account_paths_accept_distinct_ancestors() {
         let [left, right] = set_ids();
@@ -271,11 +336,12 @@ mod tests {
 
         assert_eq!(
             has_duplicate_account_membership_paths(
-                &[left, right],
-                &[account_id, account_id],
+                &[member(left, account_id), member(right, account_id)],
                 &[],
-                |set_id| known.contains(set_id),
-                |set_id| parents.get(set_id).map(Vec::as_slice).unwrap_or(&[]),
+                |account_set_id| known.contains(account_set_id).then(|| parents
+                    .get(account_set_id)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[])),
             ),
             Some(false)
         );
@@ -290,11 +356,12 @@ mod tests {
 
         assert_eq!(
             has_duplicate_account_membership_paths(
-                &[left, right],
-                &[account_id, account_id],
+                &[member(left, account_id), member(right, account_id)],
                 &[],
-                |set_id| known.contains(set_id),
-                |set_id| parents.get(set_id).map(Vec::as_slice).unwrap_or(&[]),
+                |account_set_id| known.contains(account_set_id).then(|| parents
+                    .get(account_set_id)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[])),
             ),
             Some(true)
         );
@@ -306,11 +373,9 @@ mod tests {
 
         assert_eq!(
             has_duplicate_account_membership_paths(
-                &[unknown],
-                &[AccountId::new()],
+                &[member(unknown, AccountId::new())],
                 &[],
-                |_| false,
-                |_| &[],
+                |_| None,
             ),
             None
         );
@@ -319,8 +384,8 @@ mod tests {
     #[test]
     fn set_paths_accept_a_valid_combined_tree() {
         let [root, branch, existing_leaf, proposed_leaf] = set_ids();
-        let existing = [(root, branch), (branch, existing_leaf)];
-        let proposed = [(branch, proposed_leaf)];
+        let existing = [edge(root, branch), edge(branch, existing_leaf)];
+        let proposed = [edge(branch, proposed_leaf)];
 
         assert!(validate_set_memberships(&existing, &proposed, &[]).is_ok());
     }
@@ -328,7 +393,7 @@ mod tests {
     #[test]
     fn set_paths_reject_a_cycle_created_within_the_batch() {
         let [a, b, c] = set_ids();
-        let proposed = [(a, b), (b, c), (c, a)];
+        let proposed = [edge(a, b), edge(b, c), edge(c, a)];
 
         assert!(matches!(
             validate_set_memberships(&[], &proposed, &[]),
@@ -339,8 +404,8 @@ mod tests {
     #[test]
     fn set_paths_reject_a_duplicate_existing_and_proposed_path() {
         let [root, branch, leaf] = set_ids();
-        let existing = [(root, branch), (branch, leaf)];
-        let proposed = [(root, leaf)];
+        let existing = [edge(root, branch), edge(branch, leaf)];
+        let proposed = [edge(root, leaf)];
 
         assert!(matches!(
             validate_set_memberships(&existing, &proposed, &[]),
@@ -352,8 +417,8 @@ mod tests {
     fn set_paths_reject_an_account_reachable_twice() {
         let [root, left, right] = set_ids();
         let account_id = AccountId::new();
-        let existing = [(root, left), (root, right)];
-        let account_members = [(left, account_id), (right, account_id)];
+        let existing = [edge(root, left), edge(root, right)];
+        let account_members = [member(left, account_id), member(right, account_id)];
 
         assert!(matches!(
             validate_set_memberships(&existing, &[], &account_members),
@@ -364,7 +429,7 @@ mod tests {
     #[test]
     fn set_paths_attribute_the_first_depth_overflow() {
         let sets: [AccountSetId; 18] = set_ids();
-        let proposed: Vec<_> = sets.windows(2).map(|pair| (pair[0], pair[1])).collect();
+        let proposed: Vec<_> = sets.windows(2).map(|pair| edge(pair[0], pair[1])).collect();
 
         assert!(matches!(
             validate_set_memberships(&[], &proposed, &[]),

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -10,6 +10,42 @@ use super::error::AccountSetError;
 /// headroom.
 pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
 
+/// Count paths from each account's proposed and existing direct memberships
+/// through the supplied parent graph. Returns `None` when the graph view does
+/// not know a traversed set, allowing the cache adapter to fall back to SQL.
+pub(super) fn has_duplicate_account_membership_paths<'a>(
+    new_set_ids: &[AccountSetId],
+    new_account_ids: &[AccountId],
+    existing_seeds: &[(AccountId, AccountSetId)],
+    is_known: impl Fn(&AccountSetId) -> bool,
+    parents_of: impl Fn(&AccountSetId) -> &'a [AccountSetId],
+) -> Option<bool> {
+    let mut per_account: HashMap<AccountId, Vec<AccountSetId>> = HashMap::new();
+    for (set_id, account_id) in new_set_ids.iter().zip(new_account_ids) {
+        per_account.entry(*account_id).or_default().push(*set_id);
+    }
+    for (account_id, set_id) in existing_seeds {
+        per_account.entry(*account_id).or_default().push(*set_id);
+    }
+
+    for seeds in per_account.into_values() {
+        let mut path_counts: HashMap<AccountSetId, u32> = HashMap::new();
+        let mut queue: VecDeque<AccountSetId> = seeds.into();
+        while let Some(set_id) = queue.pop_front() {
+            if !is_known(&set_id) {
+                return None;
+            }
+            let count = path_counts.entry(set_id).or_default();
+            *count += 1;
+            if *count > 1 {
+                return Some(true);
+            }
+            queue.extend(parents_of(&set_id));
+        }
+    }
+    Some(false)
+}
+
 pub(super) fn validate_set_memberships(
     existing_edges: &[(AccountSetId, AccountSetId)],
     proposed_edges: &[(AccountSetId, AccountSetId)],
@@ -212,6 +248,60 @@ mod tests {
 
     fn set_ids<const N: usize>() -> [AccountSetId; N] {
         std::array::from_fn(|_| AccountSetId::new())
+    }
+
+    #[test]
+    fn account_paths_accept_distinct_ancestors() {
+        let [left, right] = set_ids();
+        let account_id = AccountId::new();
+        let known = HashSet::from([left, right]);
+        let parents: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+
+        assert_eq!(
+            has_duplicate_account_membership_paths(
+                &[left, right],
+                &[account_id, account_id],
+                &[],
+                |set_id| known.contains(set_id),
+                |set_id| parents.get(set_id).map(Vec::as_slice).unwrap_or(&[]),
+            ),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn account_paths_reject_a_shared_ancestor() {
+        let [root, left, right] = set_ids();
+        let account_id = AccountId::new();
+        let known = HashSet::from([root, left, right]);
+        let parents = HashMap::from([(left, vec![root]), (right, vec![root])]);
+
+        assert_eq!(
+            has_duplicate_account_membership_paths(
+                &[left, right],
+                &[account_id, account_id],
+                &[],
+                |set_id| known.contains(set_id),
+                |set_id| parents.get(set_id).map(Vec::as_slice).unwrap_or(&[]),
+            ),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn account_paths_defer_an_unknown_set() {
+        let [unknown] = set_ids();
+
+        assert_eq!(
+            has_duplicate_account_membership_paths(
+                &[unknown],
+                &[AccountId::new()],
+                &[],
+                |_| false,
+                |_| &[],
+            ),
+            None
+        );
     }
 
     #[test]

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -1,0 +1,277 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::primitives::{AccountId, AccountSetId};
+
+use super::error::AccountSetError;
+
+/// Maximum depth (in set->set edges) of any root-to-leaf membership
+/// chain. Rejecting edges past this bound keeps the read-time ancestor
+/// walk cheap and terminating. Real hierarchies are <=10 deep; 16 leaves
+/// headroom.
+pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
+
+pub(super) fn validate_set_memberships(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+    account_members: &[(AccountSetId, AccountId)],
+) -> Result<(), AccountSetError> {
+    let mut nodes = HashSet::new();
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        nodes.insert(*account_set_id);
+        nodes.insert(*member_account_set_id);
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+    for (account_set_id, _) in account_members {
+        nodes.insert(*account_set_id);
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut topological_order = Vec::with_capacity(nodes.len());
+    while let Some(account_set_id) = queue.pop_front() {
+        topological_order.push(account_set_id);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+
+    if topological_order.len() != nodes.len() {
+        let (account_set_id, member_account_set_id) = proposed_edges
+            .iter()
+            .find(|(account_set_id, member_account_set_id)| {
+                account_set_id == member_account_set_id
+                    || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
+            })
+            .copied()
+            .unwrap_or(proposed_edges[0]);
+        return Err(AccountSetError::MembershipCycleDetected {
+            account_set_id,
+            member_account_set_id,
+        });
+    }
+
+    // In topological order, every parent's ancestor set is complete before
+    // its contribution reaches a child. An overlap means the child has two
+    // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
+    // worst case instead of enumerating exponentially many paths.
+    let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
+    let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
+    for account_set_id in &topological_order {
+        let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
+        contribution.insert(*account_set_id);
+        let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
+
+        if let Some(children) = adjacency.get(account_set_id) {
+            for child in children {
+                let child_ancestors = ancestors.entry(*child).or_default();
+                if !child_ancestors.is_disjoint(&contribution) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+                child_ancestors.extend(contribution.iter().copied());
+                depth_from_root
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
+                    .or_insert(parent_depth + 1);
+            }
+        }
+    }
+
+    let mut account_paths = HashSet::new();
+    for (account_set_id, account_id) in account_members {
+        if !account_paths.insert((*account_set_id, *account_id)) {
+            return Err(AccountSetError::MemberAlreadyAdded);
+        }
+        if let Some(containers) = ancestors.get(account_set_id) {
+            for container in containers {
+                if !account_paths.insert((*container, *account_id)) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+            }
+        }
+    }
+
+    let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
+    if max_depth > MAX_MEMBERSHIP_DEPTH {
+        let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
+        let (account_set_id, member_account_set_id) = proposed_edges[index];
+        return Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth,
+            max: MAX_MEMBERSHIP_DEPTH,
+        });
+    }
+
+    Ok(())
+}
+
+fn graph_has_path(
+    adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
+    from: AccountSetId,
+    to: AccountSetId,
+) -> bool {
+    let mut pending = vec![from];
+    let mut visited = HashSet::new();
+    while let Some(current) = pending.pop() {
+        if current == to {
+            return true;
+        }
+        if visited.insert(current) {
+            pending.extend(adjacency.get(&current).into_iter().flatten().copied());
+        }
+    }
+    false
+}
+
+fn first_depth_overflow(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> (usize, i32) {
+    let mut low = 1;
+    let mut high = proposed_edges.len();
+    while low < high {
+        let middle = (low + high) / 2;
+        if graph_max_depth(existing_edges, &proposed_edges[..middle]) > MAX_MEMBERSHIP_DEPTH {
+            high = middle;
+        } else {
+            low = middle + 1;
+        }
+    }
+    (
+        low - 1,
+        graph_max_depth(existing_edges, &proposed_edges[..low]),
+    )
+}
+
+fn graph_max_depth(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> i32 {
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut depths = HashMap::new();
+    let mut max_depth = 0;
+    while let Some(account_set_id) = queue.pop_front() {
+        let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let child_depth = parent_depth + 1;
+                depths
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(child_depth))
+                    .or_insert(child_depth);
+                max_depth = max_depth.max(child_depth);
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+    max_depth
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_ids<const N: usize>() -> [AccountSetId; N] {
+        std::array::from_fn(|_| AccountSetId::new())
+    }
+
+    #[test]
+    fn set_paths_accept_a_valid_combined_tree() {
+        let [root, branch, existing_leaf, proposed_leaf] = set_ids();
+        let existing = [(root, branch), (branch, existing_leaf)];
+        let proposed = [(branch, proposed_leaf)];
+
+        assert!(validate_set_memberships(&existing, &proposed, &[]).is_ok());
+    }
+
+    #[test]
+    fn set_paths_reject_a_cycle_created_within_the_batch() {
+        let [a, b, c] = set_ids();
+        let proposed = [(a, b), (b, c), (c, a)];
+
+        assert!(matches!(
+            validate_set_memberships(&[], &proposed, &[]),
+            Err(AccountSetError::MembershipCycleDetected { .. })
+        ));
+    }
+
+    #[test]
+    fn set_paths_reject_a_duplicate_existing_and_proposed_path() {
+        let [root, branch, leaf] = set_ids();
+        let existing = [(root, branch), (branch, leaf)];
+        let proposed = [(root, leaf)];
+
+        assert!(matches!(
+            validate_set_memberships(&existing, &proposed, &[]),
+            Err(AccountSetError::MemberAlreadyAdded)
+        ));
+    }
+
+    #[test]
+    fn set_paths_reject_an_account_reachable_twice() {
+        let [root, left, right] = set_ids();
+        let account_id = AccountId::new();
+        let existing = [(root, left), (root, right)];
+        let account_members = [(left, account_id), (right, account_id)];
+
+        assert!(matches!(
+            validate_set_memberships(&existing, &[], &account_members),
+            Err(AccountSetError::MemberAlreadyAdded)
+        ));
+    }
+
+    #[test]
+    fn set_paths_attribute_the_first_depth_overflow() {
+        let sets: [AccountSetId; 18] = set_ids();
+        let proposed: Vec<_> = sets.windows(2).map(|pair| (pair[0], pair[1])).collect();
+
+        assert!(matches!(
+            validate_set_memberships(&[], &proposed, &[]),
+            Err(AccountSetError::MembershipDepthExceeded {
+                account_set_id,
+                member_account_set_id,
+                depth: 17,
+                max: 16,
+            }) if account_set_id == sets[16] && member_account_set_id == sets[17]
+        ));
+    }
+}

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -51,6 +51,10 @@ pub(super) fn validate_set_memberships(
     proposed_edges: &[(AccountSetId, AccountSetId)],
     account_members: &[(AccountSetId, AccountId)],
 ) -> Result<(), AccountSetError> {
+    debug_assert!(
+        !proposed_edges.is_empty(),
+        "batch validation requires at least one proposed edge"
+    );
     let mut nodes = HashSet::new();
     let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
     let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -94,40 +94,91 @@ pub(super) fn has_duplicate_account_membership_paths<'a>(
     Some(false)
 }
 
-pub(super) fn validate_set_memberships(
-    existing_edges: &[SetMembership],
-    proposed_edges: &[SetMembership],
-    account_members: &[AccountMembership],
-) -> Result<(), AccountSetError> {
-    let mut nodes = HashSet::new();
-    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+/// The combined existing-plus-proposed set graph, indexed once.
+///
+/// Nodes are exactly the keys of `indegree`: every edge endpoint gets an entry
+/// (the member's is incremented, the container's defaulted), and isolated sets
+/// are added explicitly. That makes a separate node set redundant, so the cycle
+/// test is `order.len() != node_count()`.
+struct SetDag {
+    adjacency: HashMap<AccountSetId, Vec<AccountSetId>>,
+    indegree: HashMap<AccountSetId, usize>,
+}
 
-    for edge in existing_edges.iter().chain(proposed_edges) {
-        nodes.insert(edge.account_set_id);
-        nodes.insert(edge.member_account_set_id);
-        adjacency
-            .entry(edge.account_set_id)
-            .or_default()
-            .push(edge.member_account_set_id);
-        *indegree.entry(edge.member_account_set_id).or_default() += 1;
-        indegree.entry(edge.account_set_id).or_default();
+/// One Kahn pass over a [`SetDag`], yielding both products the validator needs:
+/// the topological order and each node's longest-path depth from a root.
+///
+/// These were previously two separate walks — one ordering, one measuring
+/// depth — computing the same recurrence with the same `max` merge. Producing
+/// them together is what keeps a single traversal implementation in the module.
+struct Traversal {
+    order: Vec<AccountSetId>,
+    depths: HashMap<AccountSetId, i32>,
+}
+
+impl Traversal {
+    fn max_depth(&self) -> i32 {
+        self.depths.values().copied().max().unwrap_or(0)
     }
-    for membership in account_members {
-        nodes.insert(membership.account_set_id);
-        indegree.entry(membership.account_set_id).or_default();
+}
+
+impl SetDag {
+    fn new<'a>(edges: impl IntoIterator<Item = &'a SetMembership>) -> Self {
+        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+        for edge in edges {
+            adjacency
+                .entry(edge.account_set_id)
+                .or_default()
+                .push(edge.member_account_set_id);
+            *indegree.entry(edge.member_account_set_id).or_default() += 1;
+            indegree.entry(edge.account_set_id).or_default();
+        }
+        Self {
+            adjacency,
+            indegree,
+        }
     }
 
-    let mut queue: VecDeque<AccountSetId> = indegree
-        .iter()
-        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-        .collect();
-    let mut topological_order = Vec::with_capacity(nodes.len());
-    while let Some(account_set_id) = queue.pop_front() {
-        topological_order.push(account_set_id);
-        if let Some(children) = adjacency.get(&account_set_id) {
-            for child in children {
-                let degree = indegree
+    /// Register a set that carries no edges of its own, so it still counts as
+    /// a node for the cycle test.
+    fn add_isolated(&mut self, account_set_id: AccountSetId) {
+        self.indegree.entry(account_set_id).or_default();
+    }
+
+    fn node_count(&self) -> usize {
+        self.indegree.len()
+    }
+
+    fn children(&self, account_set_id: &AccountSetId) -> &[AccountSetId] {
+        self.adjacency
+            .get(account_set_id)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Kahn's algorithm. `order` is shorter than [`Self::node_count`] exactly
+    /// when the graph contains a cycle (the nodes on it never reach indegree 0).
+    fn traverse(&self) -> Traversal {
+        // Cloned because the walk consumes indegrees and `&self` may be
+        // traversed more than once; O(V), dominated by the O(V + E) walk.
+        let mut remaining = self.indegree.clone();
+        let mut queue: VecDeque<AccountSetId> = remaining
+            .iter()
+            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+            .collect();
+        let mut order = Vec::with_capacity(remaining.len());
+        let mut depths: HashMap<AccountSetId, i32> = HashMap::new();
+
+        while let Some(account_set_id) = queue.pop_front() {
+            order.push(account_set_id);
+            let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
+            for child in self.children(&account_set_id) {
+                depths
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
+                    .or_insert(parent_depth + 1);
+                let degree = remaining
                     .get_mut(child)
                     .expect("every child must have an indegree");
                 *degree -= 1;
@@ -136,9 +187,36 @@ pub(super) fn validate_set_memberships(
                 }
             }
         }
+        Traversal { order, depths }
     }
 
-    if topological_order.len() != nodes.len() {
+    fn has_path(&self, from: AccountSetId, to: AccountSetId) -> bool {
+        let mut pending = vec![from];
+        let mut visited = HashSet::new();
+        while let Some(current) = pending.pop() {
+            if current == to {
+                return true;
+            }
+            if visited.insert(current) {
+                pending.extend(self.children(&current));
+            }
+        }
+        false
+    }
+}
+
+pub(super) fn validate_set_memberships(
+    existing_edges: &[SetMembership],
+    proposed_edges: &[SetMembership],
+    account_members: &[AccountMembership],
+) -> Result<(), AccountSetError> {
+    let mut dag = SetDag::new(existing_edges.iter().chain(proposed_edges));
+    for membership in account_members {
+        dag.add_isolated(membership.account_set_id);
+    }
+    let traversal = dag.traverse();
+
+    if traversal.order.len() != dag.node_count() {
         // A cycle must involve at least one proposed edge (the committed
         // graph is a DAG). If it is in the existing graph that is
         // corrupted state; attribute to the first existing edge so the
@@ -147,7 +225,7 @@ pub(super) fn validate_set_memberships(
             .iter()
             .find(|edge| {
                 edge.account_set_id == edge.member_account_set_id
-                    || graph_has_path(&adjacency, edge.member_account_set_id, edge.account_set_id)
+                    || dag.has_path(edge.member_account_set_id, edge.account_set_id)
             })
             .copied()
             .or_else(|| existing_edges.first().copied())
@@ -163,24 +241,16 @@ pub(super) fn validate_set_memberships(
     // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
     // worst case instead of enumerating exponentially many paths.
     let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
-    let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
-    for account_set_id in &topological_order {
+    for account_set_id in &traversal.order {
         let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
         contribution.insert(*account_set_id);
-        let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
 
-        if let Some(children) = adjacency.get(account_set_id) {
-            for child in children {
-                let child_ancestors = ancestors.entry(*child).or_default();
-                if !child_ancestors.is_disjoint(&contribution) {
-                    return Err(AccountSetError::MemberAlreadyAdded);
-                }
-                child_ancestors.extend(contribution.iter().copied());
-                depth_from_root
-                    .entry(*child)
-                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
-                    .or_insert(parent_depth + 1);
+        for child in dag.children(account_set_id) {
+            let child_ancestors = ancestors.entry(*child).or_default();
+            if !child_ancestors.is_disjoint(&contribution) {
+                return Err(AccountSetError::MemberAlreadyAdded);
             }
+            child_ancestors.extend(contribution.iter().copied());
         }
     }
 
@@ -204,8 +274,7 @@ pub(super) fn validate_set_memberships(
         }
     }
 
-    let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
-    if max_depth > MAX_MEMBERSHIP_DEPTH {
+    if traversal.max_depth() > MAX_MEMBERSHIP_DEPTH {
         let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
         let edge = proposed_edges[index];
         return Err(AccountSetError::MembershipDepthExceeded {
@@ -219,24 +288,6 @@ pub(super) fn validate_set_memberships(
     Ok(())
 }
 
-fn graph_has_path(
-    adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
-    from: AccountSetId,
-    to: AccountSetId,
-) -> bool {
-    let mut pending = vec![from];
-    let mut visited = HashSet::new();
-    while let Some(current) = pending.pop() {
-        if current == to {
-            return true;
-        }
-        if visited.insert(current) {
-            pending.extend(adjacency.get(&current).into_iter().flatten().copied());
-        }
-    }
-    false
-}
-
 /// Find the first proposed edge whose inclusion makes the *combined*
 /// existing-plus-proposed graph exceed `MAX_MEMBERSHIP_DEPTH`. The returned
 /// depth is the maximum depth of that combined graph (not only the depth of
@@ -244,65 +295,32 @@ fn graph_has_path(
 /// bound so the read-time ancestor walk stays cheap and terminating; the
 /// reported `depth` therefore reflects the bound that was exceeded, and the
 /// returned index identifies the first edge responsible.
+///
+/// Each probe rebuilds the graph for its prefix, so this is O(E log P) — but it
+/// runs only once the batch is already being rejected, never on the accept
+/// path. Depth is monotone in the prefix length, which is what makes the binary
+/// search valid; maintaining depths incrementally instead would be O(P(V + E)),
+/// worse than this for exactly the large batches that would motivate it.
 fn first_depth_overflow(
     existing_edges: &[SetMembership],
     proposed_edges: &[SetMembership],
 ) -> (usize, i32) {
+    let prefix_depth = |take: usize| {
+        SetDag::new(existing_edges.iter().chain(&proposed_edges[..take]))
+            .traverse()
+            .max_depth()
+    };
     let mut low = 1;
     let mut high = proposed_edges.len();
     while low < high {
         let middle = (low + high) / 2;
-        if graph_max_depth(existing_edges, &proposed_edges[..middle]) > MAX_MEMBERSHIP_DEPTH {
+        if prefix_depth(middle) > MAX_MEMBERSHIP_DEPTH {
             high = middle;
         } else {
             low = middle + 1;
         }
     }
-    (
-        low - 1,
-        graph_max_depth(existing_edges, &proposed_edges[..low]),
-    )
-}
-
-fn graph_max_depth(existing_edges: &[SetMembership], proposed_edges: &[SetMembership]) -> i32 {
-    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-    for edge in existing_edges.iter().chain(proposed_edges) {
-        adjacency
-            .entry(edge.account_set_id)
-            .or_default()
-            .push(edge.member_account_set_id);
-        *indegree.entry(edge.member_account_set_id).or_default() += 1;
-        indegree.entry(edge.account_set_id).or_default();
-    }
-
-    let mut queue: VecDeque<AccountSetId> = indegree
-        .iter()
-        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-        .collect();
-    let mut depths = HashMap::new();
-    let mut max_depth = 0;
-    while let Some(account_set_id) = queue.pop_front() {
-        let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
-        if let Some(children) = adjacency.get(&account_set_id) {
-            for child in children {
-                let child_depth = parent_depth + 1;
-                depths
-                    .entry(*child)
-                    .and_modify(|depth| *depth = (*depth).max(child_depth))
-                    .or_insert(child_depth);
-                max_depth = max_depth.max(child_depth);
-                let degree = indegree
-                    .get_mut(child)
-                    .expect("every child must have an indegree");
-                *degree -= 1;
-                if *degree == 0 {
-                    queue.push_back(*child);
-                }
-            }
-        }
-    }
-    max_depth
+    (low - 1, prefix_depth(low))
 }
 
 #[cfg(test)]
@@ -325,6 +343,73 @@ mod tests {
             account_set_id,
             account_id,
         }
+    }
+
+    #[test]
+    fn dag_orders_parents_before_members() {
+        let [root, branch, leaf] = set_ids();
+        let dag = SetDag::new(&[edge(root, branch), edge(branch, leaf)]);
+
+        let order = dag.traverse().order;
+
+        let position = |id| order.iter().position(|other| *other == id).unwrap();
+        assert_eq!(order.len(), dag.node_count());
+        assert!(position(root) < position(branch));
+        assert!(position(branch) < position(leaf));
+    }
+
+    #[test]
+    fn dag_counts_isolated_sets_as_nodes() {
+        let [root, branch, lone] = set_ids();
+        let mut dag = SetDag::new(&[edge(root, branch)]);
+        assert_eq!(dag.node_count(), 2);
+
+        dag.add_isolated(lone);
+
+        assert_eq!(dag.node_count(), 3);
+        assert_eq!(dag.traverse().order.len(), 3);
+    }
+
+    #[test]
+    fn dag_leaves_a_cycles_nodes_out_of_the_order() {
+        let [a, b, c] = set_ids();
+        let dag = SetDag::new(&[edge(a, b), edge(b, c), edge(c, a)]);
+
+        // Every node on the cycle keeps a nonzero indegree, so none is emitted.
+        assert!(dag.traverse().order.len() < dag.node_count());
+    }
+
+    #[test]
+    fn dag_measures_the_longest_path_not_the_shortest() {
+        // root -> branch -> leaf is longer than the direct root -> leaf edge.
+        let [root, branch, leaf] = set_ids();
+        let dag = SetDag::new(&[edge(root, branch), edge(branch, leaf), edge(root, leaf)]);
+
+        assert_eq!(dag.traverse().max_depth(), 2);
+    }
+
+    #[test]
+    fn dag_max_depth_of_an_empty_graph_is_zero() {
+        assert_eq!(SetDag::new(&[]).traverse().max_depth(), 0);
+    }
+
+    #[test]
+    fn dag_finds_paths_only_downward() {
+        let [root, branch, leaf] = set_ids();
+        let dag = SetDag::new(&[edge(root, branch), edge(branch, leaf)]);
+
+        assert!(dag.has_path(root, leaf));
+        assert!(!dag.has_path(leaf, root));
+    }
+
+    #[test]
+    fn dag_traversal_is_repeatable() {
+        // `traverse` takes &self and must not consume the indegrees it walks.
+        let [root, branch] = set_ids();
+        let dag = SetDag::new(&[edge(root, branch)]);
+
+        assert_eq!(dag.traverse().order, dag.traverse().order);
+        assert_eq!(dag.traverse().max_depth(), 1);
     }
 
     #[test]

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -51,10 +51,6 @@ pub(super) fn validate_set_memberships(
     proposed_edges: &[(AccountSetId, AccountSetId)],
     account_members: &[(AccountSetId, AccountId)],
 ) -> Result<(), AccountSetError> {
-    debug_assert!(
-        !proposed_edges.is_empty(),
-        "batch validation requires at least one proposed edge"
-    );
     let mut nodes = HashSet::new();
     let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
     let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -91,6 +91,10 @@ pub(super) fn validate_set_memberships(
     }
 
     if topological_order.len() != nodes.len() {
+        // A cycle must involve at least one proposed edge (the committed
+        // graph is a DAG). If it is in the existing graph that is
+        // corrupted state; attribute to the first existing edge so the
+        // fallback never indexes an empty proposed-edges slice.
         let (account_set_id, member_account_set_id) = proposed_edges
             .iter()
             .find(|(account_set_id, member_account_set_id)| {
@@ -98,7 +102,8 @@ pub(super) fn validate_set_memberships(
                     || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
             })
             .copied()
-            .unwrap_or(proposed_edges[0]);
+            .or_else(|| existing_edges.first().copied())
+            .expect("cycle detected in a graph with no edges");
         return Err(AccountSetError::MembershipCycleDetected {
             account_set_id,
             member_account_set_id,
@@ -178,6 +183,13 @@ fn graph_has_path(
     false
 }
 
+/// Find the first proposed edge whose inclusion makes the *combined*
+/// existing-plus-proposed graph exceed `MAX_MEMBERSHIP_DEPTH`. The returned
+/// depth is the maximum depth of that combined graph (not only the depth of
+/// the chain through the offending edge). The batch enforces a global depth
+/// bound so the read-time ancestor walk stays cheap and terminating; the
+/// reported `depth` therefore reflects the bound that was exceeded, and the
+/// returned index identifies the first edge responsible.
 fn first_depth_overflow(
     existing_edges: &[(AccountSetId, AccountSetId)],
     proposed_edges: &[(AccountSetId, AccountSetId)],

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -358,7 +358,9 @@ impl AccountSets {
     /// itself. Against a mature chart the account read is scoped to the
     /// descendant closure of the proposed member endpoints, and existing
     /// edges are served from the epoch-validated in-process cache, so a
-    /// small batch does not re-read or re-validate the whole graph. The
+    /// small batch does not re-read or re-validate the whole graph. A
+    /// single proposed edge routes through the existing single-attach
+    /// path, preserving the old cost model for degenerate batches. The
     /// exclusive membership-graph lock is held for the whole op, so very
     /// large batches will block other structure and account-member writers
     /// for the duration of validation and insert.
@@ -428,6 +430,18 @@ impl AccountSets {
                 account_set_id: *account_set_id,
                 member_id,
             });
+        }
+
+        // A single edge is cheaper through the existing single-attach path:
+        // one targeted CTE validation and insert, no combined-graph cache
+        // work. This preserves the old cost model for callers that batch a
+        // single pair by accident or for convenience.
+        if members.len() == 1 {
+            let (account_set_id, member_account_set_id) = members[0];
+            return self
+                .repo
+                .add_member_set(op, account_set_id, member_account_set_id)
+                .await;
         }
 
         self.repo.lock_for_set_membership_op(op).await?;

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -412,6 +412,10 @@ impl AccountSets {
             });
         }
 
+        self.repo.lock_for_set_membership_op(op).await?;
+        self.set_graph_cache
+            .assert_valid_set_memberships_in_op(op, members)
+            .await?;
         self.repo.insert_member_sets(op, members).await?;
 
         Ok(())

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -14,6 +14,11 @@ use crate::{account::*, balance::*, outbox::*, primitives::JournalId};
 pub use entity::*;
 use error::*;
 use graph_cache::SetGraphCache;
+/// Re-exported for the posting flow, which reads the direct-membership probe
+/// seeds as part of its single read statement and hands them back to the
+/// set-graph cache.
+pub(crate) use graph_validation::AccountMembership;
+use graph_validation::SetMembership;
 use repo::*;
 pub use repo::{account_set_cursor::*, members_cursor::*};
 
@@ -239,7 +244,13 @@ impl AccountSets {
                 // direct-edge insert the check's verdict fences.
                 self.repo.lock_for_account_member_op(&mut *op, id).await?;
                 self.set_graph_cache
-                    .assert_no_double_membership_in_op(op, &[account_set_id], &[id])
+                    .assert_no_double_membership_in_op(
+                        op,
+                        &[AccountMembership {
+                            account_set_id,
+                            account_id: id,
+                        }],
+                    )
                     .await?;
                 self.repo
                     .insert_member_account(&mut *op, account_set_id, id)
@@ -286,31 +297,38 @@ impl AccountSets {
             return Ok(());
         }
 
-        let account_set_ids: Vec<AccountSetId> =
-            members.iter().map(|(set_id, _)| *set_id).collect();
+        // The public API takes plain pairs; convert once here so every layer
+        // below the service names the two ends.
+        let members: Vec<AccountMembership> = members
+            .iter()
+            .copied()
+            .map(AccountMembership::from)
+            .collect();
+
+        let account_set_ids: Vec<AccountSetId> = members.iter().map(|m| m.account_set_id).collect();
         let sets = self
             .repo
             .find_all_in_op::<AccountSet>(&mut *op, &account_set_ids)
             .await?;
 
         let mut check_pairs = Vec::with_capacity(members.len());
-        for (account_set_id, member_id) in members {
+        for membership in &members {
             let set = sets
-                .get(account_set_id)
-                .ok_or(AccountSetError::CouldNotFindById(*account_set_id))?;
-            check_pairs.push((set.values().journal_id, *member_id));
+                .get(&membership.account_set_id)
+                .ok_or(AccountSetError::CouldNotFindById(membership.account_set_id))?;
+            check_pairs.push((set.values().journal_id, membership.account_id));
         }
         let with_history = self
             .balances
             .members_with_balance_history_in_op(op, &check_pairs)
             .await?;
         if let Some(member_id) = with_history.into_iter().next() {
-            let (account_set_id, _) = members
+            let membership = members
                 .iter()
-                .find(|(_, m)| *m == member_id)
+                .find(|m| m.account_id == member_id)
                 .expect("member with history must be in input");
             return Err(AccountSetError::MemberHasBalanceHistory {
-                account_set_id: *account_set_id,
+                account_set_id: membership.account_set_id,
                 member_id,
             });
         }
@@ -318,15 +336,14 @@ impl AccountSets {
         // Batch attach sequence, mirroring the single-pair path: batch
         // lock protocol, one path-uniqueness check covering all pairs
         // (and their interactions with each other), one insert.
-        let account_ids: Vec<AccountId> =
-            members.iter().map(|(_, account_id)| *account_id).collect();
+        let account_ids: Vec<AccountId> = members.iter().map(|m| m.account_id).collect();
         self.repo
             .lock_for_account_members_op(op, &account_ids)
             .await?;
         self.set_graph_cache
-            .assert_no_double_membership_in_op(op, &account_set_ids, &account_ids)
+            .assert_no_double_membership_in_op(op, &members)
             .await?;
-        self.repo.insert_member_accounts(op, members).await?;
+        self.repo.insert_member_accounts(op, &members).await?;
 
         Ok(())
     }
@@ -380,12 +397,15 @@ impl AccountSets {
             return Ok(());
         }
 
+        // The public API takes plain pairs; convert once here so every layer
+        // below the service names container and member explicitly.
+        let members: Vec<SetMembership> =
+            members.iter().copied().map(SetMembership::from).collect();
+
         let account_set_ids: Vec<AccountSetId> = {
             let mut ids: Vec<AccountSetId> = members
                 .iter()
-                .flat_map(|(account_set_id, member_account_set_id)| {
-                    [*account_set_id, *member_account_set_id]
-                })
+                .flat_map(|edge| [edge.account_set_id, edge.member_account_set_id])
                 .collect();
             ids.sort_unstable();
             ids.dedup();
@@ -397,13 +417,15 @@ impl AccountSets {
             .await?;
 
         let mut check_pairs = Vec::with_capacity(members.len());
-        for (account_set_id, member_account_set_id) in members {
+        for edge in &members {
             let account_set = sets
-                .get(account_set_id)
-                .ok_or(AccountSetError::CouldNotFindById(*account_set_id))?;
-            let member_account_set = sets
-                .get(member_account_set_id)
-                .ok_or(AccountSetError::CouldNotFindById(*member_account_set_id))?;
+                .get(&edge.account_set_id)
+                .ok_or(AccountSetError::CouldNotFindById(edge.account_set_id))?;
+            let member_account_set =
+                sets.get(&edge.member_account_set_id)
+                    .ok_or(AccountSetError::CouldNotFindById(
+                        edge.member_account_set_id,
+                    ))?;
 
             if account_set.values().journal_id != member_account_set.values().journal_id {
                 return Err(AccountSetError::JournalIdMismatch);
@@ -411,7 +433,7 @@ impl AccountSets {
 
             check_pairs.push((
                 account_set.values().journal_id,
-                AccountId::from(*member_account_set_id),
+                AccountId::from(edge.member_account_set_id),
             ));
         }
 
@@ -420,14 +442,12 @@ impl AccountSets {
             .members_with_balance_history_in_op(op, &check_pairs)
             .await?;
         if let Some(member_id) = with_history.into_iter().next() {
-            let (account_set_id, _) = members
+            let edge = members
                 .iter()
-                .find(|(_, member_account_set_id)| {
-                    AccountId::from(*member_account_set_id) == member_id
-                })
+                .find(|edge| AccountId::from(edge.member_account_set_id) == member_id)
                 .expect("member with history must be in input");
             return Err(AccountSetError::MemberHasBalanceHistory {
-                account_set_id: *account_set_id,
+                account_set_id: edge.account_set_id,
                 member_id,
             });
         }
@@ -436,19 +456,18 @@ impl AccountSets {
         // one targeted CTE validation and insert, no combined-graph cache
         // work. This preserves the old cost model for callers that batch a
         // single pair by accident or for convenience.
-        if members.len() == 1 {
-            let (account_set_id, member_account_set_id) = members[0];
+        if let [edge] = members[..] {
             return self
                 .repo
-                .add_member_set(op, account_set_id, member_account_set_id)
+                .add_member_set(op, edge.account_set_id, edge.member_account_set_id)
                 .await;
         }
 
         self.repo.lock_for_set_membership_op(op).await?;
         self.set_graph_cache
-            .assert_valid_set_memberships_in_op(op, members)
+            .assert_valid_set_memberships_in_op(op, &members)
             .await?;
-        self.repo.insert_member_sets(op, members).await?;
+        self.repo.insert_member_sets(op, &members).await?;
 
         Ok(())
     }
@@ -767,7 +786,7 @@ impl AccountSets {
         op: &mut impl es_entity::AtomicOperation,
         journal_id: JournalId,
         probe_epoch: i64,
-        probe_seeds: &[(AccountId, AccountSetId)],
+        probe_seeds: &[AccountMembership],
         entry_pairs: &(Vec<AccountId>, Vec<&str>),
     ) -> Result<HashMap<AccountId, Vec<AccountSetId>>, AccountSetError> {
         self.set_graph_cache

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -1,6 +1,7 @@
 mod entity;
 pub mod error;
 mod graph_cache;
+mod graph_validation;
 mod repo;
 
 use es_entity::clock::ClockHandle;

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -330,6 +330,93 @@ impl AccountSets {
         Ok(())
     }
 
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.add_member_sets",
+        skip(self, members),
+        fields(count = members.len())
+    )]
+    pub async fn add_member_sets(
+        &self,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        let mut op = self.repo.begin_op_with_clock(&self.clock).await?;
+        self.add_member_sets_in_op(&mut op, members).await?;
+        op.commit().await?;
+        Ok(())
+    }
+
+    /// Batch variant of [`add_member_in_op`](Self::add_member_in_op) for
+    /// account-set members. The complete proposed graph is validated before
+    /// any edge is inserted, then all direct edges are persisted together.
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.account_sets.add_member_sets_in_op",
+        skip(self, op, members),
+        fields(count = members.len()),
+        err(level = "warn")
+    )]
+    pub async fn add_member_sets_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        if members.is_empty() {
+            return Ok(());
+        }
+
+        let account_set_ids: Vec<AccountSetId> = members
+            .iter()
+            .flat_map(|(account_set_id, member_account_set_id)| {
+                [*account_set_id, *member_account_set_id]
+            })
+            .collect();
+        let sets = self
+            .repo
+            .find_all_in_op::<AccountSet>(&mut *op, &account_set_ids)
+            .await?;
+
+        let mut check_pairs = Vec::with_capacity(members.len());
+        for (account_set_id, member_account_set_id) in members {
+            let account_set = sets
+                .get(account_set_id)
+                .ok_or(AccountSetError::CouldNotFindById(*account_set_id))?;
+            let member_account_set = sets
+                .get(member_account_set_id)
+                .ok_or(AccountSetError::CouldNotFindById(*member_account_set_id))?;
+
+            if account_set.values().journal_id != member_account_set.values().journal_id {
+                return Err(AccountSetError::JournalIdMismatch);
+            }
+
+            check_pairs.push((
+                account_set.values().journal_id,
+                AccountId::from(*member_account_set_id),
+            ));
+        }
+
+        let with_history = self
+            .balances
+            .members_with_balance_history_in_op(op, &check_pairs)
+            .await?;
+        if let Some(member_id) = with_history.into_iter().next() {
+            let (account_set_id, _) = members
+                .iter()
+                .find(|(_, member_account_set_id)| {
+                    AccountId::from(*member_account_set_id) == member_id
+                })
+                .expect("member with history must be in input");
+            return Err(AccountSetError::MemberHasBalanceHistory {
+                account_set_id: *account_set_id,
+                member_id,
+            });
+        }
+
+        self.repo.insert_member_sets(op, members).await?;
+
+        Ok(())
+    }
+
     /// `cala_balance_history` row in `journal_id`. Folding existing
     /// balance into a parent set after the fact is unsafe: the streaming
     /// rollup only folds in a member's activity from the point it joins,

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -366,12 +366,17 @@ impl AccountSets {
             return Ok(());
         }
 
-        let account_set_ids: Vec<AccountSetId> = members
-            .iter()
-            .flat_map(|(account_set_id, member_account_set_id)| {
-                [*account_set_id, *member_account_set_id]
-            })
-            .collect();
+        let account_set_ids: Vec<AccountSetId> = {
+            let mut ids: Vec<AccountSetId> = members
+                .iter()
+                .flat_map(|(account_set_id, member_account_set_id)| {
+                    [*account_set_id, *member_account_set_id]
+                })
+                .collect();
+            ids.sort_unstable();
+            ids.dedup();
+            ids
+        };
         let sets = self
             .repo
             .find_all_in_op::<AccountSet>(&mut *op, &account_set_ids)

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -348,8 +348,20 @@ impl AccountSets {
     }
 
     /// Batch variant of [`add_member_in_op`](Self::add_member_in_op) for
-    /// account-set members. The complete proposed graph is validated before
-    /// any edge is inserted, then all direct edges are persisted together.
+    /// account-set hierarchy edges. The complete proposed graph is validated
+    /// before any edge is inserted, then all direct edges, the epoch bump,
+    /// and outbox events are persisted atomically.
+    ///
+    /// **Cost model.** The first consumer is a one-shot chart import that
+    /// builds a fresh hierarchy, so existing edges and account memberships
+    /// are near-empty and validation is dominated by the proposed batch
+    /// itself. Against a mature chart the account read is scoped to the
+    /// descendant closure of the proposed member endpoints, and existing
+    /// edges are served from the epoch-validated in-process cache, so a
+    /// small batch does not re-read or re-validate the whole graph. The
+    /// exclusive membership-graph lock is held for the whole op, so very
+    /// large batches will block other structure and account-member writers
+    /// for the duration of validation and insert.
     #[instrument(
         level = "debug",
         name = "cala_ledger.account_sets.add_member_sets_in_op",

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -2,14 +2,14 @@ use es_entity::*;
 use sqlx::PgPool;
 use tracing::instrument;
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet};
 
 use crate::{
     outbox::OutboxPublisher,
     primitives::{AccountId, JournalId},
 };
 
-use super::{entity::*, error::*};
+use super::{entity::*, error::*, graph_cache::MAX_MEMBERSHIP_DEPTH};
 
 /// Coarse advisory lock guarding the account-set membership graph
 /// (`cala_account_set_member_accounts` and
@@ -58,208 +58,6 @@ const ADDVISORY_LOCK_ID: i64 = 123456;
 /// keyed on `hashtext(<member account id>)`. Must stay disjoint from
 /// `EC_SET_LOCK_CLASS` (= 1) used by balance locking.
 const MEMBER_LOCK_CLASS: i32 = 2;
-
-/// Maximum depth (in set->set edges) of any root-to-leaf membership
-/// chain. Enforced in single and batched set attachment: rejecting edges past this bound
-/// keeps the read-time ancestor walk cheap and terminating. Real
-/// hierarchies are <=10 deep; 16 leaves headroom.
-const MAX_MEMBERSHIP_DEPTH: i32 = 16;
-
-fn validate_set_membership_batch(
-    existing_edges: &[(AccountSetId, AccountSetId)],
-    proposed_edges: &[(AccountSetId, AccountSetId)],
-    account_members: &[(AccountSetId, AccountId)],
-) -> Result<(), AccountSetError> {
-    let mut nodes = HashSet::new();
-    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-
-    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-        nodes.insert(*account_set_id);
-        nodes.insert(*member_account_set_id);
-        adjacency
-            .entry(*account_set_id)
-            .or_default()
-            .push(*member_account_set_id);
-        *indegree.entry(*member_account_set_id).or_default() += 1;
-        indegree.entry(*account_set_id).or_default();
-    }
-    for (account_set_id, _) in account_members {
-        nodes.insert(*account_set_id);
-        indegree.entry(*account_set_id).or_default();
-    }
-
-    let mut queue: VecDeque<AccountSetId> = indegree
-        .iter()
-        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-        .collect();
-    let mut topological_order = Vec::with_capacity(nodes.len());
-    while let Some(account_set_id) = queue.pop_front() {
-        topological_order.push(account_set_id);
-        if let Some(children) = adjacency.get(&account_set_id) {
-            for child in children {
-                let degree = indegree
-                    .get_mut(child)
-                    .expect("every child must have an indegree");
-                *degree -= 1;
-                if *degree == 0 {
-                    queue.push_back(*child);
-                }
-            }
-        }
-    }
-
-    if topological_order.len() != nodes.len() {
-        let (account_set_id, member_account_set_id) = proposed_edges
-            .iter()
-            .find(|(account_set_id, member_account_set_id)| {
-                account_set_id == member_account_set_id
-                    || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
-            })
-            .copied()
-            .unwrap_or(proposed_edges[0]);
-        return Err(AccountSetError::MembershipCycleDetected {
-            account_set_id,
-            member_account_set_id,
-        });
-    }
-
-    // In topological order, every parent's ancestor set is complete before
-    // its contribution reaches a child. An overlap means the child has two
-    // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
-    // worst case instead of enumerating exponentially many paths.
-    let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
-    let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
-    for account_set_id in &topological_order {
-        let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
-        contribution.insert(*account_set_id);
-        let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
-
-        if let Some(children) = adjacency.get(account_set_id) {
-            for child in children {
-                let child_ancestors = ancestors.entry(*child).or_default();
-                if !child_ancestors.is_disjoint(&contribution) {
-                    return Err(AccountSetError::MemberAlreadyAdded);
-                }
-                child_ancestors.extend(contribution.iter().copied());
-                depth_from_root
-                    .entry(*child)
-                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
-                    .or_insert(parent_depth + 1);
-            }
-        }
-    }
-
-    let mut account_paths = HashSet::new();
-    for (account_set_id, account_id) in account_members {
-        if !account_paths.insert((*account_set_id, *account_id)) {
-            return Err(AccountSetError::MemberAlreadyAdded);
-        }
-        if let Some(containers) = ancestors.get(account_set_id) {
-            for container in containers {
-                if !account_paths.insert((*container, *account_id)) {
-                    return Err(AccountSetError::MemberAlreadyAdded);
-                }
-            }
-        }
-    }
-
-    let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
-    if max_depth > MAX_MEMBERSHIP_DEPTH {
-        let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
-        let (account_set_id, member_account_set_id) = proposed_edges[index];
-        return Err(AccountSetError::MembershipDepthExceeded {
-            account_set_id,
-            member_account_set_id,
-            depth,
-            max: MAX_MEMBERSHIP_DEPTH,
-        });
-    }
-
-    Ok(())
-}
-
-fn graph_has_path(
-    adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
-    from: AccountSetId,
-    to: AccountSetId,
-) -> bool {
-    let mut pending = vec![from];
-    let mut visited = HashSet::new();
-    while let Some(current) = pending.pop() {
-        if current == to {
-            return true;
-        }
-        if visited.insert(current) {
-            pending.extend(adjacency.get(&current).into_iter().flatten().copied());
-        }
-    }
-    false
-}
-
-fn first_depth_overflow(
-    existing_edges: &[(AccountSetId, AccountSetId)],
-    proposed_edges: &[(AccountSetId, AccountSetId)],
-) -> (usize, i32) {
-    let mut low = 1;
-    let mut high = proposed_edges.len();
-    while low < high {
-        let middle = (low + high) / 2;
-        if graph_max_depth(existing_edges, &proposed_edges[..middle]) > MAX_MEMBERSHIP_DEPTH {
-            high = middle;
-        } else {
-            low = middle + 1;
-        }
-    }
-    (
-        low - 1,
-        graph_max_depth(existing_edges, &proposed_edges[..low]),
-    )
-}
-
-fn graph_max_depth(
-    existing_edges: &[(AccountSetId, AccountSetId)],
-    proposed_edges: &[(AccountSetId, AccountSetId)],
-) -> i32 {
-    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-        adjacency
-            .entry(*account_set_id)
-            .or_default()
-            .push(*member_account_set_id);
-        *indegree.entry(*member_account_set_id).or_default() += 1;
-        indegree.entry(*account_set_id).or_default();
-    }
-
-    let mut queue: VecDeque<AccountSetId> = indegree
-        .iter()
-        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-        .collect();
-    let mut depths = HashMap::new();
-    let mut max_depth = 0;
-    while let Some(account_set_id) = queue.pop_front() {
-        let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
-        if let Some(children) = adjacency.get(&account_set_id) {
-            for child in children {
-                let child_depth = parent_depth + 1;
-                depths
-                    .entry(*child)
-                    .and_modify(|depth| *depth = (*depth).max(child_depth))
-                    .or_insert(child_depth);
-                max_depth = max_depth.max(child_depth);
-                let degree = indegree
-                    .get_mut(child)
-                    .expect("every child must have an indegree");
-                *degree -= 1;
-                if *degree == 0 {
-                    queue.push_back(*child);
-                }
-            }
-        }
-    }
-    max_depth
-}
 
 pub mod members_cursor {
     use cala_types::account_set::{
@@ -1055,34 +853,31 @@ impl AccountSetRepo {
         Ok(())
     }
 
-    /// Validates and inserts a batch of direct account-set membership edges.
-    ///
-    /// The exclusive graph lock fences the combined-graph validation from all
-    /// membership writers. A deduplicating query loads the affected connected
-    /// components, then bounded in-memory graph validation evaluates existing
-    /// and proposed edges together. Cycles, duplicate paths, account-path
-    /// conflicts, and depth overflow caused by interactions within the batch
-    /// are rejected before the first edge is written.
-    #[instrument(
-        level = "debug",
-        name = "account_set.insert_member_sets",
-        skip_all,
-        fields(count = members.len()),
-        err(level = "warn")
-    )]
-    pub(super) async fn insert_member_sets(
+    /// Take the exclusive membership-graph lock for a structure mutation.
+    /// Held until `db` commits or rolls back.
+    pub(super) async fn lock_for_set_membership_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-        members: &[(AccountSetId, AccountSetId)],
     ) -> Result<(), AccountSetError> {
-        if members.is_empty() {
-            return Ok(());
-        }
-
         sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
             .execute(db.as_executor())
             .await?;
+        Ok(())
+    }
 
+    /// Load the existing graph and direct account memberships needed to
+    /// validate a batch of proposed set-to-set edges.
+    pub(super) async fn fetch_set_membership_validation_data_in_op(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<
+        (
+            Vec<(AccountSetId, AccountSetId)>,
+            Vec<(AccountSetId, AccountId)>,
+        ),
+        AccountSetError,
+    > {
         let account_set_ids: Vec<AccountSetId> = members.iter().map(|(id, _)| *id).collect();
         let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
 
@@ -1136,7 +931,7 @@ impl AccountSetRepo {
             .collect::<HashSet<_>>()
             .into_iter()
             .collect();
-        let account_members: Vec<(AccountSetId, AccountId)> = sqlx::query_as(
+        let account_members = sqlx::query_as(
             r#"
           SELECT account_set_id, member_account_id
           FROM cala_account_set_member_accounts
@@ -1147,7 +942,37 @@ impl AccountSetRepo {
         .fetch_all(db.as_executor())
         .await?;
 
-        validate_set_membership_batch(&existing_edges, members, &account_members)?;
+        Ok((existing_edges, account_members))
+    }
+
+    /// Insert a validated batch of direct account-set membership edges.
+    ///
+    /// Precondition: the caller holds [`Self::lock_for_set_membership_op`] and
+    /// has passed the graph cache's combined-graph validation in this same op.
+    /// The exclusive graph lock fences the combined-graph validation from all
+    /// membership writers. A deduplicating query loads the affected connected
+    /// components, then bounded in-memory graph validation evaluates existing
+    /// and proposed edges together. Cycles, duplicate paths, account-path
+    /// conflicts, and depth overflow caused by interactions within the batch
+    /// are rejected before the first edge is written.
+    #[instrument(
+        level = "debug",
+        name = "account_set.insert_member_sets",
+        skip_all,
+        fields(count = members.len()),
+        err(level = "warn")
+    )]
+    pub(super) async fn insert_member_sets(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        if members.is_empty() {
+            return Ok(());
+        }
+
+        let account_set_ids: Vec<AccountSetId> = members.iter().map(|(id, _)| *id).collect();
+        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
 
         sqlx::query(
             r#"

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -2,7 +2,7 @@ use es_entity::*;
 use sqlx::PgPool;
 use tracing::instrument;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::{
     outbox::OutboxPublisher,
@@ -34,8 +34,8 @@ use super::{entity::*, error::*};
 /// so it must be fenced against concurrent writers — which is why the
 /// closure-era lock protocol survives walk-only unchanged:
 ///
-/// - Set-structure mutations (`add_member_set` / `remove_member_set`)
-///   take this lock EXCLUSIVE. They mutate the edges that every walk
+/// - Set-structure mutations (`add_member_set`, batched set attachment, and
+///   `remove_member_set`) take this lock EXCLUSIVE. They mutate the edges that every walk
 ///   reads, and read the member rows that account-member mutations
 ///   write, so they must exclude everything.
 /// - Account-member mutations (`add_member_account(s)` /
@@ -60,10 +60,206 @@ const ADDVISORY_LOCK_ID: i64 = 123456;
 const MEMBER_LOCK_CLASS: i32 = 2;
 
 /// Maximum depth (in set->set edges) of any root-to-leaf membership
-/// chain. Enforced in `add_member_set`: rejecting edges past this bound
+/// chain. Enforced in single and batched set attachment: rejecting edges past this bound
 /// keeps the read-time ancestor walk cheap and terminating. Real
 /// hierarchies are <=10 deep; 16 leaves headroom.
 const MAX_MEMBERSHIP_DEPTH: i32 = 16;
+
+fn validate_set_membership_batch(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+    account_members: &[(AccountSetId, AccountId)],
+) -> Result<(), AccountSetError> {
+    let mut nodes = HashSet::new();
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        nodes.insert(*account_set_id);
+        nodes.insert(*member_account_set_id);
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+    for (account_set_id, _) in account_members {
+        nodes.insert(*account_set_id);
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut topological_order = Vec::with_capacity(nodes.len());
+    while let Some(account_set_id) = queue.pop_front() {
+        topological_order.push(account_set_id);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+
+    if topological_order.len() != nodes.len() {
+        let (account_set_id, member_account_set_id) = proposed_edges
+            .iter()
+            .find(|(account_set_id, member_account_set_id)| {
+                account_set_id == member_account_set_id
+                    || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
+            })
+            .copied()
+            .unwrap_or(proposed_edges[0]);
+        return Err(AccountSetError::MembershipCycleDetected {
+            account_set_id,
+            member_account_set_id,
+        });
+    }
+
+    // In topological order, every parent's ancestor set is complete before
+    // its contribution reaches a child. An overlap means the child has two
+    // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
+    // worst case instead of enumerating exponentially many paths.
+    let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
+    let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
+    for account_set_id in &topological_order {
+        let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
+        contribution.insert(*account_set_id);
+        let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
+
+        if let Some(children) = adjacency.get(account_set_id) {
+            for child in children {
+                let child_ancestors = ancestors.entry(*child).or_default();
+                if !child_ancestors.is_disjoint(&contribution) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+                child_ancestors.extend(contribution.iter().copied());
+                depth_from_root
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
+                    .or_insert(parent_depth + 1);
+            }
+        }
+    }
+
+    let mut account_paths = HashSet::new();
+    for (account_set_id, account_id) in account_members {
+        if !account_paths.insert((*account_set_id, *account_id)) {
+            return Err(AccountSetError::MemberAlreadyAdded);
+        }
+        if let Some(containers) = ancestors.get(account_set_id) {
+            for container in containers {
+                if !account_paths.insert((*container, *account_id)) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+            }
+        }
+    }
+
+    let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
+    if max_depth > MAX_MEMBERSHIP_DEPTH {
+        let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
+        let (account_set_id, member_account_set_id) = proposed_edges[index];
+        return Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth,
+            max: MAX_MEMBERSHIP_DEPTH,
+        });
+    }
+
+    Ok(())
+}
+
+fn graph_has_path(
+    adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
+    from: AccountSetId,
+    to: AccountSetId,
+) -> bool {
+    let mut pending = vec![from];
+    let mut visited = HashSet::new();
+    while let Some(current) = pending.pop() {
+        if current == to {
+            return true;
+        }
+        if visited.insert(current) {
+            pending.extend(adjacency.get(&current).into_iter().flatten().copied());
+        }
+    }
+    false
+}
+
+fn first_depth_overflow(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> (usize, i32) {
+    let mut low = 1;
+    let mut high = proposed_edges.len();
+    while low < high {
+        let middle = (low + high) / 2;
+        if graph_max_depth(existing_edges, &proposed_edges[..middle]) > MAX_MEMBERSHIP_DEPTH {
+            high = middle;
+        } else {
+            low = middle + 1;
+        }
+    }
+    (
+        low - 1,
+        graph_max_depth(existing_edges, &proposed_edges[..low]),
+    )
+}
+
+fn graph_max_depth(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> i32 {
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut depths = HashMap::new();
+    let mut max_depth = 0;
+    while let Some(account_set_id) = queue.pop_front() {
+        let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let child_depth = parent_depth + 1;
+                depths
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(child_depth))
+                    .or_insert(child_depth);
+                max_depth = max_depth.max(child_depth);
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+    max_depth
+}
 
 pub mod members_cursor {
     use cala_types::account_set::{
@@ -853,6 +1049,137 @@ impl AccountSetRepo {
                         member_account_set_id,
                     ),
                 }),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Validates and inserts a batch of direct account-set membership edges.
+    ///
+    /// The exclusive graph lock fences the combined-graph validation from all
+    /// membership writers. A deduplicating query loads the affected connected
+    /// components, then bounded in-memory graph validation evaluates existing
+    /// and proposed edges together. Cycles, duplicate paths, account-path
+    /// conflicts, and depth overflow caused by interactions within the batch
+    /// are rejected before the first edge is written.
+    #[instrument(
+        level = "debug",
+        name = "account_set.insert_member_sets",
+        skip_all,
+        fields(count = members.len()),
+        err(level = "warn")
+    )]
+    pub(super) async fn insert_member_sets(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<(), AccountSetError> {
+        if members.is_empty() {
+            return Ok(());
+        }
+
+        sqlx::query!("SELECT pg_advisory_xact_lock($1)", ADDVISORY_LOCK_ID)
+            .execute(db.as_executor())
+            .await?;
+
+        let account_set_ids: Vec<AccountSetId> = members.iter().map(|(id, _)| *id).collect();
+        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
+
+        // Load only existing edges connected to a proposed endpoint. The
+        // recursive component walk uses UNION (not UNION ALL), so malformed or
+        // adversarial input cannot make database work grow with path count.
+        let existing_edges: Vec<(AccountSetId, AccountSetId)> = sqlx::query_as(
+            r#"
+          WITH RECURSIVE input_sets AS (
+            SELECT set_id FROM UNNEST($1::uuid[]) AS input(set_id)
+            UNION
+            SELECT set_id FROM UNNEST($2::uuid[]) AS input(set_id)
+          ),
+          relevant_sets AS (
+            SELECT set_id FROM input_sets
+
+            UNION
+
+            SELECT CASE
+                     WHEN edge.account_set_id = relevant.set_id
+                       THEN edge.member_account_set_id
+                     ELSE edge.account_set_id
+                   END
+            FROM relevant_sets relevant
+            JOIN cala_account_set_member_account_sets edge
+              ON edge.account_set_id = relevant.set_id
+              OR edge.member_account_set_id = relevant.set_id
+          )
+          SELECT edge.account_set_id, edge.member_account_set_id
+          FROM cala_account_set_member_account_sets edge
+          JOIN relevant_sets relevant
+            ON relevant.set_id = edge.account_set_id
+          "#,
+        )
+        .bind(&account_set_ids)
+        .bind(&member_account_set_ids)
+        .fetch_all(db.as_executor())
+        .await?;
+
+        let relevant_set_ids: Vec<AccountSetId> = account_set_ids
+            .iter()
+            .chain(&member_account_set_ids)
+            .copied()
+            .chain(
+                existing_edges
+                    .iter()
+                    .flat_map(|(account_set_id, member_account_set_id)| {
+                        [*account_set_id, *member_account_set_id]
+                    }),
+            )
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        let account_members: Vec<(AccountSetId, AccountId)> = sqlx::query_as(
+            r#"
+          SELECT account_set_id, member_account_id
+          FROM cala_account_set_member_accounts
+          WHERE account_set_id = ANY($1)
+          "#,
+        )
+        .bind(&relevant_set_ids)
+        .fetch_all(db.as_executor())
+        .await?;
+
+        validate_set_membership_batch(&existing_edges, members, &account_members)?;
+
+        sqlx::query(
+            r#"
+          INSERT INTO cala_account_set_member_account_sets
+            (account_set_id, member_account_set_id)
+          SELECT account_set_id, member_account_set_id
+          FROM UNNEST($1::uuid[], $2::uuid[])
+            AS proposed(account_set_id, member_account_set_id)
+          "#,
+        )
+        .bind(&account_set_ids)
+        .bind(&member_account_set_ids)
+        .execute(db.as_executor())
+        .await?;
+
+        sqlx::query!("UPDATE cala_account_set_graph_epoch SET epoch = epoch + 1")
+            .execute(db.as_executor())
+            .await?;
+
+        self.publisher
+            .publish_all(
+                db,
+                members
+                    .iter()
+                    .map(|(account_set_id, member_account_set_id)| {
+                        crate::outbox::OutboxEventPayload::AccountSetMemberCreated {
+                            account_set_id: *account_set_id,
+                            member_id: crate::account_set::AccountSetMemberId::AccountSet(
+                                *member_account_set_id,
+                            ),
+                        }
+                    }),
             )
             .await?;
 

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -865,57 +865,47 @@ impl AccountSetRepo {
         Ok(())
     }
 
-    /// Load the existing graph and direct account memberships needed to
-    /// validate a batch of proposed set-to-set edges.
-    pub(super) async fn fetch_set_membership_validation_data_in_op(
+    /// Read the membership-graph epoch in this operation's snapshot.
+    pub(super) async fn fetch_set_graph_epoch_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-        members: &[(AccountSetId, AccountSetId)],
-    ) -> Result<
-        (
-            Vec<(AccountSetId, AccountSetId)>,
-            Vec<(AccountSetId, AccountId)>,
-        ),
-        AccountSetError,
-    > {
-        let account_set_ids: Vec<AccountSetId> = members.iter().map(|(id, _)| *id).collect();
-        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
+    ) -> Result<i64, AccountSetError> {
+        Ok(
+            sqlx::query_scalar("SELECT epoch FROM cala_account_set_graph_epoch")
+                .fetch_one(db.as_executor())
+                .await?,
+        )
+    }
 
-        // Load only existing edges connected to a proposed endpoint. The
-        // recursive component walk uses UNION (not UNION ALL), so malformed or
-        // adversarial input cannot make database work grow with path count.
-        let existing_edges: Vec<(AccountSetId, AccountSetId)> = sqlx::query_as(
+    /// Load all committed set-to-set edges as an op-local cache fallback.
+    ///
+    /// The graph is intentionally read with one flat query. It is small, and
+    /// this path runs only when the epoch-validated snapshot is cold or stale;
+    /// avoiding a recursive component walk keeps fallback work bounded by the
+    /// edge table rather than graph depth.
+    pub(super) async fn fetch_set_membership_edges_in_op(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+    ) -> Result<Vec<(AccountSetId, AccountSetId)>, AccountSetError> {
+        Ok(sqlx::query_as(
             r#"
-          WITH RECURSIVE input_sets AS (
-            SELECT set_id FROM UNNEST($1::uuid[]) AS input(set_id)
-            UNION
-            SELECT set_id FROM UNNEST($2::uuid[]) AS input(set_id)
-          ),
-          relevant_sets AS (
-            SELECT set_id FROM input_sets
-
-            UNION
-
-            SELECT CASE
-                     WHEN edge.account_set_id = relevant.set_id
-                       THEN edge.member_account_set_id
-                     ELSE edge.account_set_id
-                   END
-            FROM relevant_sets relevant
-            JOIN cala_account_set_member_account_sets edge
-              ON edge.account_set_id = relevant.set_id
-              OR edge.member_account_set_id = relevant.set_id
-          )
-          SELECT edge.account_set_id, edge.member_account_set_id
-          FROM cala_account_set_member_account_sets edge
-          JOIN relevant_sets relevant
-            ON relevant.set_id = edge.account_set_id
+          SELECT account_set_id, member_account_set_id
+          FROM cala_account_set_member_account_sets
           "#,
         )
-        .bind(&account_set_ids)
-        .bind(&member_account_set_ids)
         .fetch_all(db.as_executor())
-        .await?;
+        .await?)
+    }
+
+    /// Load only direct account memberships that can participate in a conflict
+    /// introduced by `members` against the supplied existing edge graph.
+    pub(super) async fn fetch_affected_account_memberships_in_op(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        existing_edges: &[(AccountSetId, AccountSetId)],
+        members: &[(AccountSetId, AccountSetId)],
+    ) -> Result<Vec<(AccountSetId, AccountId)>, AccountSetError> {
+        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
 
         // Only accounts below a proposed member endpoint can gain a new
         // containment path. Compute that affected descendant closure over the
@@ -928,7 +918,7 @@ impl AccountSetRepo {
                 .push(*member_account_set_id);
         }
         let mut affected_set_ids = HashSet::new();
-        let mut pending: Vec<AccountSetId> = member_account_set_ids.clone();
+        let mut pending = member_account_set_ids;
         while let Some(account_set_id) = pending.pop() {
             if affected_set_ids.insert(account_set_id) {
                 pending.extend(children.get(&account_set_id).into_iter().flatten().copied());
@@ -953,22 +943,20 @@ impl AccountSetRepo {
         .bind(&affected_set_ids)
         .fetch_all(db.as_executor())
         .await?;
-        let account_members = if candidate_account_ids.is_empty() {
-            Vec::new()
-        } else {
-            sqlx::query_as(
-                r#"
-              SELECT account_set_id, member_account_id
-              FROM cala_account_set_member_accounts
-              WHERE member_account_id = ANY($1)
-              "#,
-            )
-            .bind(&candidate_account_ids)
-            .fetch_all(db.as_executor())
-            .await?
-        };
+        if candidate_account_ids.is_empty() {
+            return Ok(Vec::new());
+        }
 
-        Ok((existing_edges, account_members))
+        Ok(sqlx::query_as(
+            r#"
+          SELECT account_set_id, member_account_id
+          FROM cala_account_set_member_accounts
+          WHERE member_account_id = ANY($1)
+          "#,
+        )
+        .bind(&candidate_account_ids)
+        .fetch_all(db.as_executor())
+        .await?)
     }
 
     /// Insert a validated batch of direct account-set membership edges.

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -9,7 +9,11 @@ use crate::{
     primitives::{AccountId, JournalId},
 };
 
-use super::{entity::*, error::*, graph_validation::MAX_MEMBERSHIP_DEPTH};
+use super::{
+    entity::*,
+    error::*,
+    graph_validation::{AccountMembership, SetMembership, MAX_MEMBERSHIP_DEPTH},
+};
 
 /// Coarse advisory lock guarding the account-set membership graph
 /// (`cala_account_set_member_accounts` and
@@ -191,9 +195,12 @@ impl AccountSetRepo {
     pub(super) async fn assert_no_double_membership(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-        account_set_ids: &[AccountSetId],
-        account_ids: &[AccountId],
+        members: &[AccountMembership],
     ) -> Result<(), AccountSetError> {
+        // The parallel arrays the UNNEST needs are built here, at the SQL
+        // boundary, so the ordered-pair shape never escapes into the caller.
+        let account_set_ids: Vec<AccountSetId> = members.iter().map(|m| m.account_set_id).collect();
+        let account_ids: Vec<AccountId> = members.iter().map(|m| m.account_id).collect();
         let row = sqlx::query!(
             r#"
             WITH RECURSIVE all_seeds AS (
@@ -220,8 +227,8 @@ impl AccountSetRepo {
                 HAVING COUNT(*) > 1
             ) AS "conflict!"
             "#,
-            account_set_ids as &[AccountSetId],
-            account_ids as &[AccountId],
+            &account_set_ids as &[AccountSetId],
+            &account_ids as &[AccountId],
         )
         .fetch_one(db.as_executor())
         .await?;
@@ -585,13 +592,13 @@ impl AccountSetRepo {
     pub(super) async fn insert_member_accounts(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-        members: &[(AccountSetId, AccountId)],
+        members: &[AccountMembership],
     ) -> Result<(), AccountSetError> {
         if members.is_empty() {
             return Ok(());
         }
-        let account_set_ids: Vec<AccountSetId> = members.iter().map(|(s, _)| *s).collect();
-        let account_ids: Vec<AccountId> = members.iter().map(|(_, a)| *a).collect();
+        let account_set_ids: Vec<AccountSetId> = members.iter().map(|m| m.account_set_id).collect();
+        let account_ids: Vec<AccountId> = members.iter().map(|m| m.account_id).collect();
 
         // Direct edges only: one insert covers every pair; ancestor sets
         // are resolved by the read-time walk.
@@ -610,10 +617,12 @@ impl AccountSetRepo {
         self.publisher
             .publish_all(
                 db,
-                members.iter().map(|(account_set_id, account_id)| {
+                members.iter().map(|membership| {
                     crate::outbox::OutboxEventPayload::AccountSetMemberCreated {
-                        account_set_id: *account_set_id,
-                        member_id: crate::account_set::AccountSetMemberId::Account(*account_id),
+                        account_set_id: membership.account_set_id,
+                        member_id: crate::account_set::AccountSetMemberId::Account(
+                            membership.account_id,
+                        ),
                     }
                 }),
             )
@@ -886,15 +895,16 @@ impl AccountSetRepo {
     pub(super) async fn fetch_set_membership_edges_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-    ) -> Result<Vec<(AccountSetId, AccountSetId)>, AccountSetError> {
-        Ok(sqlx::query_as(
+    ) -> Result<Vec<SetMembership>, AccountSetError> {
+        let rows: Vec<(AccountSetId, AccountSetId)> = sqlx::query_as(
             r#"
           SELECT account_set_id, member_account_set_id
           FROM cala_account_set_member_account_sets
           "#,
         )
         .fetch_all(db.as_executor())
-        .await?)
+        .await?;
+        Ok(rows.into_iter().map(SetMembership::from).collect())
     }
 
     /// Load only direct account memberships that can participate in a conflict
@@ -902,20 +912,23 @@ impl AccountSetRepo {
     pub(super) async fn fetch_affected_account_memberships_in_op(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        members: &[(AccountSetId, AccountSetId)],
-    ) -> Result<Vec<(AccountSetId, AccountId)>, AccountSetError> {
-        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
+        existing_edges: &[SetMembership],
+        members: &[SetMembership],
+    ) -> Result<Vec<AccountMembership>, AccountSetError> {
+        let member_account_set_ids: Vec<AccountSetId> = members
+            .iter()
+            .map(|edge| edge.member_account_set_id)
+            .collect();
 
         // Only accounts below a proposed member endpoint can gain a new
         // containment path. Compute that affected descendant closure over the
         // final graph so interactions between proposed edges are included.
         let mut children: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(members) {
+        for edge in existing_edges.iter().chain(members) {
             children
-                .entry(*account_set_id)
+                .entry(edge.account_set_id)
                 .or_default()
-                .push(*member_account_set_id);
+                .push(edge.member_account_set_id);
         }
         let mut affected_set_ids = HashSet::new();
         let mut pending = member_account_set_ids;
@@ -954,7 +967,7 @@ impl AccountSetRepo {
             return Ok(Vec::new());
         }
 
-        Ok(sqlx::query_as(
+        let rows: Vec<(AccountSetId, AccountId)> = sqlx::query_as(
             r#"
           SELECT account_set_id, member_account_id
           FROM cala_account_set_member_accounts
@@ -964,7 +977,8 @@ impl AccountSetRepo {
         )
         .bind(&candidate_account_ids)
         .fetch_all(db.as_executor())
-        .await?)
+        .await?;
+        Ok(rows.into_iter().map(AccountMembership::from).collect())
     }
 
     /// Insert a validated batch of direct account-set membership edges.
@@ -985,14 +999,18 @@ impl AccountSetRepo {
     pub(super) async fn insert_member_sets(
         &self,
         db: &mut impl es_entity::AtomicOperation,
-        members: &[(AccountSetId, AccountSetId)],
+        members: &[SetMembership],
     ) -> Result<(), AccountSetError> {
         if members.is_empty() {
             return Ok(());
         }
 
-        let account_set_ids: Vec<AccountSetId> = members.iter().map(|(id, _)| *id).collect();
-        let member_account_set_ids: Vec<AccountSetId> = members.iter().map(|(_, id)| *id).collect();
+        let account_set_ids: Vec<AccountSetId> =
+            members.iter().map(|edge| edge.account_set_id).collect();
+        let member_account_set_ids: Vec<AccountSetId> = members
+            .iter()
+            .map(|edge| edge.member_account_set_id)
+            .collect();
 
         sqlx::query(
             r#"
@@ -1015,16 +1033,14 @@ impl AccountSetRepo {
         self.publisher
             .publish_all(
                 db,
-                members
-                    .iter()
-                    .map(|(account_set_id, member_account_set_id)| {
-                        crate::outbox::OutboxEventPayload::AccountSetMemberCreated {
-                            account_set_id: *account_set_id,
-                            member_id: crate::account_set::AccountSetMemberId::AccountSet(
-                                *member_account_set_id,
-                            ),
-                        }
-                    }),
+                members.iter().map(|edge| {
+                    crate::outbox::OutboxEventPayload::AccountSetMemberCreated {
+                        account_set_id: edge.account_set_id,
+                        member_id: crate::account_set::AccountSetMemberId::AccountSet(
+                            edge.member_account_set_id,
+                        ),
+                    }
+                }),
             )
             .await?;
 
@@ -1231,7 +1247,12 @@ impl AccountSetRepo {
             epoch,
             seeds: rows
                 .into_iter()
-                .filter_map(|row| Some((row.account_id?, row.set_id?)))
+                .filter_map(|row| {
+                    Some(AccountMembership {
+                        account_set_id: row.set_id?,
+                        account_id: row.account_id?,
+                    })
+                })
                 .collect(),
         })
     }
@@ -1483,7 +1504,7 @@ impl AccountSetRepo {
 /// in one snapshot.
 pub(super) struct DirectMembershipProbe {
     pub epoch: i64,
-    pub seeds: Vec<(AccountId, AccountSetId)>,
+    pub seeds: Vec<AccountMembership>,
 }
 
 /// One set's graph node as stored: its immutable meta plus one upward

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -917,30 +917,56 @@ impl AccountSetRepo {
         .fetch_all(db.as_executor())
         .await?;
 
-        let relevant_set_ids: Vec<AccountSetId> = account_set_ids
-            .iter()
-            .chain(&member_account_set_ids)
-            .copied()
-            .chain(
-                existing_edges
-                    .iter()
-                    .flat_map(|(account_set_id, member_account_set_id)| {
-                        [*account_set_id, *member_account_set_id]
-                    }),
-            )
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
-        let account_members = sqlx::query_as(
+        // Only accounts below a proposed member endpoint can gain a new
+        // containment path. Compute that affected descendant closure over the
+        // final graph so interactions between proposed edges are included.
+        let mut children: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(members) {
+            children
+                .entry(*account_set_id)
+                .or_default()
+                .push(*member_account_set_id);
+        }
+        let mut affected_set_ids = HashSet::new();
+        let mut pending: Vec<AccountSetId> = member_account_set_ids.clone();
+        while let Some(account_set_id) = pending.pop() {
+            if affected_set_ids.insert(account_set_id) {
+                pending.extend(children.get(&account_set_id).into_iter().flatten().copied());
+            }
+        }
+        let affected_set_ids: Vec<_> = affected_set_ids.into_iter().collect();
+
+        // The committed graph is already account-path valid. Therefore every
+        // conflict introduced by this batch includes an account attached in
+        // the affected descendant closure above. Find those candidate accounts
+        // through the set-leading index, then load all of their direct
+        // memberships through the member-leading unique index. This preserves
+        // complete account-path validation without reading every membership in
+        // the connected component.
+        let candidate_account_ids: Vec<AccountId> = sqlx::query_scalar(
             r#"
-          SELECT account_set_id, member_account_id
+          SELECT DISTINCT member_account_id
           FROM cala_account_set_member_accounts
           WHERE account_set_id = ANY($1)
           "#,
         )
-        .bind(&relevant_set_ids)
+        .bind(&affected_set_ids)
         .fetch_all(db.as_executor())
         .await?;
+        let account_members = if candidate_account_ids.is_empty() {
+            Vec::new()
+        } else {
+            sqlx::query_as(
+                r#"
+              SELECT account_set_id, member_account_id
+              FROM cala_account_set_member_accounts
+              WHERE member_account_id = ANY($1)
+              "#,
+            )
+            .bind(&candidate_account_ids)
+            .fetch_all(db.as_executor())
+            .await?
+        };
 
         Ok((existing_edges, account_members))
     }

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -9,7 +9,7 @@ use crate::{
     primitives::{AccountId, JournalId},
 };
 
-use super::{entity::*, error::*, graph_cache::MAX_MEMBERSHIP_DEPTH};
+use super::{entity::*, error::*, graph_validation::MAX_MEMBERSHIP_DEPTH};
 
 /// Coarse advisory lock guarding the account-set membership graph
 /// (`cala_account_set_member_accounts` and

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -961,14 +961,12 @@ impl AccountSetRepo {
 
     /// Insert a validated batch of direct account-set membership edges.
     ///
-    /// Precondition: the caller holds [`Self::lock_for_set_membership_op`] and
-    /// has passed the graph cache's combined-graph validation in this same op.
-    /// The exclusive graph lock fences the combined-graph validation from all
-    /// membership writers. A deduplicating query loads the affected connected
-    /// components, then bounded in-memory graph validation evaluates existing
-    /// and proposed edges together. Cycles, duplicate paths, account-path
-    /// conflicts, and depth overflow caused by interactions within the batch
-    /// are rejected before the first edge is written.
+    /// Precondition: the caller holds [`Self::lock_for_set_membership_op`]
+    /// and has passed the graph cache's combined-graph validation in this
+    /// same op. This function only persists: it inserts the edges, bumps the
+    /// graph epoch once for the whole batch, and publishes one outbox event
+    /// per edge. All cycle, path, account, and depth checks happen in the
+    /// caller's validation step before this runs.
     #[instrument(
         level = "debug",
         name = "account_set.insert_member_sets",

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -933,11 +933,18 @@ impl AccountSetRepo {
         // memberships through the member-leading unique index. This preserves
         // complete account-path validation without reading every membership in
         // the connected component.
+        //
+        // These queries decode into newtype tuples rather than using sqlx's
+        // compile-time checked `query!`, because the column types are stable
+        // and the tuple shape is local to this module. An `ORDER BY` keeps
+        // the candidate and membership rows deterministic so the same conflict
+        // is reported consistently across runs.
         let candidate_account_ids: Vec<AccountId> = sqlx::query_scalar(
             r#"
           SELECT DISTINCT member_account_id
           FROM cala_account_set_member_accounts
           WHERE account_set_id = ANY($1)
+          ORDER BY member_account_id
           "#,
         )
         .bind(&affected_set_ids)
@@ -952,6 +959,7 @@ impl AccountSetRepo {
           SELECT account_set_id, member_account_id
           FROM cala_account_set_member_accounts
           WHERE member_account_id = ANY($1)
+          ORDER BY member_account_id, account_set_id
           "#,
         )
         .bind(&candidate_account_ids)

--- a/cala-ledger/src/posting/repo.rs
+++ b/cala-ledger/src/posting/repo.rs
@@ -72,6 +72,7 @@ use cala_types::{
 };
 
 use crate::{
+    account_set::AccountMembership,
     entry::{Entry, NewEntry},
     primitives::*,
     transaction::{NewTransaction, Transaction},
@@ -159,7 +160,7 @@ pub(super) struct AccountMeta {
 /// Everything the flow reads, in one statement.
 pub(super) struct PostingState {
     pub epoch: i64,
-    pub seeds: Vec<(AccountId, AccountSetId)>,
+    pub seeds: Vec<AccountMembership>,
     pub journals: HashMap<JournalId, JournalValues>,
     pub accounts: HashMap<AccountId, AccountMeta>,
     pub balances: HashMap<(JournalId, AccountId, Currency), BalanceSnapshot>,
@@ -484,7 +485,10 @@ impl PostingRepo {
             epoch: row.epoch,
             seeds: Self::decode::<SeedRow>(row.seeds)
                 .into_iter()
-                .map(|SeedRow(a, s)| (a, s))
+                .map(|SeedRow(account_id, account_set_id)| AccountMembership {
+                    account_set_id,
+                    account_id,
+                })
                 .collect(),
             journals: Self::decode::<JournalRow>(row.journals)
                 .into_iter()

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -766,6 +766,260 @@ async fn add_member_sets_batch_rejects_account_conflict_from_interacting_edges(
 }
 
 #[tokio::test]
+async fn add_member_sets_batch_rejects_a_duplicate_of_a_committed_edge() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let parent = cala
+        .account_sets()
+        .create(new_set("batch-dup-parent"))
+        .await?;
+    let child = cala
+        .account_sets()
+        .create(new_set("batch-dup-child"))
+        .await?;
+    cala.account_sets()
+        .add_member(parent.id(), child.id())
+        .await?;
+
+    // Re-attaching an already-committed edge must be rejected before the
+    // unique constraint fires, matching the single-edge path.
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[(parent.id(), child.id())])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = $1 AND member_account_set_id = $2
+        "#,
+    )
+    .bind(parent.id())
+    .bind(child.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 1, "the committed edge must remain exactly once");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_a_path_through_committed_edges() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let root = cala
+        .account_sets()
+        .create(new_set("batch-committed-root"))
+        .await?;
+    let branch = cala
+        .account_sets()
+        .create(new_set("batch-committed-branch"))
+        .await?;
+    let leaf = cala
+        .account_sets()
+        .create(new_set("batch-committed-leaf"))
+        .await?;
+    // Commit root ⊃ leaf, then propose root ⊃ branch and branch ⊃ leaf.
+    // The second proposed edge gives leaf a second path to root.
+    cala.account_sets().add_member(root.id(), leaf.id()).await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[(root.id(), branch.id()), (branch.id(), leaf.id())])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    // The batch must not insert its proposed edges; the committed edge remains.
+    let proposed_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE (account_set_id = $1 AND member_account_set_id = $2)
+           OR (account_set_id = $2 AND member_account_set_id = $3)
+        "#,
+    )
+    .bind(root.id())
+    .bind(branch.id())
+    .bind(leaf.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(
+        proposed_count, 0,
+        "a rejected batch must not insert any edge"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_attributes_depth_overflow_through_existing_edges(
+) -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let mut sets = Vec::new();
+    for i in 0..18 {
+        let set = NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(format!("batch-existing-depth-{i}"))
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()?;
+        sets.push(cala.account_sets().create(set).await?);
+    }
+    // Commit a 10-chain, then propose 8 more edges to exceed depth 16.
+    for pair in sets[0..10].windows(2) {
+        cala.account_sets()
+            .add_member(pair[0].id(), pair[1].id())
+            .await?;
+    }
+    let proposed: Vec<_> = sets[9..18]
+        .windows(2)
+        .map(|pair| (pair[0].id(), pair[1].id()))
+        .collect();
+
+    let result = cala.account_sets().add_member_sets(&proposed).await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth: 17,
+            max: 16,
+        }) if account_set_id == sets[16].id()
+            && member_account_set_id == sets[17].id()
+    ));
+
+    let ids: Vec<_> = sets[9..18].iter().map(|set| set.id()).collect();
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_matches_serial_add_member_set() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    // Two identical trees: one attached in a batch, one edge at a time.
+    let batch_sets: Vec<_> = (0..5)
+        .map(|i| {
+            cala.account_sets()
+                .create(new_set(&format!("diff-batch-{i}")))
+        })
+        .collect();
+    let batch_sets = futures::future::try_join_all(batch_sets).await?;
+    let serial_sets: Vec<_> = (0..5)
+        .map(|i| {
+            cala.account_sets()
+                .create(new_set(&format!("diff-serial-{i}")))
+        })
+        .collect();
+    let serial_sets = futures::future::try_join_all(serial_sets).await?;
+
+    let edges: Vec<_> = batch_sets
+        .windows(2)
+        .map(|pair| (pair[0].id(), pair[1].id()))
+        .collect();
+    cala.account_sets().add_member_sets(&edges).await?;
+    for pair in serial_sets.windows(2) {
+        cala.account_sets()
+            .add_member(pair[0].id(), pair[1].id())
+            .await?;
+    }
+
+    let batch_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+        "#,
+    )
+    .bind(batch_sets.iter().map(|set| set.id()).collect::<Vec<_>>())
+    .fetch_one(&pool)
+    .await?;
+    let serial_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+        "#,
+    )
+    .bind(serial_sets.iter().map(|set| set.id()).collect::<Vec<_>>())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(batch_count, serial_count);
+    assert_eq!(batch_count, 4);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn add_member_sets_batch_rejects_dense_duplicate_paths_without_path_explosion(
 ) -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -1,5 +1,7 @@
 mod helpers;
 
+use std::time::Duration;
+
 use rand::distr::{Alphanumeric, SampleString};
 
 use cala_ledger::{
@@ -498,6 +500,418 @@ async fn add_members_batch() -> anyhow::Result<()> {
         .add_members(&[(AccountSetId::new(), unknown.id())])
         .await;
     assert!(res.is_err());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch() -> anyhow::Result<()> {
+    let pool = helpers::init_isolated_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let root = cala.account_sets().create(new_set("batch-root")).await?;
+    let left = cala.account_sets().create(new_set("batch-left")).await?;
+    let right = cala.account_sets().create(new_set("batch-right")).await?;
+    let leaf = cala.account_sets().create(new_set("batch-leaf")).await?;
+
+    cala.account_sets().add_member_sets(&[]).await?;
+    let epoch_before: i64 = sqlx::query_scalar("SELECT epoch FROM cala_account_set_graph_epoch")
+        .fetch_one(&pool)
+        .await?;
+    cala.account_sets()
+        .add_member_sets(&[
+            (root.id(), left.id()),
+            (root.id(), right.id()),
+            (left.id(), leaf.id()),
+        ])
+        .await?;
+    let epoch_after: i64 = sqlx::query_scalar("SELECT epoch FROM cala_account_set_graph_epoch")
+        .fetch_one(&pool)
+        .await?;
+    assert_eq!(epoch_after, epoch_before + 1);
+
+    let parent_ids = [root.id(), left.id()];
+    let member_ids = [left.id(), right.id(), leaf.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+          AND member_account_set_id = ANY($2)
+        "#,
+    )
+    .bind(&parent_ids[..])
+    .bind(&member_ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 3);
+
+    let event_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_persistent_outbox_events
+        WHERE payload->>'type' = 'account_set_member_created'
+          AND (payload->>'account_set_id')::uuid = ANY($1)
+        "#,
+    )
+    .bind(&parent_ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(event_count, 3, "the batch must publish one event per edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_interacting_edges_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let set_a = cala.account_sets().create(new_set("batch-cycle-a")).await?;
+    let set_b = cala.account_sets().create(new_set("batch-cycle-b")).await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[(set_a.id(), set_b.id()), (set_b.id(), set_a.id())])
+        .await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MembershipCycleDetected { .. })
+    ));
+
+    let ids = [set_a.id(), set_b.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+           OR member_account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_duplicate_paths_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let root = cala
+        .account_sets()
+        .create(new_set("batch-path-root"))
+        .await?;
+    let branch = cala
+        .account_sets()
+        .create(new_set("batch-path-branch"))
+        .await?;
+    let leaf = cala
+        .account_sets()
+        .create(new_set("batch-path-leaf"))
+        .await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[
+            (root.id(), branch.id()),
+            (branch.id(), leaf.id()),
+            (root.id(), leaf.id()),
+        ])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    let ids = [root.id(), branch.id(), leaf.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+          AND member_account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_dense_duplicate_paths_without_path_explosion(
+) -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool)
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let mut sets = Vec::new();
+    for i in 0..64 {
+        let set = NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(format!("batch-dense-{i}"))
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()?;
+        sets.push(cala.account_sets().create(set).await?);
+    }
+    let mut edges = Vec::new();
+    for parent in 0..sets.len() {
+        for child in (parent + 1)..sets.len() {
+            edges.push((sets[parent].id(), sets[child].id()));
+        }
+    }
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        cala.account_sets().add_member_sets(&edges),
+    )
+    .await
+    .expect("dense invalid input must be rejected with bounded work");
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_depth_overflow_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let mut sets = Vec::new();
+    for i in 0..18 {
+        let set = NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(format!("batch-depth-{i}"))
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()?;
+        sets.push(cala.account_sets().create(set).await?);
+    }
+    let edges: Vec<_> = sets
+        .windows(2)
+        .map(|pair| (pair[0].id(), pair[1].id()))
+        .collect();
+
+    let result = cala.account_sets().add_member_sets(&edges).await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth: 17,
+            max: 16,
+        }) if account_set_id == sets[16].id()
+            && member_account_set_id == sets[17].id()
+    ));
+
+    let ids: Vec<_> = sets.iter().map(|set| set.id()).collect();
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+        "#,
+    )
+    .bind(&ids)
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_journal_mismatch_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal_a = cala.journals().create(helpers::test_journal()).await?;
+    let journal_b = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str, journal_id| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal_id)
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let parent = cala
+        .account_sets()
+        .create(new_set("batch-journal-parent", journal_a.id()))
+        .await?;
+    let valid_child = cala
+        .account_sets()
+        .create(new_set("batch-journal-valid", journal_a.id()))
+        .await?;
+    let invalid_child = cala
+        .account_sets()
+        .create(new_set("batch-journal-invalid", journal_b.id()))
+        .await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[
+            (parent.id(), valid_child.id()),
+            (parent.id(), invalid_child.id()),
+        ])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::JournalIdMismatch)));
+
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = $1
+        "#,
+    )
+    .bind(parent.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_member_sets_batch_rejects_member_history_atomically() -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let (sender, recipient) = helpers::test_accounts();
+    let sender = cala.accounts().create(sender).await?;
+    let recipient = cala.accounts().create(recipient).await?;
+    let tx_code = Alphanumeric.sample_string(&mut rand::rng(), 32);
+    cala.tx_templates()
+        .create(helpers::currency_conversion_template(&tx_code))
+        .await?;
+
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let parent = cala
+        .account_sets()
+        .create(new_set("batch-history-parent"))
+        .await?;
+    let valid_child = cala
+        .account_sets()
+        .create(new_set("batch-history-valid"))
+        .await?;
+    let child_with_history = cala
+        .account_sets()
+        .create(new_set("batch-history-invalid"))
+        .await?;
+    cala.account_sets()
+        .add_member(child_with_history.id(), recipient.id())
+        .await?;
+
+    let mut params = Params::new();
+    params.insert("journal_id", journal.id().to_string());
+    params.insert("sender", sender.id());
+    params.insert("recipient", recipient.id());
+    cala.post_transaction(TransactionId::new(), &tx_code, params)
+        .await?;
+
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[
+            (parent.id(), valid_child.id()),
+            (parent.id(), child_with_history.id()),
+        ])
+        .await;
+    assert!(matches!(
+        result,
+        Err(AccountSetError::MemberHasBalanceHistory { .. })
+    ));
+
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = $1
+        "#,
+    )
+    .bind(parent.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
 
     Ok(())
 }

--- a/cala-ledger/tests/account_set.rs
+++ b/cala-ledger/tests/account_set.rs
@@ -687,6 +687,85 @@ async fn add_member_sets_batch_rejects_duplicate_paths_atomically() -> anyhow::R
 }
 
 #[tokio::test]
+async fn add_member_sets_batch_rejects_account_conflict_from_interacting_edges(
+) -> anyhow::Result<()> {
+    let pool = helpers::init_pool().await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+    let new_set = |name: &str| {
+        NewAccountSet::builder()
+            .id(AccountSetId::new())
+            .name(name)
+            .journal_id(journal.id())
+            .balance_rollup(BalanceRollup::Synchronous)
+            .build()
+            .unwrap()
+    };
+    let root = cala
+        .account_sets()
+        .create(new_set("batch-account-root"))
+        .await?;
+    let branch = cala
+        .account_sets()
+        .create(new_set("batch-account-branch"))
+        .await?;
+    let leaf = cala
+        .account_sets()
+        .create(new_set("batch-account-leaf"))
+        .await?;
+    let deep_leaf = cala
+        .account_sets()
+        .create(new_set("batch-account-deep-leaf"))
+        .await?;
+    cala.account_sets()
+        .add_member(leaf.id(), deep_leaf.id())
+        .await?;
+
+    let (account, _) = helpers::test_accounts();
+    let account = cala.accounts().create(account).await?;
+    cala.account_sets()
+        .add_member(root.id(), account.id())
+        .await?;
+    cala.account_sets()
+        .add_member(deep_leaf.id(), account.id())
+        .await?;
+
+    // The account below `deep_leaf` is selected by following both proposed
+    // edges and the committed leaf -> deep_leaf edge in the final descendant
+    // closure. Loading all memberships for that candidate then exposes its
+    // separate direct membership in `root`.
+    let result = cala
+        .account_sets()
+        .add_member_sets(&[(root.id(), branch.id()), (branch.id(), leaf.id())])
+        .await;
+    assert!(matches!(result, Err(AccountSetError::MemberAlreadyAdded)));
+
+    let parent_ids = [root.id(), branch.id()];
+    let member_ids = [branch.id(), leaf.id()];
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = ANY($1)
+          AND member_account_set_id = ANY($2)
+        "#,
+    )
+    .bind(&parent_ids[..])
+    .bind(&member_ids[..])
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 0, "a rejected batch must not insert any edge");
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn add_member_sets_batch_rejects_dense_duplicate_paths_without_path_explosion(
 ) -> anyhow::Result<()> {
     let pool = helpers::init_pool().await?;

--- a/cala-ledger/tests/account_set_membership_locks.rs
+++ b/cala-ledger/tests/account_set_membership_locks.rs
@@ -397,3 +397,177 @@ async fn concurrent_adds_resolve_all_ancestors() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+/// Batch set-structure mutations serialize with single-edge structure
+/// mutations on the same exclusive coarse lock, even when the sets are
+/// disjoint. This exercises the combined-graph validation path rather than
+/// the single-edge fast path.
+#[tokio::test]
+async fn batch_structure_ops_serialize() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let parent_a = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-struct-a-parent"))
+        .await?;
+    let child_a = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-struct-a-child"))
+        .await?;
+    let parent_b = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-struct-b-parent"))
+        .await?;
+    let child_b = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-struct-b-child"))
+        .await?;
+    let parent_c = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-struct-c-parent"))
+        .await?;
+    let child_c = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-struct-c-child"))
+        .await?;
+
+    // Hold an uncommitted batch structure mutation open (exclusive coarse
+    // lock, len > 1 to stay on the combined-graph path).
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_sets_in_op(
+            &mut op,
+            &[(parent_a.id(), child_a.id()), (parent_b.id(), child_b.id())],
+        )
+        .await?;
+
+    // A disjoint single-edge structure mutation must still wait.
+    let cala2 = cala.clone();
+    let (p_c, c_c) = (parent_c.id(), child_c.id());
+    let mut blocked = tokio::spawn(async move { cala2.account_sets().add_member(p_c, c_c).await });
+
+    assert!(
+        tokio::time::timeout(MUST_STILL_BE_PENDING, &mut blocked)
+            .await
+            .is_err(),
+        "a single-edge structure mutation must block while a batch is open"
+    );
+
+    op.commit().await?;
+    blocked.await??;
+    Ok(())
+}
+
+/// An open batch set-structure mutation fences unrelated account-member
+/// mutations, just like a single-edge structure mutation does.
+#[tokio::test]
+async fn batch_structure_ops_fence_account_member_ops() -> anyhow::Result<()> {
+    let cala = init_cala().await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let (one, _) = helpers::test_accounts();
+    let one = cala.accounts().create(one).await?;
+    let parent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-fence-parent"))
+        .await?;
+    let child = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-fence-child"))
+        .await?;
+    let unrelated = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-fence-unrelated"))
+        .await?;
+
+    let child2 = cala
+        .account_sets()
+        .create(new_set(journal.id(), "batch-fence-child2"))
+        .await?;
+
+    let mut op = cala.begin_operation().await?;
+    cala.account_sets()
+        .add_member_sets_in_op(
+            &mut op,
+            &[(parent.id(), child.id()), (parent.id(), child2.id())],
+        )
+        .await?;
+
+    let cala2 = cala.clone();
+    let unrelated_id = unrelated.id();
+    let member_id = one.id();
+    let mut blocked = tokio::spawn(async move {
+        cala2
+            .account_sets()
+            .add_member(unrelated_id, member_id)
+            .await
+    });
+
+    assert!(
+        tokio::time::timeout(MUST_STILL_BE_PENDING, &mut blocked)
+            .await
+            .is_err(),
+        "account-member add must block while a batch structure mutation is open"
+    );
+
+    op.commit().await?;
+    blocked.await??;
+    Ok(())
+}
+
+/// A single-edge batch routes through the same single-attach path as a
+/// direct set-structure call, so it produces identical persisted state
+/// and outbox events without running combined-graph validation.
+#[tokio::test]
+async fn single_edge_batch_matches_single_attach_path() -> anyhow::Result<()> {
+    let pool = init_isolated_pool(5).await?;
+    let mut jobs = helpers::init_jobs(pool.clone()).await?;
+    let cala_config = CalaLedgerConfig::builder()
+        .pool(pool.clone())
+        .exec_migrations(false)
+        .build()?;
+    let cala = CalaLedger::init(cala_config, &mut jobs).await?;
+    let journal = cala.journals().create(helpers::test_journal()).await?;
+
+    let parent = cala
+        .account_sets()
+        .create(new_set(journal.id(), "single-edge-parent"))
+        .await?;
+    let child = cala
+        .account_sets()
+        .create(new_set(journal.id(), "single-edge-child"))
+        .await?;
+
+    cala.account_sets()
+        .add_member_sets(&[(parent.id(), child.id())])
+        .await?;
+
+    let edge_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_account_set_member_account_sets
+        WHERE account_set_id = $1 AND member_account_set_id = $2
+        "#,
+    )
+    .bind(parent.id())
+    .bind(child.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(edge_count, 1);
+
+    let event_count: i64 = sqlx::query_scalar(
+        r#"
+        SELECT COUNT(*)
+        FROM cala_persistent_outbox_events
+        WHERE payload->>'type' = 'account_set_member_created'
+          AND payload->>'account_set_id' = $1::text
+        "#,
+    )
+    .bind(parent.id())
+    .fetch_one(&pool)
+    .await?;
+    assert_eq!(event_count, 1);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Large account-set hierarchy imports currently attach each set-to-set edge through `add_member_set`, repeating entity resolution, locking, graph validation, insertion, and graph-epoch updates for every edge. Cala already batches account-to-set membership, but lacks the symmetric API for account-set membership.

Batch attachment validates existing and proposed edges as one graph before writing anything. It preserves journal, balance-history, cycle, unique-path, depth, graph-epoch, outbox, and atomicity guarantees while replacing repeated per-edge database work with batched loads and inserts. Bounded in-memory DAG validation avoids recursively enumerating paths for dense invalid input.

This PR only changes set-to-set membership; it does not touch the account-attach hot path (`assert_no_double_membership` / `count_membership_paths`), which remains its own future optimization.

## Why set validation is heavier

Account attachment adds membership seeds to a fixed graph. Set attachment changes the graph itself and every account path derived from it, so the batch must enforce additional topology invariants before writing anything.

<details>
<summary><strong>Detailed comparison of account and set validation</strong></summary>

In this PR, the existing account decision is one focused function:

```rust
fn count_membership_paths(...) -> Option<bool>
```

The new set decision requires a primary validator plus three graph helpers:

```rust
fn validate_set_memberships(...) -> Result<(), AccountSetError>
fn graph_has_path(...) -> bool
fn first_depth_overflow(...) -> (usize, i32)
fn graph_max_depth(...) -> i32
```

| Shape in PR #840 | Existing account validation | New set validation |
|---|---:|---:|
| Pure functions | 1 | 4 |
| Approximate source lines | 46 | 198 |
| Changes graph topology | No | Yes |
| Decisions | Duplicate account path or incomplete cache | Cycle, duplicate set path, duplicate account path, depth, and offending edge |

### Existing account validation

Account attachment does not change graph topology. The existing validator groups proposed and direct memberships by account, walks upward through parent sets, and rejects when an account reaches the same set through multiple paths. An incomplete cache view returns `None` so the caller can fall back to SQL.

The pure decision is roughly 30–40 lines: seed accounts, traverse parents, and count `(account, set)` paths.

### New set validation

Set attachment changes topology and must evaluate existing and proposed edges together before writing anything. It must determine whether the batch:

1. Creates a cycle.
2. Gives any set multiple paths to an ancestor.
3. Consequently gives an existing account multiple paths to a set.
4. Exceeds the maximum hierarchy depth.
5. Contains an edge that is valid alone but invalid through interaction with another proposed edge.
6. Has a first offending edge that must be identified precisely so depth-error fields remain accurate.

The implementation therefore builds the combined adjacency graph, uses Kahn topological sorting for cycle detection, propagates ancestor sets for path uniqueness, evaluates account reachability, computes longest paths, and searches batch prefixes for precise depth-error attribution. This is roughly 190 lines of pure algorithmic code versus 30–40 for account path counting.

The pure account and set decisions now live with their unit tests in `graph_validation.rs`; the cache retains snapshot adaptation and the repository retains SQL.

</details>

## Review follow-up

- [x] **Blocker:** avoid whole-component validation reads while holding the exclusive membership-graph lock.
  - [x] Scope account reads to accounts below affected member-side descendants.
  - [x] Read existing edges from an epoch-matched cache snapshot, with an op-local fallback.
- [x] Add integration coverage for committed set-path, existing-depth, duplicate-edge, and differential cases.
- [x] Correct validation, epoch, and mutator documentation drift in code comments.
- [x] Deduplicate lookup IDs.
- [x] Pin the locally-provable cycle-fallback precondition and document depth semantics.
- [x] Document and order batch account reads; keep `query_as` for stable tuple decoding and deterministic conflict reporting.
- [x] Document the initial bulk-import consumer and the steady-state cost model.
- [x] Note in the PR body that this work does not touch the account-attach hot path (`assert_no_double_membership`).
- [ ] Address migration comment drift (immutable migration file; intentionally left for now).
- [ ] Add batch-vs-poster attach-fence coverage (currently in PR #843).

## Test plan

- [x] `cargo test -p cala-ledger`
- [x] `cargo clippy -p cala-ledger --tests -- -D warnings`
- [x] Validate successful batch insertion, epoch updates, and one outbox event per edge
- [x] Validate atomic rejection of cycles, duplicate paths, journal mismatch, balance history, and depth overflow
- [x] Reject a dense 2,016-edge invalid DAG without path explosion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes membership-graph validation, advisory locking, and atomic persistence for hierarchy edges—core ledger invariants (cycles, path uniqueness, depth, epoch, outbox).
> 
> **Overview**
> Adds **`add_member_sets`** / **`add_member_sets_in_op`** so many set-to-set edges are validated as one combined graph and persisted atomically (single epoch bump, one outbox event per edge). A one-edge batch still uses the existing **`add_member_set`** path.
> 
> Introduces **`graph_validation.rs`** with **`SetMembership`** and **`AccountMembership`**, pure checks for cycles, duplicate set/account paths, and depth limits, plus **`has_duplicate_account_membership_paths`** moved out of the cache. **`SetGraphCache`** gains downward **`children`** edges, **`edges_connected_to`**, and **`assert_valid_set_memberships_in_op`** (memory when epoch matches, flat SQL edge load otherwise).
> 
> **`AccountSetRepo`** adds structure-lock helpers, scoped account membership reads under proposed member descendants, and **`insert_member_sets`**. Account attach and posting paths now use **`AccountMembership`** instead of transposed tuple pairs. Integration tests cover atomic rejection, serialization under the exclusive lock, and dense invalid graphs without path explosion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5287a6c22a26d71bc7f8f7f90e776da034288793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->








