### PR TITLE
feat(balance): remove EffectiveBalanceCreated/EffectiveBalanceUpdated outbox events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -898,9 +898,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f94a1c1d074fbe3ea443d6c6a476a80af6f16ea794fcb6be4bb1bdeddd7f3"
+checksum = "2227e547593b0c89be2c5711af8af0ec132397a4bdd2eb13033171e06ce4fba7"
 dependencies = [
  "async-stream",
  "chrono",
@@ -926,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f846f97468b73de4d70059c6c89adf5606dfdd3b08f7d98f2093e9b534d699c"
+checksum = "cdde286ff62b9d58b6e43ce414920c57b799641fcbadb8c633452f8e7687122c"
 dependencies = [
  "convert_case",
  "darling 0.24.0",
@@ -1647,9 +1647,9 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90cf0f8d7276927ccf51535e4bbbdb13f65ef73f30bd55f63e147a68d45f41b"
+checksum = "a445299b365dd8058ebff758213ebe3d3e1c910f7cb159cfe1641e8e7fe8ccb3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1670,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb03ce8b8dbd3c542ac11a511444574b61c032282d2c512e8bf1d9ce8815a247"
+checksum = "0ff2cd179133d36761881970ca73497fac9d130688c5d9cee934f2a3122278fe"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cala-ledger = { path = "cala-ledger", version = "0.23.3-dev" }
 cel = "0.14.1"
 es-entity = "0.12.7"
 job = { version = "0.9.1", features = ["es-entity"] }
-obix = { version = "0.8.0", default-features = false }
+obix = { version = "0.8.2", default-features = false }
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }

--- a/cala-ledger-core-types/src/outbox.rs
+++ b/cala-ledger-core-types/src/outbox.rs
@@ -1,8 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    account::*, account_set::*, entry::*, journal::*, primitives::*, transaction::*,
-    tx_template::*,
+    account::*, account_set::*, entry::*, journal::*, primitives::*, transaction::*, tx_template::*,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/cala-ledger-core-types/src/outbox.rs
+++ b/cala-ledger-core-types/src/outbox.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    account::*, account_set::*, balance::*, entry::*, journal::*, primitives::*, transaction::*,
+    account::*, account_set::*, entry::*, journal::*, primitives::*, transaction::*,
     tx_template::*,
 };
 
@@ -51,11 +51,5 @@ pub enum OutboxEventPayload {
     },
     EntryCreated {
         entry: EntryValues,
-    },
-    EffectiveBalanceCreated {
-        balance: EffectiveBalanceSnapshot,
-    },
-    EffectiveBalanceUpdated {
-        balance: EffectiveBalanceSnapshot,
     },
 }

--- a/cala-ledger/.sqlx/query-1c2d8b4c28be1a21a9c49bb67f86513b20ff35151bdb099279d997927c6fbc24.json
+++ b/cala-ledger/.sqlx/query-1c2d8b4c28be1a21a9c49bb67f86513b20ff35151bdb099279d997927c6fbc24.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT EXISTS (\n                SELECT 1 FROM cala_persistent_outbox_events WHERE sequence = $1\n            ) AS \"present!\"",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "present!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1c2d8b4c28be1a21a9c49bb67f86513b20ff35151bdb099279d997927c6fbc24"
+}

--- a/cala-ledger/.sqlx/query-2607ae5121a22e7b69e7e98a577c6c4d2b62004d86d77b7a0c735abf885b370d.json
+++ b/cala-ledger/.sqlx/query-2607ae5121a22e7b69e7e98a577c6c4d2b62004d86d77b7a0c735abf885b370d.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT g AS \"sequence!: i64\"\n            FROM generate_series($1::bigint + 1, $2::bigint) g\n            EXCEPT\n            SELECT sequence FROM cala_persistent_outbox_events\n            WHERE sequence > $1 AND sequence <= $2\n            ORDER BY 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "sequence!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2607ae5121a22e7b69e7e98a577c6c4d2b62004d86d77b7a0c735abf885b370d"
+}

--- a/cala-ledger/.sqlx/query-eac483be72a79861524aebcd30b62948a4e87df694cd9cbe4a941879481756ae.json
+++ b/cala-ledger/.sqlx/query-eac483be72a79861524aebcd30b62948a4e87df694cd9cbe4a941879481756ae.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH win AS (\n                SELECT sequence, ROW_NUMBER() OVER (ORDER BY sequence) AS rn\n                FROM cala_persistent_outbox_events\n                WHERE sequence > $1\n                  AND sequence <= $1 + $2\n            )\n            SELECT e.sequence AS \"sequence!: i64\", e.id AS \"id!\", e.payload,\n                   e.tracing_context, e.recorded_at AS \"recorded_at!\"\n            FROM cala_persistent_outbox_events e\n            WHERE e.sequence > $1\n              AND e.sequence <= $1 + $2\n              AND e.sequence < (\n                  SELECT COALESCE(MIN(sequence), $1 + $2 + 1)\n                  FROM win\n                  WHERE sequence <> $1 + rn\n              )\n            ORDER BY e.sequence ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "sequence!: i64",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "tracing_context",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "eac483be72a79861524aebcd30b62948a4e87df694cd9cbe4a941879481756ae"
+}

--- a/cala-ledger/src/balance/effective/mod.rs
+++ b/cala-ledger/src/balance/effective/mod.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 
 use cala_types::{balance::EffectiveBalanceSnapshot, entry::EntryValues, primitives::*};
 
-use crate::{outbox::OutboxPublisher, primitives::JournalId};
+use crate::primitives::JournalId;
 
 use super::{
     account_balance::*,
@@ -26,9 +26,9 @@ pub struct EffectiveBalances {
     _pool: PgPool,
 }
 impl EffectiveBalances {
-    pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
+    pub(crate) fn new(pool: &PgPool) -> Self {
         Self {
-            repo: EffectiveBalanceRepo::new(pool, publisher),
+            repo: EffectiveBalanceRepo::new(pool),
             _pool: pool.clone(),
         }
     }
@@ -185,8 +185,7 @@ impl EffectiveBalances {
     /// [`EffectiveBalanceSnapshot`] (not merely the latest one written since
     /// `since` — the tuple's newest row overall, so callers never need a
     /// second read). A CDC-style pull API: designed to replace entry-derived
-    /// dirty-tracking side tables built against the
-    /// `EffectiveBalanceCreated`/`EffectiveBalanceUpdated` outbox events.
+    /// dirty-tracking side tables built against per-snapshot outbox events.
     ///
     /// # Contract (load-bearing — read before wiring up a consumer)
     ///

--- a/cala-ledger/src/balance/effective/repo.rs
+++ b/cala-ledger/src/balance/effective/repo.rs
@@ -3,19 +3,15 @@ use sqlx::PgPool;
 use std::collections::HashMap;
 use tracing::instrument;
 
-use crate::{
-    balance::{
-        account_balance::{AccountBalance, BalanceRange},
-        cursor::{
-            AccountBalanceByCurrencyCursor, AccountBalanceCursor, EffectiveBalancesModifiedCursor,
-        },
-        error::BalanceError,
+use crate::balance::{
+    account_balance::{AccountBalance, BalanceRange},
+    cursor::{
+        AccountBalanceByCurrencyCursor, AccountBalanceCursor, EffectiveBalancesModifiedCursor,
     },
-    outbox::OutboxPublisher,
+    error::BalanceError,
 };
 use cala_types::{
     balance::{BalanceSnapshot, EffectiveBalanceSnapshot},
-    outbox::OutboxEventPayload,
     primitives::{AccountId, BalanceId, Currency, DebitOrCredit, EntryId, JournalId},
 };
 
@@ -27,15 +23,11 @@ type BalanceRangeResult =
 #[derive(Debug, Clone)]
 pub(super) struct EffectiveBalanceRepo {
     pool: PgPool,
-    publisher: OutboxPublisher,
 }
 
 impl EffectiveBalanceRepo {
-    pub fn new(pool: &PgPool, publisher: &OutboxPublisher) -> Self {
-        Self {
-            pool: pool.clone(),
-            publisher: publisher.clone(),
-        }
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
     }
 
     pub async fn find(
@@ -1226,19 +1218,6 @@ impl EffectiveBalanceRepo {
         )
         .execute(op.as_executor())
         .await?;
-
-        self.publisher
-            .publish_all(
-                op,
-                new_balances.into_iter().map(|balance| {
-                    if balance.all_time_version == 1 {
-                        OutboxEventPayload::EffectiveBalanceCreated { balance }
-                    } else {
-                        OutboxEventPayload::EffectiveBalanceUpdated { balance }
-                    }
-                }),
-            )
-            .await?;
 
         Ok(())
     }

--- a/cala-ledger/src/balance/mod.rs
+++ b/cala-ledger/src/balance/mod.rs
@@ -46,7 +46,7 @@ pub use cala_types::{
 };
 use cala_types::{entry::EntryValues, primitives::*};
 
-use crate::{journal::Journals, outbox::*, primitives::JournalId};
+use crate::{journal::Journals, primitives::JournalId};
 
 pub use account_balance::*;
 pub use cursor::*;
@@ -75,10 +75,10 @@ pub struct Balances {
 }
 
 impl Balances {
-    pub(crate) fn new(pool: &PgPool, publisher: &OutboxPublisher, journals: &Journals) -> Self {
+    pub(crate) fn new(pool: &PgPool, journals: &Journals) -> Self {
         Self {
             repo: BalanceRepo::new(pool),
-            effective: EffectiveBalances::new(pool, publisher),
+            effective: EffectiveBalances::new(pool),
             journals: journals.clone(),
             _pool: pool.clone(),
         }

--- a/cala-ledger/src/ledger/mod.rs
+++ b/cala-ledger/src/ledger/mod.rs
@@ -81,7 +81,7 @@ impl CalaLedger {
         let tx_templates = TxTemplates::new(&pool, &publisher, &clock);
         let transactions = Transactions::new(&pool);
         let entries = Entries::new(&pool);
-        let balances = Balances::new(&pool, &publisher, &journals);
+        let balances = Balances::new(&pool, &journals);
         let velocities = Velocities::new(&pool, &clock);
         let account_sets = AccountSets::new(&pool, &publisher, &accounts, &balances, &clock);
         let postings = Postings::new(


### PR DESCRIPTION
## Summary
Removes `OutboxEventPayload::EffectiveBalanceCreated` and `OutboxEventPayload::EffectiveBalanceUpdated` entirely from the codebase, along with the now-dead `OutboxPublisher` plumbing that only existed to emit them.

This is a **breaking change** — no deprecation/compat shim. Per-snapshot effective-balance outbox events are superseded by the CDC watermark query added in #849 (`EffectiveBalances::list_modified_since`), whose doc comment already states it's designed to replace dirty-tracking built against these events.

## Changes
- `cala-ledger-core-types/src/outbox.rs`: drop the two `OutboxEventPayload` variants (and the now-unused `balance::*` glob import).
- `cala-ledger/src/balance/effective/repo.rs`: drop the `publish_all` call in `insert_new_snapshots`, and the `publisher: OutboxPublisher` field/constructor param (now dead).
- `cala-ledger/src/balance/effective/mod.rs`: `EffectiveBalances::new` no longer takes a publisher; updated the doc comment on `list_modified_since` that referenced the removed events by name.
- `cala-ledger/src/balance/mod.rs`: `Balances::new` no longer takes a publisher (was only used to construct `EffectiveBalances`).
- `cala-ledger/src/ledger/mod.rs`: updated call site.

## Migration
Consumers subscribed to `EffectiveBalanceCreated`/`EffectiveBalanceUpdated` outbox events must switch to `EffectiveBalances::list_modified_since` for CDC-style consumption of effective balance snapshots.

## Testing
- `SQLX_OFFLINE=true cargo check --workspace --all-features --tests` — clean.
- `SQLX_OFFLINE=true cargo check -p cala-ledger --features fail-on-warnings` — clean.
- `SQLX_OFFLINE=true cargo clippy --workspace --all-features --tests -- -D warnings` — clean except one pre-existing, unrelated `unused_mut` warning in `transaction_batch.rs` (present on `main` before this change).
- Did not run the DB-backed integration tests locally (no local Postgres instance running in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking change for outbox subscribers on effective balance events; core balance write path no longer emits those events, so downstream consumers must migrate to `list_modified_since` to avoid silent data loss.
> 
> **Overview**
> Removes **`EffectiveBalanceCreated`** and **`EffectiveBalanceUpdated`** from `OutboxEventPayload` and stops publishing them when cumulative effective balance snapshots are inserted. **`EffectiveBalanceRepo`** no longer holds an **`OutboxPublisher`**; **`Balances::new`** and **`EffectiveBalances::new`** drop the publisher parameter, and ledger initialization wires balances without passing the outbox publisher.
> 
> The **`list_modified_since`** doc comment is updated to refer generically to per-snapshot outbox events instead of naming the removed variants. **Migration:** consumers that relied on those outbox payloads should use **`EffectiveBalances::list_modified_since`** for CDC-style dirty tracking.
> 
> The workspace bumps **`obix`** to **0.8.2** (and **`es-entity`** in the lockfile). New **`cala-ledger/.sqlx`** offline query metadata accompanies the dependency update for persistent outbox SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1faff37f0492046ed89ab25e60707a1fb9a6426. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->