### PR TITLE
chore(deps): prepare checked inbox scrub query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,9 +899,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "es-entity"
-version = "0.12.10"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b46ec6f5ea842d48519daa7a59060667e5df7a8018390d9aefb9928f4241883"
+checksum = "01763a0eade587e3661b5c62f07359a1b0c4e78e04ae59563a6a4e859e9887d8"
 dependencies = [
  "async-stream",
  "chrono",
@@ -927,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "es-entity-macros"
-version = "0.12.10"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80cfaeb802cdfc853aaba00a123b2f8b4593f970ad5e1de7c9c77a503e7c260"
+checksum = "60e120de17396a3a74534e7cf103899a33d8eed6fb576497ebc4c2207e1ff665"
 dependencies = [
  "convert_case",
  "darling 0.24.0",
@@ -1648,9 +1648,8 @@ dependencies = [
 
 [[package]]
 name = "obix"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fade60a8d1d8d5875cd5eb83fe348c87005db173e908108ed8663f38cf44295e"
+version = "0.9.1"
+source = "git+https://github.com/GaloyMoney/obix?rev=54eae28f14674495ca381bbfc21fea0ac98bf284#54eae28f14674495ca381bbfc21fea0ac98bf284"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1671,9 +1670,8 @@ dependencies = [
 
 [[package]]
 name = "obix-macros"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18609b1d1090810458687dbcb2c3f70125dd6d86da172b2395f1b326a2a99386"
+version = "0.9.1"
+source = "git+https://github.com/GaloyMoney/obix?rev=54eae28f14674495ca381bbfc21fea0ac98bf284#54eae28f14674495ca381bbfc21fea0ac98bf284"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,7 @@ cala-ledger = { path = "cala-ledger", version = "0.26.2-dev" }
 cel = "0.14.3"
 es-entity = "0.12.7"
 job = { version = "0.13.4", features = ["es-entity"] }
-obix = {
-  git = "https://github.com/GaloyMoney/obix",
-  rev = "54eae28f14674495ca381bbfc21fea0ac98bf284",
-  version = "0.9.1",
-  default-features = false,
-}
+obix = { git = "https://github.com/GaloyMoney/obix", rev = "54eae28f14674495ca381bbfc21fea0ac98bf284", version = "0.9.1", default-features = false }
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,12 @@ cala-ledger = { path = "cala-ledger", version = "0.26.2-dev" }
 cel = "0.14.3"
 es-entity = "0.12.7"
 job = { version = "0.13.4", features = ["es-entity"] }
-obix = { version = "0.9.0", default-features = false }
+obix = {
+  git = "https://github.com/GaloyMoney/obix",
+  rev = "54eae28f14674495ca381bbfc21fea0ac98bf284",
+  version = "0.9.1",
+  default-features = false,
+}
 
 anyhow = "1.0.99"
 cached = { version = "2.0", features = ["async"] }

--- a/cala-ledger/.sqlx/query-1b08486998f36ccc8a01531fa1b1c6a2831eb39c07bd546ffb0f2bf0477590d6.json
+++ b/cala-ledger/.sqlx/query-1b08486998f36ccc8a01531fa1b1c6a2831eb39c07bd546ffb0f2bf0477590d6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE cala_inbox_events\n            SET status = 'completed'::InboxEventStatus,\n                payload = 'null'::jsonb,\n                error = NULL,\n                processed_at = COALESCE($2::timestamptz, NOW())\n            WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1b08486998f36ccc8a01531fa1b1c6a2831eb39c07bd546ffb0f2bf0477590d6"
+}


### PR DESCRIPTION
## What

- Update CALA to the Obix inbox-scrub integration revision.
- Generate and package CALA’s crate-local SQLx metadata for the new checked `complete_and_scrub_inbox_event_in_op` query.
- Keep CALA inbox behavior unchanged.

## Why

CALA derives `MailboxTables` inside the published `cala-ledger` crate. Its crate-local cache must therefore contain metadata for every checked query emitted by that derive before downstream applications such as Lana can compile it offline.

Depends on https://github.com/GaloyMoney/obix/pull/138. The temporary git revision must be replaced by the released Obix version before merge.

## Checks

- `make sqlx-prepare`