### PR TITLE
chore(cel): Do not cache compile_program errors

### DIFF
--- a/cala-cel-interpreter/src/interpreter.rs
+++ b/cala-cel-interpreter/src/interpreter.rs
@@ -28,7 +28,7 @@ const COMPILE_STACK_BYTES: usize = 32 * 1024 * 1024;
 /// frames leave far less headroom than the parser needs, so compiling on the
 /// caller's thread can overflow the stack. The spawn cost is paid once per
 /// unique expression thanks to the memoization above.
-#[cached(max_size = 10000, cache_err = true)]
+#[cached(max_size = 10000)]
 #[instrument(name = "cel.compile", skip(source), fields(expression = %source), err(level = tracing::Level::WARN))]
 fn compile_program(source: String) -> Result<Arc<Program>, String> {
     let started = std::time::Instant::now();


### PR DESCRIPTION
Error messages are notoriously big (easily 200 or 300 kB), caching them in memory without byte-cap or TTL can cause OOM in certain cases. `cached` of version 1.* automatically cached errors, version 2.* does not. To preserve functionality, `cache_err = true` was added here.

This change removes the caching of errors. It protects memory from large error objects for the cost of repeated parsing of failed expressions.

---

This issue [causes](https://github.com/GaloyMoney/drua-library/blob/main/spaces/on-call/investigations/2026-08-25-cala-fuzz-oom-cel-compile-error-cache.md) OOM during fuzzing, which is, by design, producing large number of failures.

Alternative approach would be to keep error caching but truncate the textual error messages. Other, less viable, approaches are described in the same analysis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Memory-safety fix with minor extra CPU on repeated failed parses; no change to successful compile caching or evaluation behavior.
> 
> **Overview**
> Stops memoizing **failed** `compile_program` results by dropping `cache_err = true` from the `#[cached]` on `compile_program` in `interpreter.rs`. Successful compilations are still cached (`max_size = 10000`).
> 
> CEL parse failures can return very large error strings; keeping those in the cache (especially under fuzzing with many distinct bad inputs) was driving OOM. The tradeoff is that the same invalid expression may be compiled on the dedicated thread again on each `CelExpression` construction instead of hitting the cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c93ba12612757bd5de50a77d7bee6346179d4c77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->