### PR TITLE
perf(balance): read the journal on the open op, not a second connection

### DIFF
--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -216,7 +216,7 @@ impl Balances {
         created_at: DateTime<Utc>,
         account_set_mappings: HashMap<AccountId, Vec<AccountSetId>>,
     ) -> Result<(), BalanceError> {
-        let journal = self.journals.find(journal_id).await?;
+        let journal = self.journals.find_in_op(&mut *op, journal_id).await?;
         if journal.is_locked() {
             return Err(BalanceError::JournalLocked(journal.id));
         }
@@ -459,7 +459,7 @@ impl Balances {
                 .await?;
         }
 
-        let journal = self.journals.find(journal_id).await?;
+        let journal = self.journals.find_in_op(&mut *op, journal_id).await?;
         if journal.insert_effective_balances() {
             for tx in group {
                 let mut tx_involved: HashSet<(AccountId, Currency)> = HashSet::new();

--- a/cala-ledger/src/journal/mod.rs
+++ b/cala-ledger/src/journal/mod.rs
@@ -59,6 +59,19 @@ impl Journals {
         Ok(self.repo.find_by_id(journal_id).await?)
     }
 
+    #[instrument(
+        level = "debug",
+        name = "cala_ledger.journals.find_in_op",
+        skip(self, op)
+    )]
+    pub async fn find_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        journal_id: JournalId,
+    ) -> Result<Journal, JournalError> {
+        Ok(self.repo.find_by_id_in_op(op, journal_id).await?)
+    }
+
     #[instrument(name = "cala_ledger.journals.persist", skip(self, journal))]
     pub async fn persist(&self, journal: &mut Journal) -> Result<(), JournalError> {
         let mut op = self.repo.begin_op_with_clock(&self.clock).await?;


### PR DESCRIPTION
`Balances::update_balances_in_op` fetched the journal with `Journals::find`, which goes to the pool:

```rust
let journal = self.journals.find(journal_id).await?;   // <- pool
if journal.is_locked() { ... }
```

On the posting path that runs inside an already-open transaction (`post_transaction` → `post_transaction_in_op` → `update_balances_in_op`), so every posted transaction checked out a **second** pool connection and held it while the first still had the transaction open. That doubles connection demand at peak concurrency and is a pool-exhaustion / self-deadlock risk under load.

## Change

- New `Journals::find_in_op`, mirroring the existing `AccountSets::find_in_op`.
- `update_balances_in_op` (posting path) now reads through the op.
- `apply_ec_rollup_group_in_op` had the identical shape — also switched. It is not `post_transaction`, but it is the same defect inside a method that already holds an op, so leaving it would just relocate the problem to the EC rollup path.

`Journals::find` stays as-is for standalone callers.

## Correctness note

Reading on the op also changes visibility in the right direction: a caller that locked or created the journal earlier in the same op now observes it, where the pool connection could only see committed state. Nothing in-tree depended on the old behaviour.

## Verified

`cargo clippy --workspace --all-features --all-targets -- --deny warnings` clean, `cargo fmt --check` clean, 139/139 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow refactor of journal reads on paths that already hold an op; behavior aligns with other in-op find helpers and improves transactional visibility.
> 
> **Overview**
> Balance updates inside an already-open transaction used **`Journals::find`**, which checked out a **second** pool connection while the posting transaction still held the first. That inflated connection use on the hot path (`post_transaction` → `update_balances_in_op`) and raised pool-exhaustion / deadlock risk under load.
> 
> Adds **`Journals::find_in_op`** (same pattern as `AccountSets::find_in_op`) and switches **`update_balances_in_op`** and **`apply_ec_rollup_group_in_op`** to load the journal through the existing op. Standalone **`Journals::find`** is unchanged.
> 
> Reads on the op also see uncommitted journal changes from the same transaction (e.g. lock/create), which is the desired visibility for in-op callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce11bd36f8433d09a388affee6e789ed3e93df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->