### PR TITLE
fix(cala-ledger): don't publish Account outbox events for AccountSet-backing accounts

### DIFF
--- a/cala-ledger/src/account/repo.rs
+++ b/cala-ledger/src/account/repo.rs
@@ -87,6 +87,13 @@ impl AccountRepo {
         entity: &Account,
         new_events: es_entity::LastPersisted<'_, AccountEvent>,
     ) -> Result<(), sqlx::Error> {
+        // Accounts that back an `AccountSet` are an implementation detail of
+        // the set (see `AccountSets::create_in_op`) and must not surface as
+        // `Account` outbox events — the `AccountSet`'s own repo already
+        // publishes `AccountSetCreated`/`AccountSetUpdated` for them.
+        if entity.is_account_set() {
+            return Ok(());
+        }
         self.publisher
             .publish_entity_events(op, entity, new_events)
             .await?;

--- a/cala-ledger/src/account/repo.rs
+++ b/cala-ledger/src/account/repo.rs
@@ -87,10 +87,6 @@ impl AccountRepo {
         entity: &Account,
         new_events: es_entity::LastPersisted<'_, AccountEvent>,
     ) -> Result<(), sqlx::Error> {
-        // Accounts that back an `AccountSet` are an implementation detail of
-        // the set (see `AccountSets::create_in_op`) and must not surface as
-        // `Account` outbox events — the `AccountSet`'s own repo already
-        // publishes `AccountSetCreated`/`AccountSetUpdated` for them.
         if entity.is_account_set() {
             return Ok(());
         }


### PR DESCRIPTION
## Bug

When creating an `AccountSet`, `AccountSets::create_in_op` also creates a
backing `Account` (`NewAccount` with `is_account_set = true`) to represent
the set in the accounts table. That backing account's own outbox event
(`AccountCreated`, and potentially `AccountUpdated`) was being published on
the outbox alongside `AccountSetCreated` — consumers should only ever see
the `AccountSet` event for it.

## Fix

`AccountRepo`'s `post_persist_hook` (`publish`) now skips publishing
entirely when the persisted `Account` is account-set-backed
(`entity.is_account_set()`). `AccountSetRepo` already publishes
`AccountSetCreated`/`AccountSetUpdated` independently, so this is a pure
duplicate-event fix with no change to `AccountSet` behavior.

## Testing

Pushing to let CI run the full suite (local Postgres-backed `cargo check`
wasn't run for this change per request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbox event visibility for account-set-backed accounts; downstream consumers that relied on duplicate Account events could miss updates, though the intended contract is AccountSet-only events.
> 
> **Overview**
> **Stops duplicate outbox traffic** when an `AccountSet` is created: the backing row in `cala_accounts` (`is_account_set = true`) no longer emits `AccountCreated` / `AccountUpdated` through `AccountRepo`'s `publish` post-persist hook.
> 
> `AccountSetRepo` still publishes `AccountSetCreated` / `AccountSetUpdated`, so consumers should only see the set entity events for those IDs. Regular accounts continue to publish as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1252ea81dbba0949acc183c395ace9d02f202fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->