### PR TITLE
docs(example): post a transaction and print balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "anyhow",
  "cala-ledger",
  "rand 0.10.2",
+ "rust_decimal",
  "sqlx",
  "tokio",
 ]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -11,4 +11,5 @@ cala-ledger = { path = "../../cala-ledger" }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 sqlx = { workspace = true }
+rust_decimal = { workspace = true }
 rand = "0.10"

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -1,27 +1,13 @@
-use anyhow::Context;
 use rand::RngExt;
-use std::fs;
+use rust_decimal::Decimal;
 
 use cala_ledger::{account::*, journal::*, migrate::IncludeMigrations, tx_template::*, *};
-
-pub fn store_server_pid(cala_home: &str, pid: u32) -> anyhow::Result<()> {
-    create_cala_dir(cala_home)?;
-    let _ = fs::remove_file(format!("{cala_home}/rust-example-pid"));
-    fs::write(format!("{cala_home}/rust-example-pid"), pid.to_string())
-        .context("Writing PID file")?;
-    Ok(())
-}
-
-fn create_cala_dir(bria_home: &str) -> anyhow::Result<()> {
-    let _ = fs::create_dir(bria_home);
-    Ok(())
-}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let random_number = rand::rng().random_range(0..1000);
     let example_suffix = std::env::var("EXAMPLE_SUFFIX").unwrap_or(format!("{random_number:03}"));
-    store_server_pid(".cala", std::process::id())?;
+
     let pg_con = std::env::var("PG_CON")
         .unwrap_or_else(|_| "postgres://user:password@localhost:5432/pg".to_string());
     let pool = sqlx::postgres::PgPoolOptions::new()
@@ -45,29 +31,37 @@ async fn main() -> anyhow::Result<()> {
         .exec_migrations(false)
         .build()?;
     let cala = CalaLedger::init(cala_config, &mut jobs).await?;
-    let code_string = format!("USERS.{example_suffix}");
-    let new_account = NewAccount::builder()
+
+    // Create two accounts so we have somewhere to move funds between.
+    let new_sender = NewAccount::builder()
         .id(AccountId::new())
-        .name(format!("ACCOUNT #{random_number:03}"))
-        .code(code_string)
-        .description("description")
+        .name(format!("SENDER #{random_number:03}"))
+        .code(format!("SENDER.{example_suffix}"))
+        .description("sender account")
         .build()?;
-    let mut account = cala.accounts().create(new_account).await?;
-    println!("account_id: {}", account.id());
+    let mut sender = cala.accounts().create(new_sender).await?;
+    println!("sender_account_id: {}", sender.id());
 
-    // update account name and description
-    let mut builder = AccountUpdate::default();
-    builder
-        .name(format!("ACCOUNT #{random_number:04}"))
-        .description("new description")
+    let new_recipient = NewAccount::builder()
+        .id(AccountId::new())
+        .name(format!("RECIPIENT #{random_number:03}"))
+        .code(format!("RECIPIENT.{example_suffix}"))
+        .description("recipient account")
         .build()?;
+    let recipient = cala.accounts().create(new_recipient).await?;
+    println!("recipient_account_id: {}", recipient.id());
 
-    if account.update(builder).did_execute() {
-        cala.accounts().persist(&mut account).await?;
+    // Demonstrate the update flow: rename the sender and re-persist.
+    let mut sender_update = AccountUpdate::default();
+    sender_update
+        .name(format!("SENDER #{random_number:04}"))
+        .description("updated description")
+        .build()?;
+    if sender.update(sender_update).did_execute() {
+        cala.accounts().persist(&mut sender).await?;
     }
-
-    let account = cala.accounts().find(account.id()).await?;
-    println!("account name: {}", account.values().name);
+    let sender = cala.accounts().find(sender.id()).await?;
+    println!("sender name after update: {}", sender.values().name);
 
     let journal_id = JournalId::new();
     let new_journal = NewJournal::builder()
@@ -76,59 +70,88 @@ async fn main() -> anyhow::Result<()> {
         .description("description")
         .build()?;
     let mut journal = cala.journals().create(new_journal).await?;
-    let journal_id = journal.id();
     println!("journal_id: {journal_id}");
 
-    // update journal name and description
-
-    let mut builder = JournalUpdate::default();
-    builder
+    let mut journal_update = JournalUpdate::default();
+    journal_update
         .name("UPDATED_JOURNAL_NAME")
         .description("new description")
         .build()?;
-    if journal.update(builder).did_execute() {
+    if journal.update(journal_update).did_execute() {
         cala.journals().persist(&mut journal).await?;
-    };
+    }
 
-    let transaction = NewTxTemplateTransaction::builder()
-        .journal_id(format!("uuid('{journal_id}')"))
-        .effective("date('2022-11-01')")
-        .build()?;
+    // Templates are CEL expressions parameterized by `params.*`. The
+    // ParamDataType-typed definitions below are what the caller must
+    // supply when posting a transaction against this template.
+    let template_params = vec![
+        NewParamDefinition::builder()
+            .name("sender")
+            .r#type(ParamDataType::Uuid)
+            .build()?,
+        NewParamDefinition::builder()
+            .name("recipient")
+            .r#type(ParamDataType::Uuid)
+            .build()?,
+        NewParamDefinition::builder()
+            .name("amount")
+            .r#type(ParamDataType::Decimal)
+            .build()?,
+    ];
     let entries = vec![
         NewTxTemplateEntry::builder()
             .entry_type("'TEST_DR'")
-            .account_id("param.recipient")
+            .account_id("params.sender")
             .layer("'SETTLED'")
             .direction("'DEBIT'")
-            .units("1290")
+            .units("params.amount")
             .currency("'BTC'")
-            .build()
-            .unwrap(),
+            .build()?,
         NewTxTemplateEntry::builder()
             .entry_type("'TEST_CR'")
-            .account_id("param.sender")
+            .account_id("params.recipient")
             .layer("'SETTLED'")
             .direction("'CREDIT'")
-            .units("1290")
+            .units("params.amount")
             .currency("'BTC'")
-            .build()
-            .unwrap(),
+            .build()?,
     ];
-    let tx_template_id = TxTemplateId::new();
-
+    let tx_code = format!("CODE_{example_suffix}");
     let new_tx_template = NewTxTemplate::builder()
-        .id(tx_template_id)
-        .code(format!("CODE_{example_suffix}"))
-        .transaction(transaction)
+        .id(TxTemplateId::new())
+        .code(&tx_code)
+        .params(template_params)
+        .transaction(
+            NewTxTemplateTransaction::builder()
+                .journal_id(format!("uuid('{journal_id}')"))
+                .effective("date()")
+                .build()?,
+        )
         .entries(entries)
-        .build()
-        .unwrap();
+        .build()?;
     let tx_template = cala.tx_templates().create(new_tx_template).await?;
-    println!("tx_template_id: {}", tx_template.id());
-    let code = tx_template.into_values().code;
-    println!("tx_template_code: {code}");
+    println!("tx_template_code: {}", tx_template.values().code);
 
-    loop {
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-    }
+    // Post a transaction against the template.
+    let mut post_params = Params::new();
+    post_params.insert("sender", sender.id());
+    post_params.insert("recipient", recipient.id());
+    post_params.insert("amount", Decimal::from(1290));
+
+    cala.post_transaction(TransactionId::new(), &tx_code, post_params)
+        .await?;
+
+    let currency = "BTC".parse()?;
+    let sender_balance = cala
+        .balances()
+        .find(journal_id, sender.id(), currency)
+        .await?;
+    let recipient_balance = cala
+        .balances()
+        .find(journal_id, recipient.id(), currency)
+        .await?;
+    println!("sender settled BTC: {}", sender_balance.settled());
+    println!("recipient settled BTC: {}", recipient_balance.settled());
+
+    Ok(())
 }


### PR DESCRIPTION
The rust example created accounts, a journal, and a tx template, then blocked on `loop { sleep }` without actually posting anything. The loop and the `store_server_pid` helper existed to keep the process alive for a BATS outbox-sync test that was deleted in #661 along with the gRPC sync layer; the example itself was never cleaned up.

Rewrite it to demonstrate the full flow the README already advertises: two accounts, a properly parameterized template (typed `NewParamDefinition`s, `params.*` CEL refs), a `post_transaction` call, and settled-balance reads. Also fixes latent `param.*` (singular) CEL refs that would have failed evaluation had the template ever been used.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the Rust example and its lockfile; no production ledger or API behavior is modified.
> 
> **Overview**
> The **Rust ledger example** now runs an end-to-end demo instead of idling forever: it creates **sender and recipient** accounts, a journal, and a **parameterized** tx template, then **posts a transaction** and prints **settled BTC balances**.
> 
> Removes the obsolete **`store_server_pid`** helper and **`loop { sleep }`** (leftover from a deleted BATS outbox test). Adds **`rust_decimal`** for the posted amount.
> 
> The template is wired with typed **`NewParamDefinition`** entries and **`params.*`** CEL references (replacing incorrect **`param.*`** and hardcoded units), matching what callers must supply when posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc0d706ecdb44d6a5a10390fc810222efbc323d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->