### PR TITLE
feat(velocity): batch-attach a velocity control to N accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/cala-ledger/.sqlx/query-466f96bc7968e18045691e3942342ff62413f10bb45400089fd02dfb0f85de70.json
+++ b/cala-ledger/.sqlx/query-466f96bc7968e18045691e3942342ff62413f10bb45400089fd02dfb0f85de70.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO cala_velocity_account_controls (account_id, velocity_control_id, values)\n            SELECT account_id, velocity_control_id, values\n            FROM UNNEST($1::uuid[], $2::uuid[], $3::jsonb[])\n                AS v(account_id, velocity_control_id, values)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "UuidArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "466f96bc7968e18045691e3942342ff62413f10bb45400089fd02dfb0f85de70"
+}

--- a/cala-ledger/Cargo.toml
+++ b/cala-ledger/Cargo.toml
@@ -60,5 +60,14 @@ anyhow = { workspace = true }
 rand = { workspace = true }
 tokio-test = "0.4"
 rust_decimal_macros = { workspace = true }
+# Already resolved workspace-wide via tracing-opentelemetry's dependency on
+# it (see Cargo.lock) — no new dependency-tree surface, just reusing an
+# already-vetted version for a test-only span counter. Only the `registry`
+# feature (Registry + Layer + SubscriberExt) is needed — default features
+# would additionally pull in `fmt` (and its `nu-ansi-term` dependency),
+# which nothing here uses.
+tracing-subscriber = { version = "0.3", default-features = false, features = [
+  "registry",
+] }
 
 [build-dependencies]

--- a/cala-ledger/src/velocity/account_control/mod.rs
+++ b/cala-ledger/src/velocity/account_control/mod.rs
@@ -4,6 +4,7 @@ mod value;
 use es_entity::clock::ClockHandle;
 use rust_decimal::Decimal;
 use sqlx::PgPool;
+use tracing::instrument;
 
 use cala_types::velocity::{VelocityControlValues, VelocityLimitValues};
 
@@ -41,12 +42,81 @@ impl AccountControls {
         limits: Vec<VelocityLimitValues>,
         params: impl Into<Params> + std::fmt::Debug,
     ) -> Result<(), VelocityError> {
-        let params = params.into();
+        let velocity_limits = Self::evaluate_velocity_limits(&self.clock, limits, params.into())?;
 
+        let control = AccountVelocityControl {
+            account_id,
+            control_id: control.id,
+            condition: control.condition.clone(),
+            enforcement: control.enforcement.clone(),
+            velocity_limits,
+        };
+
+        self.repo.create_in_op(db, control).await?;
+
+        Ok(())
+    }
+
+    /// Batched counterpart of [`Self::attach_control_in_op`]: attaches the
+    /// same `control` (with the same `params`) to every account in
+    /// `account_ids` in one round trip.
+    ///
+    /// `params` is shared across the whole batch (a single
+    /// `impl Into<Params>`, not `Vec<Params>`) — every account is attached
+    /// to the same control under the same evaluated condition and limits.
+    /// Accounts that need different params attach in separate calls.
+    ///
+    /// Because `params` (and therefore every evaluated `condition` /
+    /// `AccountVelocityLimit`) is identical for every account in the
+    /// batch, the CEL evaluation that builds `velocity_limits` runs
+    /// **once** for the whole batch and is cloned per account — the
+    /// per-row difference is only `account_id`.
+    #[instrument(
+        level = "debug",
+        name = "account_control.attach_control_to_accounts_in_op",
+        skip(self, db, limits, params),
+        fields(control_id = %control.id, account_count = account_ids.len()),
+        err(level = "warn")
+    )]
+    pub async fn attach_control_to_accounts_in_op(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        control: &VelocityControlValues,
+        account_ids: &[AccountId],
+        limits: Vec<VelocityLimitValues>,
+        params: impl Into<Params> + std::fmt::Debug,
+    ) -> Result<(), VelocityError> {
+        if account_ids.is_empty() {
+            return Ok(());
+        }
+
+        let velocity_limits = Self::evaluate_velocity_limits(&self.clock, limits, params.into())?;
+
+        let controls = account_ids
+            .iter()
+            .map(|&account_id| AccountVelocityControl {
+                account_id,
+                control_id: control.id,
+                condition: control.condition.clone(),
+                enforcement: control.enforcement.clone(),
+                velocity_limits: velocity_limits.clone(),
+            })
+            .collect();
+
+        self.repo.create_all_in_op(db, controls).await?;
+
+        Ok(())
+    }
+
+    fn evaluate_velocity_limits(
+        clock: &ClockHandle,
+        limits: Vec<VelocityLimitValues>,
+        params: Params,
+    ) -> Result<Vec<AccountVelocityLimit>, VelocityError> {
         let mut velocity_limits = Vec::new();
         for velocity in limits {
             let defs = velocity.params;
-            let ctx = params.clone().into_context(&self.clock, defs.as_ref())?;
+            let ctx = params.clone().into_context(clock, defs.as_ref())?;
             let mut limits = Vec::new();
             for limit in velocity.limit.balance {
                 let layer: Layer = limit.layer.try_evaluate(&ctx)?;
@@ -78,17 +148,6 @@ impl AccountControls {
                 },
             });
         }
-
-        let control = AccountVelocityControl {
-            account_id,
-            control_id: control.id,
-            condition: control.condition.clone(),
-            enforcement: control.enforcement.clone(),
-            velocity_limits,
-        };
-
-        self.repo.create_in_op(db, control).await?;
-
-        Ok(())
+        Ok(velocity_limits)
     }
 }

--- a/cala-ledger/src/velocity/account_control/repo.rs
+++ b/cala-ledger/src/velocity/account_control/repo.rs
@@ -39,4 +39,61 @@ impl AccountControlRepo {
         .await?;
         Ok(())
     }
+
+    /// Batched counterpart of [`Self::create_in_op`]: one multi-row `INSERT`
+    /// for every `(account_id, velocity_control_id, values)` triple instead
+    /// of one `INSERT` per row.
+    ///
+    /// `controls` is sorted by `account_id` so that concurrent callers
+    /// insert overlapping rows in the same order: two multi-row `INSERT`s
+    /// touching the same `(account_id, velocity_control_id)` keys in
+    /// opposite order can otherwise deadlock against each other on that
+    /// unique index mid-statement.
+    ///
+    /// The sort is done in Rust rather than with a SQL `ORDER BY` because
+    /// the `UNNEST` is join-free: nothing can reorder a bare `UNNEST`
+    /// scan, so rows are inserted in the array order they are supplied in.
+    #[instrument(
+        level = "debug",
+        name = "account_control.create_all_in_op",
+        skip_all,
+        fields(count = controls.len()),
+        err(level = "warn")
+    )]
+    pub async fn create_all_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        mut controls: Vec<AccountVelocityControl>,
+    ) -> Result<(), VelocityError> {
+        if controls.is_empty() {
+            return Ok(());
+        }
+
+        controls.sort_unstable_by_key(|c| c.account_id);
+
+        let mut account_ids = Vec::with_capacity(controls.len());
+        let mut control_ids = Vec::with_capacity(controls.len());
+        let mut values = Vec::with_capacity(controls.len());
+        for control in controls {
+            account_ids.push(control.account_id);
+            control_ids.push(control.control_id);
+            values.push(serde_json::to_value(control).expect("Failed to serialize control values"));
+        }
+
+        sqlx::query!(
+            r#"
+            INSERT INTO cala_velocity_account_controls (account_id, velocity_control_id, values)
+            SELECT account_id, velocity_control_id, values
+            FROM UNNEST($1::uuid[], $2::uuid[], $3::jsonb[])
+                AS v(account_id, velocity_control_id, values)
+            "#,
+            &account_ids as &[AccountId],
+            &control_ids as &[VelocityControlId],
+            &values,
+        )
+        .execute(op.as_executor())
+        .await?;
+
+        Ok(())
+    }
 }

--- a/cala-ledger/src/velocity/mod.rs
+++ b/cala-ledger/src/velocity/mod.rs
@@ -152,8 +152,48 @@ impl Velocities {
         account_id: AccountId,
         params: impl Into<Params> + std::fmt::Debug,
     ) -> Result<VelocityControl, VelocityError> {
-        self.attach_control_to_account_or_account_set_in_op(db, control_id, account_id, params)
-            .await
+        self.attach_control_to_accounts_in_op(
+            db,
+            control_id,
+            std::slice::from_ref(&account_id),
+            params,
+        )
+        .await
+    }
+
+    /// Attach one control to N accounts in a fixed number of round trips
+    /// (find control, list its limits, one batched insert) instead of `3 *
+    /// account_ids.len()`.
+    ///
+    /// `params` is shared by every account in the batch — see the docs on
+    /// [`AccountControls::attach_control_to_accounts_in_op`]. Intra-batch
+    /// ordering is not observable: every account gets the same control,
+    /// condition, and evaluated limits, so no caller can come to depend on
+    /// an order here. `account_ids` is not deduplicated — attaching the
+    /// same `account_id` twice in one call hits the same
+    /// `UNIQUE(account_id, velocity_control_id)` constraint a second
+    /// singular call would, and aborts the whole batch, not just that row.
+    #[instrument(level = "debug", name = "velocity.attach_control_to_accounts_in_op", skip(self, db, account_ids), fields(control_id = %control_id, account_count = account_ids.len()), err(level = tracing::Level::WARN))]
+    pub async fn attach_control_to_accounts_in_op(
+        &self,
+        db: &mut impl es_entity::AtomicOperation,
+        control_id: VelocityControlId,
+        account_ids: &[AccountId],
+        params: impl Into<Params> + std::fmt::Debug,
+    ) -> Result<VelocityControl, VelocityError> {
+        let control = self.controls.find_by_id_in_op(&mut *db, control_id).await?;
+        let limits = self
+            .limits
+            .list_for_control(&mut *db, control_id)
+            .await?
+            .into_iter()
+            .map(|l| l.into_values())
+            .collect();
+
+        self.account_controls
+            .attach_control_to_accounts_in_op(db, control.values(), account_ids, limits, params)
+            .await?;
+        Ok(control)
     }
 
     #[instrument(level = "debug", name = "velocity.attach_control_to_account_set_in_op", skip(self, db), fields(control_id = %control_id, account_set_id = %account_set_id))]

--- a/cala-ledger/tests/velocity.rs
+++ b/cala-ledger/tests/velocity.rs
@@ -216,6 +216,201 @@ async fn create_control_on_account_set() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Counts `tracing` spans by exact name — used to prove the batched attach
+/// issues one round trip regardless of how many accounts it covers,
+/// without depending on `pg_stat_statements` (not test-isolated: shared
+/// across concurrent activity on the DB) or a new query-logging mechanism.
+/// `tracing-subscriber` is already resolved in this workspace's
+/// `Cargo.lock` (pulled in via `tracing-opentelemetry`), so this reuses an
+/// already-vetted dependency rather than adding a new one.
+///
+/// Registered as the process-global default subscriber, not a
+/// thread-local one (`tracing::subscriber::with_default`): tokio's
+/// multi-thread runtime can resume this test's future on a different
+/// worker thread after an `.await`, and a thread-local subscriber would
+/// silently miss spans created after such a hop. `cargo-nextest` runs
+/// every test in its own OS process, so a process-global subscriber here
+/// cannot observe — or be observed by — any other test.
+struct SpanCallCounter {
+    name: &'static str,
+    count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for SpanCallCounter {
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if attrs.metadata().name() == self.name {
+            self.count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+}
+
+/// Attaching one control to N accounts must cost a fixed number of round
+/// trips, not `3 * N`. This is the regression guard — verified against the
+/// specific mechanism (batched `UNNEST` insert) by temporarily reverting
+/// `AccountControlRepo::create_all_in_op` to a loop calling `create_in_op`
+/// once per account: with that reversion, `per_row_calls` reads 4 instead
+/// of 0 and this test fails; restoring the batched insert makes it pass
+/// again.
+#[tokio::test]
+async fn attach_control_to_accounts_in_op_issues_one_batched_insert() -> anyhow::Result<()> {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use tracing_subscriber::prelude::*;
+
+    let (cala, _journal_id, _tx_code) = init_test().await?;
+    let velocity = cala.velocities();
+    let (control_id, control_params) = control_and_limits(velocity, Decimal::ONE_HUNDRED).await?;
+
+    let mut account_ids = Vec::new();
+    for _ in 0..4 {
+        let (new_account, _) = helpers::test_accounts();
+        let account = cala.accounts().create(new_account).await.unwrap();
+        account_ids.push(account.id());
+    }
+
+    let batched_calls = Arc::new(AtomicUsize::new(0));
+    let per_row_calls = Arc::new(AtomicUsize::new(0));
+    let subscriber = tracing_subscriber::registry()
+        .with(SpanCallCounter {
+            name: "account_control.create_all_in_op",
+            count: batched_calls.clone(),
+        })
+        .with(SpanCallCounter {
+            name: "account_control.create_in_op",
+            count: per_row_calls.clone(),
+        });
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("no other global tracing subscriber should be set in this test process");
+
+    let mut op = cala.begin_operation().await?;
+    velocity
+        .attach_control_to_accounts_in_op(&mut op, control_id, &account_ids, control_params)
+        .await?;
+    op.commit().await?;
+
+    assert_eq!(
+        batched_calls.load(Ordering::SeqCst),
+        1,
+        "attaching to N accounts must issue exactly one batched insert, not N"
+    );
+    assert_eq!(
+        per_row_calls.load(Ordering::SeqCst),
+        0,
+        "the batched path must never fall back to the per-row insert"
+    );
+
+    Ok(())
+}
+
+/// Parity with calling the singular API once per account: the limit
+/// enforces identically for every account in the batch.
+#[tokio::test]
+async fn attach_control_to_accounts_in_op_matches_singular_calls() -> anyhow::Result<()> {
+    let (cala, journal_id, tx_code) = init_test().await?;
+    let velocity = cala.velocities();
+
+    let limit = Decimal::ONE_HUNDRED;
+    let (control_id, control_params) = control_and_limits(velocity, limit).await?;
+
+    let (new_recipient, _) = helpers::test_accounts();
+    let recipient = cala.accounts().create(new_recipient).await.unwrap();
+
+    let mut senders = Vec::new();
+    for _ in 0..3 {
+        let (new_sender, _) = helpers::test_accounts();
+        senders.push(cala.accounts().create(new_sender).await.unwrap());
+    }
+    let sender_ids: Vec<_> = senders.iter().map(|s| s.id()).collect();
+
+    let mut op = cala.begin_operation().await?;
+    velocity
+        .attach_control_to_accounts_in_op(&mut op, control_id, &sender_ids, control_params)
+        .await?;
+    op.commit().await?;
+
+    for sender in &senders {
+        let mut tx_params = Params::new();
+        tx_params.insert("journal_id", journal_id.to_string());
+        tx_params.insert("sender", sender.id());
+        tx_params.insert("recipient", recipient.id());
+        tx_params.insert("amount", limit);
+        let _ = cala
+            .post_transaction(TransactionId::new(), &tx_code, tx_params.clone())
+            .await?;
+        tx_params.insert("amount", Decimal::ONE);
+        let res = cala
+            .post_transaction(TransactionId::new(), &tx_code, tx_params.clone())
+            .await;
+        assert!(res.is_err(), "limit did not enforce on {:?}", sender.id());
+    }
+
+    Ok(())
+}
+
+/// A duplicate `account_id` within one batch call hits the same
+/// `UNIQUE(account_id, velocity_control_id)` constraint a second singular
+/// call would, and aborts the *whole* batch — including the non-duplicate
+/// accounts in the same call. Re-attaching the non-duplicate account alone
+/// afterwards must still succeed, proving nothing from the failed batch
+/// was left attached.
+#[tokio::test]
+async fn attach_control_to_accounts_in_op_rejects_duplicate_account_id_atomically(
+) -> anyhow::Result<()> {
+    let (cala, _journal_id, _tx_code) = init_test().await?;
+    let velocity = cala.velocities();
+    let (control_id, control_params) = control_and_limits(velocity, Decimal::ONE_HUNDRED).await?;
+
+    let (new_account, _) = helpers::test_accounts();
+    let account = cala.accounts().create(new_account).await.unwrap();
+    let (new_other, _) = helpers::test_accounts();
+    let other = cala.accounts().create(new_other).await.unwrap();
+
+    let mut op = cala.begin_operation().await?;
+    let res = velocity
+        .attach_control_to_accounts_in_op(
+            &mut op,
+            control_id,
+            &[other.id(), account.id(), account.id()],
+            control_params.clone(),
+        )
+        .await;
+    assert!(res.is_err());
+    drop(op);
+
+    let mut op = cala.begin_operation().await?;
+    velocity
+        .attach_control_to_accounts_in_op(&mut op, control_id, &[other.id()], control_params)
+        .await?;
+    op.commit().await?;
+
+    Ok(())
+}
+
+/// An empty `account_ids` slice is a no-op insert, not an error.
+#[tokio::test]
+async fn attach_control_to_accounts_in_op_empty_slice_is_a_noop() -> anyhow::Result<()> {
+    let (cala, _journal_id, _tx_code) = init_test().await?;
+    let velocity = cala.velocities();
+    let (control_id, control_params) = control_and_limits(velocity, Decimal::ONE_HUNDRED).await?;
+
+    let mut op = cala.begin_operation().await?;
+    let control = velocity
+        .attach_control_to_accounts_in_op(&mut op, control_id, &[], control_params)
+        .await?;
+    op.commit().await?;
+
+    assert_eq!(control.id(), control_id);
+
+    Ok(())
+}
+
 mod limit_via_account_sets {
     use serde_json::json;
 


### PR DESCRIPTION
## Handoff
`cala-dev/handoff-velocity-attach-batch.md` — blocking `lana-activate-true-batched`. Adds a batched counterpart to `VelocityControls::attach_control_to_account_in_op` that attaches one control to N accounts in a fixed number of round trips (`3` instead of `3 * N`).

## Premise check vs current main
Mostly held, one correction: the handoff speculated `AccountControlRepo` "may already be macro-derived" (es-entity 0.12.7's `EsRepo::create_all_in_op`). It is **not** — `AccountControlRepo` is hand-written (`_pool: PgPool`, manual `create_in_op`); `AccountVelocityControl` is a plain values struct persisted as one JSONB blob, not an `EsEntity` (no `EntityEvents` field). So `create_all_in_op` here is hand-written, following the existing join-free `INSERT ... FROM UNNEST(...)` pattern already used in `account_set_member::repo::add_in_op` and the `jsonb[]`-array pattern in `balance::repo`'s history+current-balance upsert. Everything else in the handoff (the 3 statements, the two other single-account callers untouched, the lana caller shape) matched current main as described.

## Mechanism
- `AccountControlRepo::create_all_in_op` — one `INSERT INTO cala_velocity_account_controls SELECT ... FROM UNNEST($1::uuid[], $2::uuid[], $3::jsonb[])`, join-free, no `JOIN`/`ORDER BY`/`MATERIALIZED` needed (compare `velocity::balance::repo::find_for_update`'s documented join-free argument for the same shape).
- `AccountControls::attach_control_to_accounts_in_op` — evaluates the control's CEL condition/limits **once** per batch call (not once per account): `params` is uniform across the batch by construction (`impl Into<Params>`, not `Vec<Params>`), so the evaluated `AccountVelocityControl` differs only by `account_id`.
- `Velocities::attach_control_to_accounts_in_op` — hoists the `find_by_id_in_op` + `list_for_control` reads out of any per-account loop. `attach_control_to_account_in_op` becomes a thin wrapper (`attach_control_to_accounts_in_op(db, id, std::slice::from_ref(&account_id), params)`); no behavior change for existing callers. `attach_control_to_account_set_in_op` untouched — the set-flavoured twin is explicitly a non-goal.

## Signature verification (params-uniform assumption)
The batched signature takes one shared `params: impl Into<Params>` for the whole batch, not `Vec<Params>`. Verified against the actual intended consumer before finalizing: read `core/credit/src/ledger/mod.rs` and `core/credit/src/credit_facility/jobs/activate.rs` in the sibling `lana-activate-true-batched` worktree. All four current call sites of `add_credit_facility_control_to_account_in_op` pass `Params::default()` unconditionally, and that helper does not even accept a `params` argument from its own caller — there is no facility-specific data flowing into it today or in the not-yet-written batched refactor's current shape. A per-account `Vec<Params>` would be unusable by the one caller this API exists for; batch-uniform `params` is correct.

## Invariants — how each is preserved
- **Velocity balance lock partitioning + canonical sort (`find_for_update`)**: not touched. This PR only writes `cala_velocity_account_controls` (the attach-time control↔account mapping). It never reaches `cala_velocity_current_balances` / `cala_velocity_balance_history`, `VelocityBalances::find_for_update`, or the 1-arg advisory lock keyed on `(currency, journal, account, control, limit, partition_window)`. Read `velocity/balance/repo.rs` in full to confirm: join-free, Rust-sorted (`account_id → control_id → limit_id → currency → journal_id → window`, window as final tiebreaker), no SQL `ORDER BY` (deliberately removed, documented in that file) — none of that is anywhere near this change.
- **Attach-fence ordering (#816)**: not touched. The fence is poster-side (class-1 SHARED leaf locks in `posting/repo.rs::lock_balances_and_probe_templates_in_op`) vs guard-side (EXCLUSIVE + `MemberHasBalanceHistory` in `balance/repo.rs`, invoked from `account_set` member-add flows). Velocity control attachment is a different table/flow — it never touches `cala_account_set_member_accounts`, `cala_entries`, or `cala_balance_history`, and takes no lock today or after this change.
- **Path uniqueness (#814) / epoch-validated set-graph cache (#822) / `MemberHasBalanceHistory`**: all live in `account_set/*`, unrelated table, not touched.
- **Advisory-lock enumeration, used to prove non-applicability**: catalogued every `pg_advisory_xact_lock*` call site in the crate (13 sites, 4 named classes — `EC_SET_LOCK_CLASS=1`, `MEMBER_LOCK_CLASS=2`, `GRAPH_LOCK_CLASS=3`, plus the shared classless 1-arg space) before writing code. None are in the account_control insert path, and this PR adds none. The enumeration requirement exists to catch half-migrated lock-ordering conventions; here the complete answer is "zero sites touch this path, nothing to migrate."
- **The new "sort by account_id" I added is not the advisory-lock-ordering doctrine.** Same *shape* (Rust-side canonical sort before an UNNEST), different *mechanism*: this insert takes no advisory lock and no row lock at all. Sorting `controls` by `account_id` in `create_all_in_op` guards against a different, narrower hazard — two concurrent multi-row `INSERT`s touching the same `(account_id, velocity_control_id)` unique-index keys in opposite order can deadlock mid-insert on that btree index. A consistent order across every caller rules that out. Conflating the two mechanisms is how you either skip a needed sort or over-apply the lock-ordering doctrine where it doesn't belong — documented explicitly in the repo.rs doc comment.
- **CEL**: PR #718's cel-rust replacement (`dce8f80d`) is on main. Confirmed both of its CHANGES_REQUESTED blockers were already resolved there, not by this PR: Decimal arithmetic/comparison via explicit `decimal.Add/Sub/Mul/Cmp` builtins (opaque value + named functions, since cel-rust gives opaque values no native operators) rather than restored native operators; `date()` returns `Value::Timestamp` (RFC3339 in raw/untyped JSON), but `ParamDataType::Date` param coercion and the `NaiveDate` `TryFrom` both special-case `Timestamp → NaiveDate`, so typed Window/param paths are unaffected. This correction is for the record — this PR doesn't touch Window/date-partitioning or add/change any CEL expression logic.
- **CEL compile memoization (#823, dedicated 32MiB thread)**: untouched, and unaffected by batching — compilation is memoized by source string regardless of call count. What batching *does* change: the same already-compiled program's *evaluations* drop from up to N (one per account, in the old per-account-loop shape) to 1 per batch call, since `velocity_limits`/`condition` don't depend on `account_id`. Noted, not hidden.

## Error semantics — explicitly checked, no behavioral change
A duplicate attach (`(account_id, control_id)` twice) hits `UNIQUE(account_id, velocity_control_id)` and surfaces as a generic `VelocityError::Sqlx(...)` today — no existing mapping for that constraint (unlike the sibling `cala_velocity_control_limits_...` mapping); not adding one, out of scope. Whether looped (N single-account calls in one `_in_op` transaction) or batched (one multi-row `INSERT`), a duplicate anywhere aborts the whole enclosing Postgres transaction: Postgres poisons the tx on any statement error and rejects all subsequent statements until rollback, and every caller here propagates via `?` rather than catching per-item. **This was already all-or-nothing at the transaction level for every existing `_in_op` caller** — batching doesn't introduce that failure mode, it was already there. Closed with evidence (Postgres's actual error-poisoning behavior + every caller's `?`-propagation), not a mitigation for a hazard that turned out not to apply. `account_ids` is not deduplicated: a caller passing the same id twice gets the same unique-violation a second singular call would.

## Test plan (live PG, `make start-deps`)
Added to `cala-ledger/tests/velocity.rs`:
1. `attach_control_to_accounts_in_op_matches_singular_calls` — parity: batch-attach to 3 accounts, confirm the limit enforces identically to 3 singular calls. (This is a parity test, not a revert-to-red regression guard — its "red" state pre-implementation is a compile failure, not a meaningful revert.)
2. `attach_control_to_accounts_in_op_issues_one_batched_insert` — **the actual regression guard for the handoff's ask.** Neither of my originally-proposed precedents held up under verification: `transaction_batch.rs`/`cala-perf` do not provide a working, test-isolated statement-counting mechanism (`cala-perf`'s `pg_stat_statements` harness needs `shared_preload_libraries` configured at the Postgres server level and is a standalone manual-benchmark tool, not wired into `make start-deps`/nextest; and no test file actually uses it). Built a minimal span-count mechanism instead: a `tracing_subscriber::Layer` counting `#[instrument]` spans by exact name (`account_control.create_all_in_op` vs `account_control.create_in_op`), registered as the process-global default subscriber (not thread-local `with_default`, which silently misses events after a tokio worker-thread hop). Deterministic under `cargo-nextest` because nextest runs every test in its own OS process — no cross-test pollution, no DB-extension dependency. `tracing-subscriber` was already resolved in `Cargo.lock` (via `tracing-opentelemetry`); added as a `cala-ledger` dev-dependency with `default-features = false, features = ["registry"]` only (avoids pulling in `fmt`/`nu-ansi-term`, which nothing here uses) — net `Cargo.lock` diff is one dependency edge. **Revert-to-red verified**: temporarily reverted `create_all_in_op` to a loop calling `create_in_op` per row — test failed (`per_row_calls: 4` instead of `0`); restored the batched insert — test passes again.
3. `attach_control_to_accounts_in_op_rejects_duplicate_account_id_atomically` — a duplicate id in the batch errors, and (after `drop(op)` rolls back) the non-duplicate account in the same failed batch can still be attached fresh — proving nothing from the failed batch was left attached.
4. `attach_control_to_accounts_in_op_empty_slice_is_a_noop` — `&[]` returns `Ok(control)`, zero rows inserted, no error.
5. Existing `create_control_on_account` (unmodified) continues passing — regression guard that the `attach_control_to_account_in_op` thin-wrapper refactor doesn't change singular-call behavior.

No `pg_locks`/lock-footprint test added — this change acquires no locks, nothing there to regress.

## Verify
- `nix develop -c cargo fmt` — clean
- `cd cala-ledger && cargo sqlx prepare -- --all-features` — net diff is exactly one new `.sqlx` entry (the new UNNEST insert); an earlier run of this same command incorrectly dropped 37 unrelated `job`-crate dep entries (the documented "incremental prepare silently drops dep-crate entries" hazard) — verified by inspecting which entries changed, not just the count, and restored them via `git checkout`
- `nix flake check --option eval-cache false` — fresh (confirmed new derivation hashes each run), all checks pass: fmt, clippy `-D warnings`, audit, deny
- `make start-deps` + `cargo nextest run --all-features` (live PG) — **192/192 passed**, including `account_set_membership_locks::coarse_lock_uses_two_arg_form_only`, all `set_graph_cache::*`, all `attach_posting_fence::*`, all `ec_poster_locks::*`, all `ec_streaming_rollup::*`, all `effective_balance::*`, all `transaction_batch::*`

## Semver
Minor (`feat(velocity)`) — additive public method + internal refactor of `attach_control_to_account_in_op` with unchanged signature/behavior. Not breaking.

## Downstream ripple
lana pins `cala-ledger`. Unblocks the `lana-activate-true-batched` PR (external, not touched by this PR — confirmed its worktree is clean/unstarted, per constraints).

## Non-goals (per handoff)
`attach_control_to_account_sets_in_op` (set-flavoured twin) — not needed by the lana caller, not built.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches ledger persistence for velocity account-control mappings (unique-constraint inserts, CEL evaluation, transaction atomicity). Singular attach is refactored onto the new path, so a bug would affect existing callers as well as the new batch API.
> 
> **Overview**
> Adds `Velocities::attach_control_to_accounts_in_op` so one control (with shared `params`) can be attached to many accounts in a fixed number of round trips instead of `3 * N`.
> 
> The insert is a single join-free `UNNEST` into `cala_velocity_account_controls`. CEL limit evaluation runs once per batch and is cloned per account. Rows are sorted by `account_id` in Rust to avoid unique-index deadlocks between concurrent multi-row inserts. The existing singular `attach_control_to_account_in_op` is a thin wrapper over the batch path; account-set attach is unchanged.
> 
> Empty slices are a no-op. Duplicate ids in a batch still hit the unique constraint and abort the whole transaction. Tests cover batched-insert span counts, enforcement parity, atomic rollback on duplicates, and the empty-slice case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40dd4ee57e1ac936d99d276e83012f763356c1f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->