### PR TITLE
refactor(account-set): isolate graph validation

### DIFF
--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -19,9 +19,9 @@
 //!
 //! Layering: `AccountSets` (service) calls this cache; this cache holds
 //! a handle on `AccountSetRepo` and orchestrates — ALL SQL lives in
-//! `repo.rs`, cache state and account-path graph logic live here, and pure
-//! set-membership invariants live in `graph_validation.rs`. The call graph is
-//! strictly service -> cache -> repo; the repo never calls back up into the cache.
+//! `repo.rs`, cache state and snapshot adaptation live here, and pure graph
+//! invariants live in `graph_validation.rs`. The call graph is strictly
+//! service -> cache -> repo; the repo never calls back up into the cache.
 //!
 //! Why the split read is safe — the two inputs have opposite write
 //! rates:
@@ -92,7 +92,7 @@ use crate::primitives::{AccountId, AccountSetId, JournalId};
 
 use super::{
     error::AccountSetError,
-    graph_validation::validate_set_memberships,
+    graph_validation::{has_duplicate_account_membership_paths, validate_set_memberships},
     repo::{AccountSetRepo, SetGraphNode},
 };
 
@@ -464,12 +464,31 @@ impl SetGraphCache {
             Some(Overlay { parents, meta })
         };
 
-        match Self::count_membership_paths(
-            &snapshot,
-            overlay.as_ref(),
+        let is_known = |set_id: &AccountSetId| -> bool {
+            snapshot.meta.contains_key(set_id)
+                || overlay
+                    .as_ref()
+                    .is_some_and(|overlay| overlay.meta.contains_key(set_id))
+        };
+        let parents_of = |set_id: &AccountSetId| -> &[AccountSetId] {
+            snapshot
+                .parents
+                .get(set_id)
+                .or_else(|| {
+                    overlay
+                        .as_ref()
+                        .and_then(|overlay| overlay.parents.get(set_id))
+                })
+                .map(Vec::as_slice)
+                .unwrap_or(&[])
+        };
+
+        match has_duplicate_account_membership_paths(
             account_set_ids,
             account_ids,
             &probe.seeds,
+            is_known,
+            parents_of,
         ) {
             Some(false) => {
                 span.record(
@@ -495,69 +514,6 @@ impl SetGraphCache {
                     .await
             }
         }
-    }
-
-    /// The in-memory mirror of the SQL walk's conflict predicate: seed
-    /// each account with its new target sets (pair multiplicity
-    /// preserved) plus its existing direct memberships, expand every
-    /// seed upward over snapshot + overlay counting *paths* (unlike
-    /// [`Self::expand`], which dedups via a visited set — reachability
-    /// is the wrong question here), and report a conflict as soon as any
-    /// `(account, set)` is reached twice.
-    ///
-    /// Returns `None` if a set id is unknown to snapshot + overlay —
-    /// caller falls back to the SQL walk.
-    ///
-    /// Terminates unconditionally: every pop increments some count and
-    /// the second increment of any count returns immediately, so pops
-    /// are bounded by (known sets + 1) per account. A corrupted cyclic
-    /// graph revisits a set and reports a conflict — a conservative
-    /// reject, where the SQL walk's unbounded UNION ALL recursion would
-    /// not terminate at all.
-    fn count_membership_paths(
-        snapshot: &GraphSnapshot,
-        overlay: Option<&Overlay>,
-        new_set_ids: &[AccountSetId],
-        new_account_ids: &[AccountId],
-        existing_seeds: &[(AccountId, AccountSetId)],
-    ) -> Option<bool> {
-        let known = |set_id: &AccountSetId| -> bool {
-            snapshot.meta.contains_key(set_id)
-                || overlay.is_some_and(|o| o.meta.contains_key(set_id))
-        };
-        let parents_of = |set_id: &AccountSetId| -> &[AccountSetId] {
-            snapshot
-                .parents
-                .get(set_id)
-                .or_else(|| overlay.and_then(|o| o.parents.get(set_id)))
-                .map(Vec::as_slice)
-                .unwrap_or(&[])
-        };
-
-        let mut per_account: HashMap<AccountId, Vec<AccountSetId>> = HashMap::new();
-        for (set_id, account_id) in new_set_ids.iter().zip(new_account_ids) {
-            per_account.entry(*account_id).or_default().push(*set_id);
-        }
-        for (account_id, set_id) in existing_seeds {
-            per_account.entry(*account_id).or_default().push(*set_id);
-        }
-
-        for seeds in per_account.into_values() {
-            let mut path_counts: HashMap<AccountSetId, u32> = HashMap::new();
-            let mut queue: VecDeque<AccountSetId> = seeds.into();
-            while let Some(set_id) = queue.pop_front() {
-                if !known(&set_id) {
-                    return None;
-                }
-                let count = path_counts.entry(set_id).or_default();
-                *count += 1;
-                if *count > 1 {
-                    return Some(true);
-                }
-                queue.extend(parents_of(&set_id));
-            }
-        }
-        Some(false)
     }
 
     /// Validate a batch of set-to-set memberships against the graph read

--- a/cala-ledger/src/account_set/graph_cache.rs
+++ b/cala-ledger/src/account_set/graph_cache.rs
@@ -19,9 +19,9 @@
 //!
 //! Layering: `AccountSets` (service) calls this cache; this cache holds
 //! a handle on `AccountSetRepo` and orchestrates — ALL SQL lives in
-//! `repo.rs`, all cache state and in-memory graph logic lives here. The
-//! call graph is strictly service -> cache -> repo; the repo never
-//! calls back up into the cache.
+//! `repo.rs`, cache state and account-path graph logic live here, and pure
+//! set-membership invariants live in `graph_validation.rs`. The call graph is
+//! strictly service -> cache -> repo; the repo never calls back up into the cache.
 //!
 //! Why the split read is safe — the two inputs have opposite write
 //! rates:
@@ -92,6 +92,7 @@ use crate::primitives::{AccountId, AccountSetId, JournalId};
 
 use super::{
     error::AccountSetError,
+    graph_validation::validate_set_memberships,
     repo::{AccountSetRepo, SetGraphNode},
 };
 
@@ -105,12 +106,6 @@ const TIMER_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// increments, so this never matches and the first resolution always
 /// takes the op-local fallback (and triggers the installing refresh).
 const COLD_EPOCH: i64 = -1;
-
-/// Maximum depth (in set->set edges) of any root-to-leaf membership
-/// chain. Rejecting edges past this bound keeps the read-time ancestor
-/// walk cheap and terminating. Real hierarchies are <=10 deep; 16 leaves
-/// headroom.
-pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
 
 #[derive(Debug, Clone, Copy)]
 struct SetMeta {
@@ -578,205 +573,7 @@ impl SetGraphCache {
             .repo
             .fetch_set_membership_validation_data_in_op(op, members)
             .await?;
-        Self::validate_set_memberships(&existing_edges, members, &account_members)
-    }
-
-    fn validate_set_memberships(
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        proposed_edges: &[(AccountSetId, AccountSetId)],
-        account_members: &[(AccountSetId, AccountId)],
-    ) -> Result<(), AccountSetError> {
-        let mut nodes = HashSet::new();
-        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-
-        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-            nodes.insert(*account_set_id);
-            nodes.insert(*member_account_set_id);
-            adjacency
-                .entry(*account_set_id)
-                .or_default()
-                .push(*member_account_set_id);
-            *indegree.entry(*member_account_set_id).or_default() += 1;
-            indegree.entry(*account_set_id).or_default();
-        }
-        for (account_set_id, _) in account_members {
-            nodes.insert(*account_set_id);
-            indegree.entry(*account_set_id).or_default();
-        }
-
-        let mut queue: VecDeque<AccountSetId> = indegree
-            .iter()
-            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-            .collect();
-        let mut topological_order = Vec::with_capacity(nodes.len());
-        while let Some(account_set_id) = queue.pop_front() {
-            topological_order.push(account_set_id);
-            if let Some(children) = adjacency.get(&account_set_id) {
-                for child in children {
-                    let degree = indegree
-                        .get_mut(child)
-                        .expect("every child must have an indegree");
-                    *degree -= 1;
-                    if *degree == 0 {
-                        queue.push_back(*child);
-                    }
-                }
-            }
-        }
-
-        if topological_order.len() != nodes.len() {
-            let (account_set_id, member_account_set_id) = proposed_edges
-                .iter()
-                .find(|(account_set_id, member_account_set_id)| {
-                    account_set_id == member_account_set_id
-                        || Self::graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
-                })
-                .copied()
-                .unwrap_or(proposed_edges[0]);
-            return Err(AccountSetError::MembershipCycleDetected {
-                account_set_id,
-                member_account_set_id,
-            });
-        }
-
-        // In topological order, every parent's ancestor set is complete before
-        // its contribution reaches a child. An overlap means the child has two
-        // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
-        // worst case instead of enumerating exponentially many paths.
-        let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
-        let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
-        for account_set_id in &topological_order {
-            let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
-            contribution.insert(*account_set_id);
-            let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
-
-            if let Some(children) = adjacency.get(account_set_id) {
-                for child in children {
-                    let child_ancestors = ancestors.entry(*child).or_default();
-                    if !child_ancestors.is_disjoint(&contribution) {
-                        return Err(AccountSetError::MemberAlreadyAdded);
-                    }
-                    child_ancestors.extend(contribution.iter().copied());
-                    depth_from_root
-                        .entry(*child)
-                        .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
-                        .or_insert(parent_depth + 1);
-                }
-            }
-        }
-
-        let mut account_paths = HashSet::new();
-        for (account_set_id, account_id) in account_members {
-            if !account_paths.insert((*account_set_id, *account_id)) {
-                return Err(AccountSetError::MemberAlreadyAdded);
-            }
-            if let Some(containers) = ancestors.get(account_set_id) {
-                for container in containers {
-                    if !account_paths.insert((*container, *account_id)) {
-                        return Err(AccountSetError::MemberAlreadyAdded);
-                    }
-                }
-            }
-        }
-
-        let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
-        if max_depth > MAX_MEMBERSHIP_DEPTH {
-            let (index, depth) = Self::first_depth_overflow(existing_edges, proposed_edges);
-            let (account_set_id, member_account_set_id) = proposed_edges[index];
-            return Err(AccountSetError::MembershipDepthExceeded {
-                account_set_id,
-                member_account_set_id,
-                depth,
-                max: MAX_MEMBERSHIP_DEPTH,
-            });
-        }
-
-        Ok(())
-    }
-
-    fn graph_has_path(
-        adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
-        from: AccountSetId,
-        to: AccountSetId,
-    ) -> bool {
-        let mut pending = vec![from];
-        let mut visited = HashSet::new();
-        while let Some(current) = pending.pop() {
-            if current == to {
-                return true;
-            }
-            if visited.insert(current) {
-                pending.extend(adjacency.get(&current).into_iter().flatten().copied());
-            }
-        }
-        false
-    }
-
-    fn first_depth_overflow(
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        proposed_edges: &[(AccountSetId, AccountSetId)],
-    ) -> (usize, i32) {
-        let mut low = 1;
-        let mut high = proposed_edges.len();
-        while low < high {
-            let middle = (low + high) / 2;
-            if Self::graph_max_depth(existing_edges, &proposed_edges[..middle])
-                > MAX_MEMBERSHIP_DEPTH
-            {
-                high = middle;
-            } else {
-                low = middle + 1;
-            }
-        }
-        (
-            low - 1,
-            Self::graph_max_depth(existing_edges, &proposed_edges[..low]),
-        )
-    }
-
-    fn graph_max_depth(
-        existing_edges: &[(AccountSetId, AccountSetId)],
-        proposed_edges: &[(AccountSetId, AccountSetId)],
-    ) -> i32 {
-        let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
-        let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
-        for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
-            adjacency
-                .entry(*account_set_id)
-                .or_default()
-                .push(*member_account_set_id);
-            *indegree.entry(*member_account_set_id).or_default() += 1;
-            indegree.entry(*account_set_id).or_default();
-        }
-
-        let mut queue: VecDeque<AccountSetId> = indegree
-            .iter()
-            .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
-            .collect();
-        let mut depths = HashMap::new();
-        let mut max_depth = 0;
-        while let Some(account_set_id) = queue.pop_front() {
-            let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
-            if let Some(children) = adjacency.get(&account_set_id) {
-                for child in children {
-                    let child_depth = parent_depth + 1;
-                    depths
-                        .entry(*child)
-                        .and_modify(|depth| *depth = (*depth).max(child_depth))
-                        .or_insert(child_depth);
-                    max_depth = max_depth.max(child_depth);
-                    let degree = indegree
-                        .get_mut(child)
-                        .expect("every child must have an indegree");
-                    *degree -= 1;
-                    if *degree == 0 {
-                        queue.push_back(*child);
-                    }
-                }
-            }
-        }
-        max_depth
+        validate_set_memberships(&existing_edges, members, &account_members)
     }
 
     fn load(&self) -> Arc<GraphSnapshot> {

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -10,6 +10,42 @@ use super::error::AccountSetError;
 /// headroom.
 pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
 
+/// Count paths from each account's proposed and existing direct memberships
+/// through the supplied parent graph. Returns `None` when the graph view does
+/// not know a traversed set, allowing the cache adapter to fall back to SQL.
+pub(super) fn has_duplicate_account_membership_paths<'a>(
+    new_set_ids: &[AccountSetId],
+    new_account_ids: &[AccountId],
+    existing_seeds: &[(AccountId, AccountSetId)],
+    is_known: impl Fn(&AccountSetId) -> bool,
+    parents_of: impl Fn(&AccountSetId) -> &'a [AccountSetId],
+) -> Option<bool> {
+    let mut per_account: HashMap<AccountId, Vec<AccountSetId>> = HashMap::new();
+    for (set_id, account_id) in new_set_ids.iter().zip(new_account_ids) {
+        per_account.entry(*account_id).or_default().push(*set_id);
+    }
+    for (account_id, set_id) in existing_seeds {
+        per_account.entry(*account_id).or_default().push(*set_id);
+    }
+
+    for seeds in per_account.into_values() {
+        let mut path_counts: HashMap<AccountSetId, u32> = HashMap::new();
+        let mut queue: VecDeque<AccountSetId> = seeds.into();
+        while let Some(set_id) = queue.pop_front() {
+            if !is_known(&set_id) {
+                return None;
+            }
+            let count = path_counts.entry(set_id).or_default();
+            *count += 1;
+            if *count > 1 {
+                return Some(true);
+            }
+            queue.extend(parents_of(&set_id));
+        }
+    }
+    Some(false)
+}
+
 pub(super) fn validate_set_memberships(
     existing_edges: &[(AccountSetId, AccountSetId)],
     proposed_edges: &[(AccountSetId, AccountSetId)],
@@ -212,6 +248,60 @@ mod tests {
 
     fn set_ids<const N: usize>() -> [AccountSetId; N] {
         std::array::from_fn(|_| AccountSetId::new())
+    }
+
+    #[test]
+    fn account_paths_accept_distinct_ancestors() {
+        let [left, right] = set_ids();
+        let account_id = AccountId::new();
+        let known = HashSet::from([left, right]);
+        let parents: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+
+        assert_eq!(
+            has_duplicate_account_membership_paths(
+                &[left, right],
+                &[account_id, account_id],
+                &[],
+                |set_id| known.contains(set_id),
+                |set_id| parents.get(set_id).map(Vec::as_slice).unwrap_or(&[]),
+            ),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn account_paths_reject_a_shared_ancestor() {
+        let [root, left, right] = set_ids();
+        let account_id = AccountId::new();
+        let known = HashSet::from([root, left, right]);
+        let parents = HashMap::from([(left, vec![root]), (right, vec![root])]);
+
+        assert_eq!(
+            has_duplicate_account_membership_paths(
+                &[left, right],
+                &[account_id, account_id],
+                &[],
+                |set_id| known.contains(set_id),
+                |set_id| parents.get(set_id).map(Vec::as_slice).unwrap_or(&[]),
+            ),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn account_paths_defer_an_unknown_set() {
+        let [unknown] = set_ids();
+
+        assert_eq!(
+            has_duplicate_account_membership_paths(
+                &[unknown],
+                &[AccountId::new()],
+                &[],
+                |_| false,
+                |_| &[],
+            ),
+            None
+        );
     }
 
     #[test]

--- a/cala-ledger/src/account_set/graph_validation.rs
+++ b/cala-ledger/src/account_set/graph_validation.rs
@@ -1,0 +1,277 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use crate::primitives::{AccountId, AccountSetId};
+
+use super::error::AccountSetError;
+
+/// Maximum depth (in set->set edges) of any root-to-leaf membership
+/// chain. Rejecting edges past this bound keeps the read-time ancestor
+/// walk cheap and terminating. Real hierarchies are <=10 deep; 16 leaves
+/// headroom.
+pub(super) const MAX_MEMBERSHIP_DEPTH: i32 = 16;
+
+pub(super) fn validate_set_memberships(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+    account_members: &[(AccountSetId, AccountId)],
+) -> Result<(), AccountSetError> {
+    let mut nodes = HashSet::new();
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        nodes.insert(*account_set_id);
+        nodes.insert(*member_account_set_id);
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+    for (account_set_id, _) in account_members {
+        nodes.insert(*account_set_id);
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut topological_order = Vec::with_capacity(nodes.len());
+    while let Some(account_set_id) = queue.pop_front() {
+        topological_order.push(account_set_id);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+
+    if topological_order.len() != nodes.len() {
+        let (account_set_id, member_account_set_id) = proposed_edges
+            .iter()
+            .find(|(account_set_id, member_account_set_id)| {
+                account_set_id == member_account_set_id
+                    || graph_has_path(&adjacency, *member_account_set_id, *account_set_id)
+            })
+            .copied()
+            .unwrap_or(proposed_edges[0]);
+        return Err(AccountSetError::MembershipCycleDetected {
+            account_set_id,
+            member_account_set_id,
+        });
+    }
+
+    // In topological order, every parent's ancestor set is complete before
+    // its contribution reaches a child. An overlap means the child has two
+    // paths to the same ancestor. Hash-set union caps work at O(V^2) in the
+    // worst case instead of enumerating exponentially many paths.
+    let mut ancestors: HashMap<AccountSetId, HashSet<AccountSetId>> = HashMap::new();
+    let mut depth_from_root: HashMap<AccountSetId, i32> = HashMap::new();
+    for account_set_id in &topological_order {
+        let mut contribution = ancestors.get(account_set_id).cloned().unwrap_or_default();
+        contribution.insert(*account_set_id);
+        let parent_depth = *depth_from_root.get(account_set_id).unwrap_or(&0);
+
+        if let Some(children) = adjacency.get(account_set_id) {
+            for child in children {
+                let child_ancestors = ancestors.entry(*child).or_default();
+                if !child_ancestors.is_disjoint(&contribution) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+                child_ancestors.extend(contribution.iter().copied());
+                depth_from_root
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(parent_depth + 1))
+                    .or_insert(parent_depth + 1);
+            }
+        }
+    }
+
+    let mut account_paths = HashSet::new();
+    for (account_set_id, account_id) in account_members {
+        if !account_paths.insert((*account_set_id, *account_id)) {
+            return Err(AccountSetError::MemberAlreadyAdded);
+        }
+        if let Some(containers) = ancestors.get(account_set_id) {
+            for container in containers {
+                if !account_paths.insert((*container, *account_id)) {
+                    return Err(AccountSetError::MemberAlreadyAdded);
+                }
+            }
+        }
+    }
+
+    let max_depth = depth_from_root.values().copied().max().unwrap_or(0);
+    if max_depth > MAX_MEMBERSHIP_DEPTH {
+        let (index, depth) = first_depth_overflow(existing_edges, proposed_edges);
+        let (account_set_id, member_account_set_id) = proposed_edges[index];
+        return Err(AccountSetError::MembershipDepthExceeded {
+            account_set_id,
+            member_account_set_id,
+            depth,
+            max: MAX_MEMBERSHIP_DEPTH,
+        });
+    }
+
+    Ok(())
+}
+
+fn graph_has_path(
+    adjacency: &HashMap<AccountSetId, Vec<AccountSetId>>,
+    from: AccountSetId,
+    to: AccountSetId,
+) -> bool {
+    let mut pending = vec![from];
+    let mut visited = HashSet::new();
+    while let Some(current) = pending.pop() {
+        if current == to {
+            return true;
+        }
+        if visited.insert(current) {
+            pending.extend(adjacency.get(&current).into_iter().flatten().copied());
+        }
+    }
+    false
+}
+
+fn first_depth_overflow(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> (usize, i32) {
+    let mut low = 1;
+    let mut high = proposed_edges.len();
+    while low < high {
+        let middle = (low + high) / 2;
+        if graph_max_depth(existing_edges, &proposed_edges[..middle]) > MAX_MEMBERSHIP_DEPTH {
+            high = middle;
+        } else {
+            low = middle + 1;
+        }
+    }
+    (
+        low - 1,
+        graph_max_depth(existing_edges, &proposed_edges[..low]),
+    )
+}
+
+fn graph_max_depth(
+    existing_edges: &[(AccountSetId, AccountSetId)],
+    proposed_edges: &[(AccountSetId, AccountSetId)],
+) -> i32 {
+    let mut adjacency: HashMap<AccountSetId, Vec<AccountSetId>> = HashMap::new();
+    let mut indegree: HashMap<AccountSetId, usize> = HashMap::new();
+    for (account_set_id, member_account_set_id) in existing_edges.iter().chain(proposed_edges) {
+        adjacency
+            .entry(*account_set_id)
+            .or_default()
+            .push(*member_account_set_id);
+        *indegree.entry(*member_account_set_id).or_default() += 1;
+        indegree.entry(*account_set_id).or_default();
+    }
+
+    let mut queue: VecDeque<AccountSetId> = indegree
+        .iter()
+        .filter_map(|(id, degree)| (*degree == 0).then_some(*id))
+        .collect();
+    let mut depths = HashMap::new();
+    let mut max_depth = 0;
+    while let Some(account_set_id) = queue.pop_front() {
+        let parent_depth = *depths.get(&account_set_id).unwrap_or(&0);
+        if let Some(children) = adjacency.get(&account_set_id) {
+            for child in children {
+                let child_depth = parent_depth + 1;
+                depths
+                    .entry(*child)
+                    .and_modify(|depth| *depth = (*depth).max(child_depth))
+                    .or_insert(child_depth);
+                max_depth = max_depth.max(child_depth);
+                let degree = indegree
+                    .get_mut(child)
+                    .expect("every child must have an indegree");
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(*child);
+                }
+            }
+        }
+    }
+    max_depth
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_ids<const N: usize>() -> [AccountSetId; N] {
+        std::array::from_fn(|_| AccountSetId::new())
+    }
+
+    #[test]
+    fn set_paths_accept_a_valid_combined_tree() {
+        let [root, branch, existing_leaf, proposed_leaf] = set_ids();
+        let existing = [(root, branch), (branch, existing_leaf)];
+        let proposed = [(branch, proposed_leaf)];
+
+        assert!(validate_set_memberships(&existing, &proposed, &[]).is_ok());
+    }
+
+    #[test]
+    fn set_paths_reject_a_cycle_created_within_the_batch() {
+        let [a, b, c] = set_ids();
+        let proposed = [(a, b), (b, c), (c, a)];
+
+        assert!(matches!(
+            validate_set_memberships(&[], &proposed, &[]),
+            Err(AccountSetError::MembershipCycleDetected { .. })
+        ));
+    }
+
+    #[test]
+    fn set_paths_reject_a_duplicate_existing_and_proposed_path() {
+        let [root, branch, leaf] = set_ids();
+        let existing = [(root, branch), (branch, leaf)];
+        let proposed = [(root, leaf)];
+
+        assert!(matches!(
+            validate_set_memberships(&existing, &proposed, &[]),
+            Err(AccountSetError::MemberAlreadyAdded)
+        ));
+    }
+
+    #[test]
+    fn set_paths_reject_an_account_reachable_twice() {
+        let [root, left, right] = set_ids();
+        let account_id = AccountId::new();
+        let existing = [(root, left), (root, right)];
+        let account_members = [(left, account_id), (right, account_id)];
+
+        assert!(matches!(
+            validate_set_memberships(&existing, &[], &account_members),
+            Err(AccountSetError::MemberAlreadyAdded)
+        ));
+    }
+
+    #[test]
+    fn set_paths_attribute_the_first_depth_overflow() {
+        let sets: [AccountSetId; 18] = set_ids();
+        let proposed: Vec<_> = sets.windows(2).map(|pair| (pair[0], pair[1])).collect();
+
+        assert!(matches!(
+            validate_set_memberships(&[], &proposed, &[]),
+            Err(AccountSetError::MembershipDepthExceeded {
+                account_set_id,
+                member_account_set_id,
+                depth: 17,
+                max: 16,
+            }) if account_set_id == sets[16] && member_account_set_id == sets[17]
+        ));
+    }
+}

--- a/cala-ledger/src/account_set/mod.rs
+++ b/cala-ledger/src/account_set/mod.rs
@@ -1,6 +1,7 @@
 mod entity;
 pub mod error;
 mod graph_cache;
+mod graph_validation;
 mod repo;
 
 use es_entity::clock::ClockHandle;

--- a/cala-ledger/src/account_set/repo.rs
+++ b/cala-ledger/src/account_set/repo.rs
@@ -9,7 +9,7 @@ use crate::{
     primitives::{AccountId, JournalId},
 };
 
-use super::{entity::*, error::*, graph_cache::MAX_MEMBERSHIP_DEPTH};
+use super::{entity::*, error::*, graph_validation::MAX_MEMBERSHIP_DEPTH};
 
 /// Coarse advisory lock guarding the account-set membership graph
 /// (`cala_account_set_member_accounts` and


### PR DESCRIPTION
## Summary

The parent PR keeps set-membership validation beside the existing account-membership validator to match Cala’s current layering. That leaves pure graph invariants coupled to cache state and makes algorithmic behavior harder to test without infrastructure.

This follow-up moves both account and set path decisions into a dedicated graph-validation module. The graph cache now only adapts snapshots and overlays, selects SQL fallback when data is incomplete, and delegates deterministic decisions to the functional core. Behavior and lock ordering are unchanged.

### Chain

- Parent: [#840](https://github.com/GaloyMoney/cala/pull/840)

## Test plan

- [x] `cargo test -p cala-ledger`
- [x] `cargo clippy -p cala-ledger --tests -- -D warnings`
- [x] Unit-test account path acceptance, duplicate ancestry, and unknown-set fallback
- [x] Unit-test set cycles, duplicate paths, account-path conflicts, and depth attribution
- [x] Independently compare behavior against the parent branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Membership graph validation is correctness-critical; this is a structural move with delegated logic and new unit tests, but any mistake could change reject/accept behavior for attaches.
> 
> **Overview**
> This PR **extracts** account-set membership graph rules out of `graph_cache.rs` into a new **`graph_validation`** module so the cache only adapts snapshots/overlays and picks SQL fallback when the graph view is incomplete.
> 
> **Account attach path:** `assert_no_double_membership_in_op` now passes snapshot/overlay lookups into **`has_duplicate_account_membership_paths`** (replacing the removed in-cache path counter). **`None`** still means unknown set → SQL walk; **`Some(true)`** → `MemberAlreadyAdded`.
> 
> **Set attach path:** **`validate_set_memberships`** holds the combined-graph checks (cycles, duplicate paths, account reachability, depth cap). `assert_valid_set_memberships_in_op` only fetches repo data and delegates there.
> 
> **`MAX_MEMBERSHIP_DEPTH`** moves to `graph_validation`; `repo.rs` imports it from there for SQL depth checks. Module docs in `graph_cache` note the new layering.
> 
> **Tests** in `graph_validation` cover account path cases and set validation errors without cache/DB infrastructure. Intended behavior and lock ordering are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e847d31cd74d606a8d78c4f8497486310bc7a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->