### PR TITLE
chore: Bump cel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82399e72d100a28a0cac14251a8aba16d124af2a237d8a60ab7997ba7380cc3"
+checksum = "9f93082a93da8fd78394852602ced1e2e7754ed8c29dc813fa80b01a1baf9032"
 dependencies = [
  "antlr4rust",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ cel-interpreter = { path = "cala-cel-interpreter", package = "cala-cel-interpret
 cala-types = { path = "cala-ledger-core-types", package = "cala-ledger-core-types", version = "0.26.2-dev" }
 cala-ledger = { path = "cala-ledger", version = "0.26.2-dev" }
 
-cel = "0.14.3"
+cel = "0.14.4"
 es-entity = "0.12.7"
 job = { version = "0.13.4", features = ["es-entity"] }
 obix = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Patch-only dependency update with no source changes; risk is limited to possible behavior changes inside the external `cel` crate used for expression evaluation.
> 
> **Overview**
> Bumps the workspace **`cel`** dependency from **0.14.3** to **0.14.4** in `Cargo.toml` and refreshes the matching entry in **`Cargo.lock`**. No application or interpreter code changes—only the pinned third-party CEL engine version used by `cala-cel-interpreter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a74d320cdb05bdec5add2c45a202979b582d2e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->